### PR TITLE
docs(ops): update transfer references (Stable)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ Source of truth:
 - Product planning: `ROADMAP.md`
 - Release notes: `CHANGELOG.md`
 - User-facing release summary: `docs/WHATS_NEW.md`
-- Project board: `Lavoro-Nostro` Project `#2` (`@VaultSync Roadmap`)
+- Project board: `ATAC-Helicopter` Project `#1` (`VaultSync 1.5.1 Stabilization`)
 
 Required workflow for changes:
 1. Implement code/docs changes.

--- a/docs/PROJECT_OPERATIONS.md
+++ b/docs/PROJECT_OPERATIONS.md
@@ -50,7 +50,7 @@ Keep IDs stable once published in roadmap/changelog/project board.
 - Update current release status summary.
 - Move truly finished highlights into `Completed (highlights)` when requested.
 
-## 4) GitHub Project Board (`@VaultSync Roadmap`, org project #2)
+## 4) GitHub Project Board (`VaultSync 1.5.1 Stabilization`, org project #1)
 
 ### Solo operating model
 - `Owner`: `Flavio Giacchetti`
@@ -68,7 +68,7 @@ Keep IDs stable once published in roadmap/changelog/project board.
   - Use only when work is not execution-ready.
   - Convert to issue once scope is actionable.
   - Keep fallback fields filled while draft is used:
-    - `Repository target`: `Lavoro-Nostro/VaultSync`
+    - `Repository target`: `ATAC-Helicopter/VaultSync`
     - `Work labels`: normalized label string
 
 ## 4.1) Issue/PR Lifecycle


### PR DESCRIPTION
Updates project/repo owner references after repository transfer.\n\n- CONTRIBUTING project board reference -> ATAC-Helicopter #1\n- docs/PROJECT_OPERATIONS board/repository target updated\n\nNote: scripts/sync_project_descriptions.ps1 does not exist on Stable, so this PR is docs-only.