### PR TITLE
expand metadata sync contract coverage and docs

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -92,7 +92,17 @@ Before merging documentation updates:
 - Full docs index: `docs/README.md`
 - Wiki sidebar: `docs/wiki/_Sidebar.md`
 
-## 8. 1.7 Documentation Focus
+## 8. Metadata Sync Contract
+The metadata sync store under `<destination>/.vaultsync/meta/` currently exports:
+- project identity and shape: `external_id`, `name`, `preset`, `root_path_hint`, timestamps
+- `settings_json` with project-scoped settings such as `avatarColor`, `encryptionPolicy`, `encryptionKeyRef`, `preferredDestinationId`, `restoreMode`, `verificationPolicy`, `autoBackupEnabled`, and `tags`
+- snapshot identity plus diff summary fields: `diff_added`, `diff_modified`, `diff_deleted`, `diff_net_bytes`, `diff_top_paths_json`
+- backup identity plus operational fields: `type`, `backup_mode`, `path_rel`, `destination_alias`, `origin_machine_name`, `is_protected`, encryption flag, and non-secret crypto descriptor JSON
+- tombstones for removed projects, snapshots, and backups
+
+This contract is regression-tested in `tests/VaultSync.Core.Tests/MetadataSyncTests.cs`. If metadata behavior changes, update both the tests and this section in the same PR.
+
+## 9. 1.7 Documentation Focus
 For the `1.7` release line, keep these areas aligned:
 - update/patch behavior (`docs/UPDATER.md`, `docs/wiki/Updates.md`, `docs/RELEASING.md`)
 - integrity and Doctor workflows (`docs/HELP.md`, `README.md`)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center">
+﻿<p align="center">
   <img
     width="960"
     alt="VaultSync dashboard"
@@ -24,7 +24,7 @@
 
 <p align="center">
   🌐 <strong>Website:</strong>  
-  <a href="https://www.fglabs.dev/vaultsync">
+  <a href="https://fglabs.dev/vaultsync">
     https://www.fglabs.dev/vaultsync
   </a>
 </p>
@@ -306,4 +306,4 @@ Current stable desktop release line: `1.7.1`. Current development line: `1.7.2`.
 
 ## Credits
 
-Created by **Flavio Giacchetti**
+Created by **Flavio Giacchetti** & **Contributors**

--- a/docs/HELP.md
+++ b/docs/HELP.md
@@ -11,8 +11,9 @@ Core actions:
 - Sync metadata history across machines
 
 ## Install and Run
-- UI (Windows target):
-  - `dotnet run -f net8.0-windows10.0.19041.0 --project src/VaultSync.UI/VaultSync.UI.csproj`
+- UI:
+  - macOS/Linux: `dotnet run -f net8.0 --project src/VaultSync.UI/VaultSync.UI.csproj`
+  - Windows target: `dotnet run -f net8.0-windows10.0.19041.0 --project src/VaultSync.UI/VaultSync.UI.csproj`
 - CLI tool build/install:
   - `dotnet pack src/VaultSync.CLI -c Release`
   - `dotnet tool install --global --add-source src/VaultSync.CLI/bin/ToolPackages vaultsync.cli`
@@ -50,6 +51,17 @@ VaultSync supports two destination modes:
 - Optional auto-import is available in Settings.
 - Conflicting imported project settings can be reviewed and resolved from Settings > Advanced > Doctor.
 
+Metadata sync carries:
+- project identity and portable project settings such as encryption policy references, preferred destination, restore mode, verification policy, tags, and avatar color
+- snapshot history summaries such as file counts, bytes, and diff summary data
+- backup history details such as backup mode, destination alias, protection flag, source machine name, and non-secret encryption descriptor metadata
+
+Metadata sync does not carry:
+- backup file contents themselves
+- plaintext secrets or encryption passwords
+- your full app configuration or destination definitions
+- arbitrary local machine state outside the exported metadata store
+
 ## Doctor and Integrity Checks
 - Startup backup-index consistency checks run in the background and persist a summary for diagnostics and support bundles.
 - Settings > Advanced includes Doctor actions for:
