### PR TITLE
fix(core): resolve silent password storage failures and short timeouts on Linux (refs #220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 - [BUG-17100] Tray panel screen detection, reopen behavior, and Linux/Wayland positioning are now resilient on Hyprland-class environments. Contributed by @JustH8Me in PR #216.
 - [BUG-17101] Fixed tooltip flickering and focus issues on Linux/Wayland by enabling overlay popups PR #217 (thanks @JustH8Me)
 - [BUG-17102] Fixed fatal AccessViolationException on Linux x64 during backup (thanks @JustH8Me, refs #218)
-
+- [BUG-17103] Fixed passwords being saved as 'null' on Linux and increased timeouts passwords (thanks @JustH8Me, refs #220)
+-
 ## [1.7.2] - Unreleased
 ### Added
 - [VS-1727] Added an initial Microsoft Store packaging scaffold with the reserved Partner Center identity values, separate from the Direct installer path.

--- a/Localization/strings.ar.json
+++ b/Localization/strings.ar.json
@@ -540,6 +540,7 @@
   "Projects.Encryption.EnrollNoProjects": "أضف مشروعاً قبل تسجيل كلمة مرور التشفير.",
   "Projects.Encryption.EnrollValidationProject": "اختر مشروعاً للمتابعة.",
   "Projects.Encryption.PasswordUpdateFailed": "فشل تحديث كلمة مرور تشفير المشروع.",
+  "Projects.Encryption.LinuxSecretToolMissing": "تخزين النظام غير متوفر. تأكد من تثبيت حزمة' ليبسكريت '(أو' أداة سرية') ، وخدمة كيرينغ قيد التشغيل وغير مقفلة.",
   "Projects.Encryption.PasswordValidationMismatch": "كلمة المرور وتأكيدها غير متطابقين.",
   "Projects.Encryption.PasswordValidationRequired": "كلمة المرور وتأكيدها مطلوبان.",
   "Projects.Encryption.ProjectNotFound": "لم يتم العثور على مشروع بالمعرف {0}.",

--- a/Localization/strings.bn.json
+++ b/Localization/strings.bn.json
@@ -540,6 +540,7 @@
   "Projects.Encryption.EnrollNoProjects": "এনক্রিপশন পাসওয়ার্ড নিবন্ধনের আগে একটি প্রকল্প যোগ করুন।",
   "Projects.Encryption.EnrollValidationProject": "চালিয়ে যেতে একটি প্রকল্প নির্বাচন করুন।",
   "Projects.Encryption.PasswordUpdateFailed": "প্রজেক্ট এনক্রিপশন পাসওয়ার্ড আপডেট করতে ব্যর্থ হয়েছে।",
+  "Projects.Encryption.LinuxSecretToolMissing": "সিস্টেম স্টোরেজ অনুপলব্ধ. নিশ্চিত করুন যে 'লিবসেক্রেট' প্যাকেজ (বা 'সিক্রেট-টুল') ইনস্টল করা আছে এবং কীরিং পরিষেবা চলছে এবং আনলক করা হয়েছে৷",
   "Projects.Encryption.PasswordValidationMismatch": "পাসওয়ার্ড এবং নিশ্চিতকরণ মিলছে না।",
   "Projects.Encryption.PasswordValidationRequired": "পাসওয়ার্ড এবং নিশ্চিতকরণ প্রয়োজন।",
   "Projects.Encryption.ProjectNotFound": "আইডি {0} সহ প্রজেক্ট পাওয়া যায়নি।",

--- a/Localization/strings.de.json
+++ b/Localization/strings.de.json
@@ -540,6 +540,7 @@
   "Projects.Encryption.EnrollNoProjects": "Fügen Sie ein Projekt hinzu, bevor Sie ein Projektverschlüsselungs-Passwort hinterlegen.",
   "Projects.Encryption.EnrollValidationProject": "Wählen Sie ein Projekt aus, um fortzufahren.",
   "Projects.Encryption.PasswordUpdateFailed": "Aktualisierung des Projekt-Verschlüsselungspassworts fehlgeschlagen.",
+  "Projects.Encryption.LinuxSecretToolMissing": "Der Systemspeicher ist nicht verfügbar. Stellen Sie sicher, dass das Paket 'libsecret' (oder 'secret-tool') installiert ist und der Keyring-Dienst gestartet und entsperrt ist.",
   "Projects.Encryption.PasswordValidationMismatch": "Passwort und Bestätigung stimmen nicht überein.",
   "Projects.Encryption.PasswordValidationRequired": "Passwort und Bestätigung sind erforderlich.",
   "Projects.Encryption.ProjectNotFound": "Projekt mit der ID {0} wurde nicht gefunden.",

--- a/Localization/strings.en.json
+++ b/Localization/strings.en.json
@@ -540,6 +540,7 @@
   "Projects.Encryption.EnrollNoProjects": "Add a project before enrolling a project encryption password.",
   "Projects.Encryption.EnrollValidationProject": "Select a project to continue.",
   "Projects.Encryption.PasswordUpdateFailed": "Failed to update project encryption password.",
+  "Projects.Encryption.LinuxSecretToolMissing": "The system storage is unavailable. Make sure that the 'libsecret' package (or 'secret-tool') is installed, and the Keyring service is running and unlocked.",
   "Projects.Encryption.PasswordValidationMismatch": "Password and confirmation do not match.",
   "Projects.Encryption.PasswordValidationRequired": "Password and confirmation are required.",
   "Projects.Encryption.ProjectNotFound": "Project with id {0} was not found.",

--- a/Localization/strings.es.json
+++ b/Localization/strings.es.json
@@ -540,6 +540,7 @@
   "Projects.Encryption.EnrollNoProjects": "Añade un proyecto antes de registrar una contraseña de cifrado.",
   "Projects.Encryption.EnrollValidationProject": "Selecciona un proyecto para continuar.",
   "Projects.Encryption.PasswordUpdateFailed": "Error al actualizar la contraseña de cifrado del proyecto.",
+  "Projects.Encryption.LinuxSecretToolMissing": "El almacenamiento del sistema no está disponible. Asegúrese de que el paquete 'libsecret' (o 'secret-tool') esté instalado y que el Servicio Keyring esté en ejecución y desbloqueado..",
   "Projects.Encryption.PasswordValidationMismatch": "La contraseña y la confirmación no coinciden.",
   "Projects.Encryption.PasswordValidationRequired": "La contraseña y la confirmación son obligatorias.",
   "Projects.Encryption.ProjectNotFound": "No se encontró el proyecto con id {0}.",

--- a/Localization/strings.fr.json
+++ b/Localization/strings.fr.json
@@ -540,6 +540,7 @@
   "Projects.Encryption.EnrollNoProjects": "Ajoutez un projet avant d’enregistrer un mot de passe de chiffrement.",
   "Projects.Encryption.EnrollValidationProject": "Sélectionnez un projet pour continuer.",
   "Projects.Encryption.PasswordUpdateFailed": "Échec de la mise à jour du mot de passe de chiffrement du projet.",
+  "Projects.Encryption.LinuxSecretToolMissing": "Le stockage système n'est pas disponible. Assurez-vous que 'libsecret' (ou 'secret-tool') est installé et que le service Keyring est en cours d'exécution et déverrouillé.",
   "Projects.Encryption.PasswordValidationMismatch": "Le mot de passe et la confirmation ne correspondent pas.",
   "Projects.Encryption.PasswordValidationRequired": "Le mot de passe et la confirmation sont requis.",
   "Projects.Encryption.ProjectNotFound": "Projet avec l’id {0} introuvable.",

--- a/Localization/strings.hi.json
+++ b/Localization/strings.hi.json
@@ -540,6 +540,7 @@
   "Projects.Encryption.EnrollNoProjects": "एन्क्रिप्शन पासवर्ड पंजीकरण से पहले एक प्रोजेक्ट जोड़ें।",
   "Projects.Encryption.EnrollValidationProject": "जारी रखने के लिए एक प्रोजेक्ट चुनें।",
   "Projects.Encryption.PasswordUpdateFailed": "प्रोजेक्ट एन्क्रिप्शन पासवर्ड अपडेट करने में विफल।",
+  "Projects.Encryption.LinuxSecretToolMissing": "सिस्टम स्टोरेज अनुपलब्ध है ।  सुनिश्चित करें कि' लिबसेक्रेट 'पैकेज (या' सीक्रेट-टूल') स्थापित है, और कीरिंग सेवा चल रही है और अनलॉक है । ",
   "Projects.Encryption.PasswordValidationMismatch": "पासवर्ड और पुष्टि मेल नहीं खाते।",
   "Projects.Encryption.PasswordValidationRequired": "पासवर्ड और पुष्टि आवश्यक हैं।",
   "Projects.Encryption.ProjectNotFound": "आईडी {0} वाला प्रोजेक्ट नहीं मिला।",

--- a/Localization/strings.it.json
+++ b/Localization/strings.it.json
@@ -540,6 +540,7 @@
   "Projects.Encryption.EnrollNoProjects": "Aggiungi un progetto prima di registrare una password.",
   "Projects.Encryption.EnrollValidationProject": "Seleziona un progetto per continuare.",
   "Projects.Encryption.PasswordUpdateFailed": "Aggiornamento password di crittografia non riuscito.",
+  "Projects.Encryption.LinuxSecretToolMissing": "L'archiviazione di sistema non è disponibile. Assicurati che il pacchetto 'libsecret' (o 'secret-tool') sia installato e che il servizio Keyring sia in esecuzione e sbloccato.",
   "Projects.Encryption.PasswordValidationMismatch": "Password e conferma non corrispondono.",
   "Projects.Encryption.PasswordValidationRequired": "Password e conferma sono obbligatorie.",
   "Projects.Encryption.ProjectNotFound": "Progetto con id {0} non trovato.",

--- a/Localization/strings.pt.json
+++ b/Localization/strings.pt.json
@@ -540,6 +540,7 @@
   "Projects.Encryption.EnrollNoProjects": "Adicione um projeto antes de registrar uma senha.",
   "Projects.Encryption.EnrollValidationProject": "Selecione um projeto para continuar.",
   "Projects.Encryption.PasswordUpdateFailed": "Falha ao atualizar a senha de criptografia do projeto.",
+  "Projects.Encryption.LinuxSecretToolMissing": "O armazenamento do sistema não está disponível. Certifique-se de que o pacote 'libsecret' (ou 'secret-tool') esteja instalado e que o Keyring esteja em execução e desbloqueado.",
   "Projects.Encryption.PasswordValidationMismatch": "A senha e a confirmação não correspondem.",
   "Projects.Encryption.PasswordValidationRequired": "Senha e confirmação são obrigatórias.",
   "Projects.Encryption.ProjectNotFound": "Projeto com id {0} não encontrado.",

--- a/Localization/strings.ru.json
+++ b/Localization/strings.ru.json
@@ -540,6 +540,7 @@
   "Projects.Encryption.EnrollNoProjects": "Добавьте проект перед регистрацией пароля.",
   "Projects.Encryption.EnrollValidationProject": "Выберите проект для продолжения.",
   "Projects.Encryption.PasswordUpdateFailed": "Не удалось обновить пароль шифрования проекта.",
+  "Projects.Encryption.LinuxSecretToolMissing": "Системное хранилище недоступно. Убедитесь, что установлен пакет 'libsecret' (или 'secret-tool'), а служба Keyring запущена и разблокирована.",
   "Projects.Encryption.PasswordValidationMismatch": "Пароль и подтверждение не совпадают.",
   "Projects.Encryption.PasswordValidationRequired": "Требуются пароль и подтверждение.",
   "Projects.Encryption.ProjectNotFound": "Проект с id {0} не найден.",

--- a/Localization/strings.zh.json
+++ b/Localization/strings.zh.json
@@ -540,6 +540,7 @@
   "Projects.Encryption.EnrollNoProjects": "请先添加项目再注册密码。",
   "Projects.Encryption.EnrollValidationProject": "请选择项目以继续。",
   "Projects.Encryption.PasswordUpdateFailed": "更新项目加密密码失败。",
+  "Projects.Encryption.LinuxSecretToolMissing": "系统存储不可用。 确保安装了'libsecret'包（或'secret-tool'），并且密钥环服务正在运行和解锁。",
   "Projects.Encryption.PasswordValidationMismatch": "密码和确认不匹配。",
   "Projects.Encryption.PasswordValidationRequired": "必须输入密码和确认。",
   "Projects.Encryption.ProjectNotFound": "未找到 ID 为 {0} 的项目。",

--- a/src/VaultSync.Core/Services/CredentialVault.cs
+++ b/src/VaultSync.Core/Services/CredentialVault.cs
@@ -141,7 +141,8 @@ public sealed class CredentialVault
                 }
                 else
                 {
-                    throw new InvalidOperationException("Failed to store secret in secret service (libsecret).");
+                    //Linux secret-tool failed. 99% not installed secret-tool packages.
+                    throw new InvalidOperationException("LINUX_SECRET_TOOL_MISSING");
                 }
             }
             else if (OperatingSystem.IsWindows())
@@ -419,7 +420,7 @@ public sealed class CredentialVault
                 return null;
 
             var output = proc.StandardOutput.ReadToEnd();
-            proc.WaitForExit(5_000);
+            proc.WaitForExit(30_000);
             return proc.ExitCode == 0 ? output.Trim() : null;
         }
         catch
