### PR TITLE
fix tooltip flickering on Linux WM (OverlayPopups)

### DIFF
--- a/src/VaultSync.UI/Program.cs
+++ b/src/VaultSync.UI/Program.cs
@@ -345,4 +345,16 @@ internal static class Program
         => AppBuilder.Configure<UpdaterApp>()
             .UsePlatformDetect()
             .LogToTrace(LogEventLevel.Warning);
+
+    public static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .With(new Win32PlatformOptions
+            {
+                OverlayPopups = true // For Windows
+            })
+            .With(new X11PlatformOptions
+            {
+                OverlayPopups = true // For Linux
+            });
 }


### PR DESCRIPTION
Hi! The tooltips flickered, created transparent artifacts, and knocked out the focus of the windows in Linux/Wayland Hyprland. I fixed this by enabling OverlayPopups in AppBuilder for X11 and Windows. As a result, the tooltips are displayed inside the window and do not create any problems. I've targeted the developer branch, as you requested