@@ -79,8 +91,9 @@ See full troubleshooting page: `docs/wiki/Troubleshooting.md`.
 
 ## Where Data Lives
 - Config: `~/.vaultsync/appsettings.json`
-- DB (Windows): `%AppData%/VaultSync/vaultsync.db`
-- DB (macOS): `~/Library/Application Support/VaultSync/vaultsync.db`
+- DB (all platforms, default): `~/.vaultsync/vaultsync.db`
+- Logs: `~/.vaultsync/logs/`
+- Metadata store on destinations: `<destination>/.vaultsync/meta/vaultsync.meta.db`
 
 ## More Docs
 - Docs index: `docs/README.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ Use this page as the primary index for all project documentation.
 - Backups overview: `docs/wiki/Backups.md`
 - Backup pipeline: `docs/wiki/Backup-Pipeline.md`
 - Destinations: `docs/wiki/Destinations.md`
+- Metadata sync: `docs/wiki/Metadata-Sync.md`
 - Network shares: `docs/wiki/Network-Shares.md`
 - Snapshots: `docs/wiki/Snapshots.md`
 - Configuration: `docs/wiki/Configuration.md`
@@ -37,6 +38,11 @@ Use this page as the primary index for all project documentation.
 - Troubleshooting: `docs/wiki/Troubleshooting.md`
 - FAQ: `docs/wiki/FAQ.md`
 - Reporting bugs: `docs/wiki/Reporting-Bugs.md`
+
+## Metadata Sync Scope
+- Carries portable metadata such as project settings, snapshot summaries, backup history fields, tombstones, and non-secret encryption descriptors.
+- Does not carry backup payload contents, plaintext secrets, or the full local app configuration.
+- Contract details and regression coverage live in `DOCUMENTATION.md` and `tests/VaultSync.Core.Tests/MetadataSyncTests.cs`.
 
 ## Localization Operations
 - UI strings live in `Localization/strings.en.json`.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -11,6 +11,7 @@ Use this wiki for user-facing workflows and troubleshooting.
 - [Backups overview](Backups)
 - [Backup pipeline](Backup-Pipeline)
 - [Destinations](Destinations)
+- [Metadata sync](Metadata-Sync)
 - [Network shares](Network-Shares)
 - [Snapshots](Snapshots)
 - [Tray menu](Tray)

--- a/docs/wiki/Metadata-Sync.md
+++ b/docs/wiki/Metadata-Sync.md
@@ -1,0 +1,59 @@
+# Metadata Sync
+
+VaultSync can export a portable metadata store to backup destinations and later import that metadata on another machine.
+
+## Where it lives
+- Destination metadata is stored under `.vaultsync/meta/` at the destination root.
+- The SQLite store file is `vaultsync.meta.db`.
+
+## What it carries
+- Project identity: external id, name, preset, root path hint, timestamps
+- Portable project settings:
+  - avatar color
+  - encryption policy and key reference
+  - preferred destination id
+  - restore mode
+  - verification policy
+  - auto-backup enabled state
+  - tags
+- Snapshot summaries:
+  - file count
+  - total bytes
+  - diff summary fields
+  - top changed paths summary
+- Backup history fields:
+  - backup type
+  - backup mode
+  - relative backup path
+  - destination alias
+  - source machine name
+  - keep/protected flag
+  - non-secret encryption descriptor metadata
+- Tombstones for deleted projects, snapshots, and backups
+
+## What it does not carry
+- Backup payload contents
+- Plaintext passwords or secret material
+- Full local app configuration
+- Full destination definitions from another machine
+
+## Preferred destination behavior
+- Imported `preferredDestinationId` values are normalized against your current configured destinations.
+- If the imported value matches a configured destination id, alias, or path, VaultSync resolves it to the local canonical destination id.
+- If the imported value does not match a local destination, it may remain unresolved or be ignored depending on the import path.
+
+## Conflict behavior
+- Some project settings do not silently overwrite differing local values on existing projects.
+- In particular, preferred destination, restore mode, verification policy, and tags can create a metadata conflict record instead.
+- Review these conflicts from `Settings > Advanced > Doctor`.
+
+## Missing backup paths
+- Import only materializes backups whose relative path still exists at the destination.
+- If metadata references a backup path that no longer exists, VaultSync can record a tombstone instead of importing broken history.
+
+## Related docs
+- [Help](../HELP.md)
+- [Documentation hub](../../DOCUMENTATION.md)
+- [Backups overview](Backups)
+- [Destinations](Destinations)
+- [Troubleshooting](Troubleshooting)

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -11,13 +11,13 @@
   - [Backups overview](Backups)
   - [Backup pipeline](Backup-Pipeline)
   - [Destinations](Destinations)
+  - [Metadata sync](Metadata-Sync)
   - [Network shares](Network-Shares)
   - [Snapshots](Snapshots)
   - [Tray menu](Tray)
 
 - Updates
   - [Updates](Updates)
-  - [Installation](Installation)
 
 - 1.7 areas
   - Integrity / Doctor: [Configuration](Configuration)

--- a/tests/VaultSync.Core.Tests/MetadataSyncTests.cs
+++ b/tests/VaultSync.Core.Tests/MetadataSyncTests.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Data.Sqlite;
 using VaultSync.Core.Config;
 using VaultSync.Core.Models;
@@ -757,6 +758,416 @@ public sealed class MetadataSyncTests : IDisposable
     }
 
     [Fact]
+    public void ExportBackupToStore_ProjectSettings_IncludeDestinationRestoreVerificationAndTags()
+    {
+        var metaRoot = CreateTempDir();
+        var dbPath = Path.Combine(CreateTempDir(), "vaultsync.db");
+
+        var repo = CreateRepository(dbPath);
+        var projectId = repo.AddProject(new Project
+        {
+            Name = "Project Export Tracked Settings",
+            RootPath = CreateTempDir(),
+            Preset = "unity",
+            CreatedUtc = DateTime.UtcNow,
+            PreferredDestinationId = "dest-nas-primary",
+            RestoreMode = ProjectRestoreMode.Sandbox,
+            VerificationPolicy = ProjectVerificationPolicy.Manual,
+            Tags = "remote,critical"
+        });
+
+        var snapshotId = repo.CreateSnapshot(projectId, 2, 500);
+        var backupId = repo.CreateBackup(
+            projectId,
+            snapshotId,
+            "manual",
+            500,
+            "project-export-tracked-settings/2025-01-01_00-00-00",
+            metaRoot,
+            "Primary");
+
+        var service = new MetadataSyncService(repo);
+        var result = service.ExportBackupToStore(metaRoot, backupId, "1.7.3", "machine-settings");
+        Assert.Equal(MetadataSyncStatus.Success, result.Status);
+
+        var store = new MetadataStore(metaRoot);
+        var metaProject = store.ListProjects().Single();
+        using var doc = JsonDocument.Parse(metaProject.SettingsJson);
+        Assert.True(doc.RootElement.TryGetProperty("preferredDestinationId", out var destinationId));
+        Assert.Equal("dest-nas-primary", destinationId.GetString());
+        Assert.True(doc.RootElement.TryGetProperty("restoreMode", out var restoreMode));
+        Assert.Equal(ProjectRestoreMode.Sandbox, restoreMode.GetString());
+        Assert.True(doc.RootElement.TryGetProperty("verificationPolicy", out var verificationPolicy));
+        Assert.Equal(ProjectVerificationPolicy.Manual, verificationPolicy.GetString());
+        Assert.True(doc.RootElement.TryGetProperty("tags", out var tags));
+        Assert.Equal("remote,critical", tags.GetString());
+    }
+
+    [Fact]
+    public void ExportBackupToStore_MetadataContract_ExportsSelectedFieldsExplicitly()
+    {
+        var metaRoot = CreateTempDir();
+        var dbPath = Path.Combine(CreateTempDir(), "vaultsync.db");
+        var previousResolver = MetadataSyncService.ProjectColorResolver;
+        var previousApplier = MetadataSyncService.ProjectColorApplier;
+        const string expectedAvatarColor = "#1A2B3C";
+        var expectedTopPathsJson = JsonSerializer.Serialize(new[]
+        {
+            new SnapshotDiffPathStat("Assets/Scripts/Game.cs", 4, 3072),
+            new SnapshotDiffPathStat("Assets/Scenes/Main.unity", 2, 1024)
+        }, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        });
+
+        try
+        {
+            MetadataSyncService.ProjectColorResolver = _ => expectedAvatarColor;
+            MetadataSyncService.ProjectColorApplier = null;
+
+            var repo = CreateRepository(dbPath);
+            var projectId = repo.AddProject(new Project
+            {
+                Name = "Project Export Contract",
+                RootPath = CreateTempDir(),
+                Preset = "unity",
+                CreatedUtc = DateTime.UtcNow
+            });
+
+            var diffSummary = new SnapshotDiffSummary(
+                5,
+                3,
+                1,
+                4096,
+                SnapshotDiffSummary.ParseTopChangedPaths(expectedTopPathsJson));
+
+            var snapshotId = repo.CreateSnapshot(projectId, 42, 65_536, diffSummary);
+            var backupPath = "project-export-contract/2026-04-17_12-00-00";
+            var backupId = repo.CreateBackup(
+                projectId,
+                snapshotId,
+                "manual",
+                65_536,
+                backupPath,
+                metaRoot,
+                "Archive NAS",
+                backupMode: BackupModes.Incremental,
+                isProtected: true);
+
+            var service = new MetadataSyncService(repo);
+            var result = service.ExportBackupToStore(metaRoot, backupId, "1.7.3", "machine-contract");
+            Assert.Equal(MetadataSyncStatus.Success, result.Status);
+
+            var store = new MetadataStore(metaRoot);
+            var metaProject = Assert.Single(store.ListProjects());
+            var metaSnapshot = Assert.Single(store.ListSnapshots());
+            var metaBackup = Assert.Single(store.ListBackups());
+
+            using (var doc = JsonDocument.Parse(metaProject.SettingsJson))
+            {
+                Assert.True(doc.RootElement.TryGetProperty("avatarColor", out var avatarColor));
+                Assert.Equal(expectedAvatarColor, avatarColor.GetString());
+            }
+
+            Assert.Equal(5, metaSnapshot.DiffAdded);
+            Assert.Equal(3, metaSnapshot.DiffModified);
+            Assert.Equal(1, metaSnapshot.DiffDeleted);
+            Assert.Equal(4096, metaSnapshot.DiffNetBytes);
+            Assert.Equal(expectedTopPathsJson, metaSnapshot.DiffTopPathsJson);
+
+            Assert.Equal(BackupModes.Incremental, metaBackup.BackupMode);
+            Assert.True(metaBackup.IsProtected);
+            Assert.Equal("machine-contract", metaBackup.OriginMachineName);
+            Assert.Equal("Archive NAS", metaBackup.DestinationAlias);
+        }
+        finally
+        {
+            MetadataSyncService.ProjectColorResolver = previousResolver;
+            MetadataSyncService.ProjectColorApplier = previousApplier;
+        }
+    }
+
+    [Fact]
+    public void ImportFromStore_ProjectSettings_AppliesTrackedFieldsWhenCreatingProject()
+    {
+        var metaRoot = CreateTempDir();
+        var dbPath = Path.Combine(CreateTempDir(), "vaultsync.db");
+        var projectRoot = CreateTempDir();
+        var now = DateTime.UtcNow;
+        var originalConfig = CloneConfig(AppConfigStore.Load());
+
+        try
+        {
+            var destination = new BackupDestination
+            {
+                Path = CreateTempDir(),
+                Alias = "Imported Destination",
+                Active = true
+            };
+            var destinationId = DestinationIdentityService.GetId(destination);
+            var cfg = CloneConfig(originalConfig);
+            cfg.Advanced.ProjectMetadataConflicts.Clear();
+            cfg.Backups.Destinations = new List<BackupDestination> { destination };
+            AppConfigStore.Save(cfg);
+
+            var repo = CreateRepository(dbPath);
+            var store = CreateStore(metaRoot);
+            SeedMetaInfo(store, "machine-settings-apply");
+            store.UpsertProject(new MetaProject
+            {
+                ExternalId = "proj-settings-apply",
+                Name = "Project Settings Apply",
+                Preset = "unity",
+                RootPathHint = projectRoot,
+                CreatedUtc = now.AddDays(-2),
+                SettingsJson = $"{{\"preferredDestinationId\":\"{destinationId}\",\"restoreMode\":\"sandbox\",\"verificationPolicy\":\"manual\",\"tags\":\"imported,remote\"}}",
+                UpdatedUtc = now
+            });
+
+            var service = new MetadataSyncService(repo);
+            var result = service.ImportFromStore(metaRoot, MetadataSyncOptions.Default);
+
+            Assert.Equal(MetadataSyncStatus.Success, result.Status);
+
+            var project = repo.GetProjectByExternalId("proj-settings-apply");
+            Assert.NotNull(project);
+            Assert.Equal(destinationId, project!.PreferredDestinationId);
+            Assert.Equal(ProjectRestoreMode.Sandbox, project.RestoreMode);
+            Assert.Equal(ProjectVerificationPolicy.Manual, project.VerificationPolicy);
+            Assert.Equal("imported,remote", project.Tags);
+
+            var refreshedConfig = AppConfigStore.Load();
+            Assert.Empty(refreshedConfig.Advanced.ProjectMetadataConflicts);
+        }
+        finally
+        {
+            AppConfigStore.Save(originalConfig);
+        }
+    }
+
+    [Fact]
+    public void ImportFromStore_ProjectSettings_NormalizesPreferredDestinationIdFromAliasWhenCreatingProject()
+    {
+        var metaRoot = CreateTempDir();
+        var dbPath = Path.Combine(CreateTempDir(), "vaultsync.db");
+        var projectRoot = CreateTempDir();
+        var originalConfig = CloneConfig(AppConfigStore.Load());
+
+        try
+        {
+            var destination = new BackupDestination
+            {
+                Path = CreateTempDir(),
+                Alias = "NAS Primary",
+                Active = true
+            };
+            var destinationId = DestinationIdentityService.GetId(destination);
+            var cfg = CloneConfig(originalConfig);
+            cfg.Backups.Destinations = new List<BackupDestination> { destination };
+            AppConfigStore.Save(cfg);
+
+            var store = CreateStore(metaRoot);
+            SeedMetaInfo(store, "machine-alias-import");
+            store.UpsertProject(new MetaProject
+            {
+                ExternalId = "proj-settings-alias",
+                Name = "Project Settings Alias",
+                Preset = "unity",
+                RootPathHint = projectRoot,
+                CreatedUtc = DateTime.UtcNow.AddDays(-1),
+                SettingsJson = "{\"preferredDestinationId\":\"NAS Primary\"}",
+                UpdatedUtc = DateTime.UtcNow
+            });
+
+            var repo = CreateRepository(dbPath);
+            var service = new MetadataSyncService(repo);
+            var result = service.ImportFromStore(metaRoot, MetadataSyncOptions.Default);
+
+            Assert.Equal(MetadataSyncStatus.Success, result.Status);
+            var project = repo.GetProjectByExternalId("proj-settings-alias");
+            Assert.NotNull(project);
+            Assert.Equal(destinationId, project!.PreferredDestinationId);
+        }
+        finally
+        {
+            AppConfigStore.Save(originalConfig);
+        }
+    }
+
+    [Fact]
+    public void ImportFromStore_ProjectSettings_RecordsNormalizedPreferredDestinationInConflict()
+    {
+        var metaRoot = CreateTempDir();
+        var dbPath = Path.Combine(CreateTempDir(), "vaultsync.db");
+        var projectRoot = CreateTempDir();
+        var now = DateTime.UtcNow;
+        var originalConfig = CloneConfig(AppConfigStore.Load());
+
+        try
+        {
+            var destination = new BackupDestination
+            {
+                Path = CreateTempDir(),
+                Alias = "NAS Imported",
+                Active = true
+            };
+            var destinationId = DestinationIdentityService.GetId(destination);
+            var cfg = CloneConfig(originalConfig);
+            cfg.Advanced.ProjectMetadataConflicts.Clear();
+            cfg.Backups.Destinations = new List<BackupDestination> { destination };
+            AppConfigStore.Save(cfg);
+
+            var repo = CreateRepository(dbPath);
+            var projectId = repo.AddProject(new Project
+            {
+                ExternalId = "proj-conflict-normalized",
+                Name = "Project Conflict Normalized",
+                RootPath = projectRoot,
+                Preset = "unity",
+                CreatedUtc = now.AddDays(-2),
+                PreferredDestinationId = "dest-local",
+                RestoreMode = ProjectRestoreMode.Direct,
+                VerificationPolicy = ProjectVerificationPolicy.Always,
+                Tags = "local"
+            });
+
+            var store = CreateStore(metaRoot);
+            SeedMetaInfo(store, "machine-conflict-normalized");
+            store.UpsertProject(new MetaProject
+            {
+                ExternalId = "proj-conflict-normalized",
+                Name = "Project Conflict Normalized",
+                Preset = "unity",
+                RootPathHint = projectRoot,
+                CreatedUtc = now.AddDays(-2),
+                SettingsJson = "{\"preferredDestinationId\":\"NAS Imported\",\"restoreMode\":\"sandbox\",\"verificationPolicy\":\"manual\",\"tags\":\"imported\"}",
+                UpdatedUtc = now
+            });
+
+            var service = new MetadataSyncService(repo);
+            var result = service.ImportFromStore(metaRoot, MetadataSyncOptions.Default);
+
+            Assert.Equal(MetadataSyncStatus.Success, result.Status);
+            var project = repo.GetProjectById(projectId);
+            Assert.NotNull(project);
+            Assert.Equal("dest-local", project!.PreferredDestinationId);
+
+            var refreshedConfig = AppConfigStore.Load();
+            var conflict = Assert.Single(refreshedConfig.Advanced.ProjectMetadataConflicts);
+            Assert.Equal(destinationId, conflict.Imported.PreferredDestinationId);
+            Assert.Equal("dest-local", conflict.Local.PreferredDestinationId);
+        }
+        finally
+        {
+            AppConfigStore.Save(originalConfig);
+        }
+    }
+
+    [Fact]
+    public void ImportFromStore_MetadataContract_ImportsSelectedFieldsExplicitly()
+    {
+        var metaRoot = CreateTempDir();
+        var dbPath = Path.Combine(CreateTempDir(), "vaultsync.db");
+        var projectRoot = CreateTempDir();
+        var capturedColors = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var previousResolver = MetadataSyncService.ProjectColorResolver;
+        var previousApplier = MetadataSyncService.ProjectColorApplier;
+        const string projectExternalId = "proj-contract-import";
+        const string snapshotExternalId = "snap-contract-import";
+        const string backupExternalId = "backup-contract-import";
+        const string backupPathRel = "project-contract-import/2026-04-17_13-00-00";
+        var topPathsJson = JsonSerializer.Serialize(new[]
+        {
+            new SnapshotDiffPathStat("src/App.cs", 6, 8192),
+            new SnapshotDiffPathStat("assets/logo.png", 1, 4096)
+        }, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        });
+
+        Directory.CreateDirectory(Path.Combine(metaRoot, backupPathRel));
+
+        try
+        {
+            MetadataSyncService.ProjectColorResolver = null;
+            MetadataSyncService.ProjectColorApplier = (externalId, color) => capturedColors[externalId] = color;
+
+            var store = CreateStore(metaRoot);
+            SeedMetaInfo(store, "machine-import-source");
+            store.UpsertProject(new MetaProject
+            {
+                ExternalId = projectExternalId,
+                Name = "Project Import Contract",
+                Preset = "unity",
+                RootPathHint = projectRoot,
+                CreatedUtc = DateTime.UtcNow.AddDays(-2),
+                SettingsJson = "{\"avatarColor\":\"#ABCDEF\"}",
+                UpdatedUtc = DateTime.UtcNow
+            });
+            store.UpsertSnapshot(new MetaSnapshot
+            {
+                ExternalId = snapshotExternalId,
+                ProjectExternalId = projectExternalId,
+                CreatedUtc = DateTime.UtcNow.AddDays(-1),
+                FileCount = 17,
+                TotalBytes = 81_920,
+                DiffAdded = 7,
+                DiffModified = 4,
+                DiffDeleted = 2,
+                DiffNetBytes = 12_288,
+                DiffTopPathsJson = topPathsJson
+            });
+            store.UpsertBackup(new MetaBackup
+            {
+                ExternalId = backupExternalId,
+                ProjectExternalId = projectExternalId,
+                SnapshotExternalId = snapshotExternalId,
+                CreatedUtc = DateTime.UtcNow.AddHours(-2),
+                Type = "manual",
+                BackupMode = BackupModes.Incremental,
+                TotalBytes = 81_920,
+                PathRel = backupPathRel,
+                DestinationAlias = "Remote Vault",
+                OriginMachineName = "machine-import-source",
+                IsProtected = true,
+                IsEncrypted = false,
+                KdfParamsJson = BackupCryptoDescriptor.PlainMetadataJson
+            });
+
+            var repo = CreateRepository(dbPath);
+            var service = new MetadataSyncService(repo);
+            var result = service.ImportFromStore(metaRoot, MetadataSyncOptions.Default);
+
+            Assert.Equal(MetadataSyncStatus.Success, result.Status);
+
+            Assert.True(capturedColors.TryGetValue(projectExternalId, out var importedColor));
+            Assert.Equal("#ABCDEF", importedColor);
+
+            var importedSnapshot = repo.GetSnapshotByExternalId(snapshotExternalId);
+            Assert.NotNull(importedSnapshot);
+            Assert.Equal(7, importedSnapshot!.DiffAdded);
+            Assert.Equal(4, importedSnapshot.DiffModified);
+            Assert.Equal(2, importedSnapshot.DiffDeleted);
+            Assert.Equal(12_288, importedSnapshot.DiffNetBytes);
+            Assert.Equal(topPathsJson, importedSnapshot.DiffTopPathsJson);
+
+            var importedBackup = repo.GetBackupByExternalId(backupExternalId);
+            Assert.NotNull(importedBackup);
+            Assert.Equal(BackupModes.Incremental, importedBackup!.BackupMode);
+            Assert.True(importedBackup.IsProtected);
+            Assert.Equal("machine-import-source", importedBackup.OriginMachineName);
+            Assert.Equal("Remote Vault", importedBackup.DestinationAlias);
+        }
+        finally
+        {
+            MetadataSyncService.ProjectColorResolver = previousResolver;
+            MetadataSyncService.ProjectColorApplier = previousApplier;
+        }
+    }
+
+    [Fact]
     public void ImportFromStore_AppliesProjectTombstone()
     {
         var metaRoot = CreateTempDir();
@@ -916,6 +1327,9 @@ public sealed class MetadataSyncTests : IDisposable
 
     public void Dispose()
     {
+        MetadataSyncService.ProjectColorResolver = null;
+        MetadataSyncService.ProjectColorApplier = null;
+
         foreach (var path in _tempDirs.OrderByDescending(p => p.Length))
             TryDeleteDir(path);
     }


### PR DESCRIPTION
## What changed
- credited contributors explicitly in the root README
- expanded metadata sync contract coverage in `MetadataSyncTests`
- documented metadata sync scope, normalization behavior, and conflict behavior across the docs hub, help page, and wiki
- added a dedicated `docs/wiki/Metadata-Sync.md` page and linked it from the docs indexes

## Why
- make the metadata sync contract explicit in both tests and documentation
- reduce regression risk around exported/imported metadata fields, especially preferred destination normalization and tracked project settings
- improve discoverability for users and contributors working on cross-machine metadata behavior

## Validation
- `dotnet test tests/VaultSync.Core.Tests/VaultSync.Core.Tests.csproj --filter MetadataSyncTests`

## Notes
- this PR stays clear of the open UI/navigation PR work and does not touch those files