@@ -464,6 +465,7 @@ public sealed class CredentialVault
                 FileName               = "secret-tool",
                 RedirectStandardError  = true,
                 RedirectStandardOutput = true,
+                RedirectStandardInput = true,
                 UseShellExecute        = false
             };
 
@@ -480,7 +482,7 @@ public sealed class CredentialVault
                 return false;
             proc.StandardInput.Write(secret);
             proc.StandardInput.Close();
-            proc.WaitForExit(5_000);
+            proc.WaitForExit(30_000);
             return proc.ExitCode == 0;
         }
         catch
@@ -511,7 +513,7 @@ public sealed class CredentialVault
             if (proc is null)
                 return null;
             var output = proc.StandardOutput.ReadToEnd();
-            proc.WaitForExit(5_000);
+            proc.WaitForExit(30_000);
             return proc.ExitCode == 0 ? output.Trim() : null;
         }
         catch

--- a/src/VaultSync.UI/Services/ProjectEncryptionEnrollmentService.cs
+++ b/src/VaultSync.UI/Services/ProjectEncryptionEnrollmentService.cs
@@ -130,9 +130,18 @@ public sealed class ProjectEncryptionEnrollmentService
         catch (Exception ex)
         {
             _log($"[Projects] Failed to update encryption password for project {project.Id}: {ex.Message}");
-            _showNotification(
-                L("Projects.Encryption.PasswordUpdateFailed", "Failed to update project encryption password."),
-                NotificationSeverity.Error);
+            if (ex.Message == "LINUX_SECRET_TOOL_MISSING")
+            {
+                _showNotification(
+                    L("Projects.Encryption.LinuxSecretToolMissing", "Linux secret storage is unavailable. Ensure 'libsecret' is installed and your keyring service is running."),
+                    NotificationSeverity.Error);
+            }
+            else
+            {
+                _showNotification(
+                    L("Projects.Encryption.PasswordUpdateFailed", "Failed to update project encryption password."),
+                    NotificationSeverity.Error);
+            }
         }
     }
 

--- a/src/VaultSync.UI/ViewModels/SettingsViewModel.cs
+++ b/src/VaultSync.UI/ViewModels/SettingsViewModel.cs
@@ -2584,7 +2584,17 @@ namespace VaultSync.UI
             }
             catch (Exception ex)
             {
-                BackupEncryptionSecretStatus = L("Settings.Encryption.SecretStatusSaveFailed", "Failed to store encryption password.");
+                if (ex.InnerException.Message == "LINUX_SECRET_TOOL_MISSING")
+                {
+                    BackupEncryptionSecretStatus = L("Projects.Encryption.LinuxSecretToolMissing",
+                        "Linux secret storage is unavailable. Ensure 'libsecret' is installed and your keyring service is running.");
+                }
+                else
+                {
+                    BackupEncryptionSecretStatus = L("Settings.Encryption.SecretStatusSaveFailed",
+                        "Failed to store encryption password.");
+                }
+
                 GlobalNotificationCenter.Instance.Show(
                     $"{BackupEncryptionSecretStatus} {ex.Message}",
                     NotificationSeverity.Error,


### PR DESCRIPTION
I have fixed everything that is specified in the ticket #220 . On Linux, there is no standard "storage" that is guaranteed to be everywhere, and I'm sure that you don't want to keep passwords in the clear, so I just removed the ability for Linux to encrypt without gnome-keyring and so on. I tried to follow your code philosophy!