### PR TITLE
feat(release): add linux release assets and patch packaging

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -240,3 +240,76 @@ jobs:
             patches/v${{ inputs.target_version }}/vaultsync-patch-macos-apple-silicon.zip
             patches/v${{ inputs.target_version }}/vaultsync-patch-macos-intel.json
             patches/v${{ inputs.target_version }}/vaultsync-patch-macos-intel.zip
+
+  linux:
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Publish (linux-x64)
+        run: >
+          dotnet publish src/VaultSync.UI/VaultSync.UI.csproj
+          -c Release
+          -f net8.0
+          -r linux-x64
+          --self-contained true
+
+      - name: Publish (linux-arm64)
+        run: >
+          dotnet publish src/VaultSync.UI/VaultSync.UI.csproj
+          -c Release
+          -f net8.0
+          -r linux-arm64
+          --self-contained true
+
+      - name: Build Linux archives
+        run: |
+          bash scripts/build_linux_release.sh "${{ inputs.target_version }}" x64 src/VaultSync.UI/bin/Release/net8.0/linux-x64/publish
+          bash scripts/build_linux_release.sh "${{ inputs.target_version }}" arm64 src/VaultSync.UI/bin/Release/net8.0/linux-arm64/publish
+
+      - name: Build patch assets
+        env:
+          PATCH_BASE_VERSIONS: ${{ needs.validate.outputs.patch_base_versions }}
+        run: |
+          mkdir -p "patches/v${{ inputs.target_version }}"
+          previous_args=()
+          while IFS= read -r base; do
+            [[ -n "$base" ]] || continue
+            previous_args+=( --previous "$base" )
+          done <<'EOF'
+          ${{ needs.validate.outputs.patch_base_versions }}
+          EOF
+          python3 scripts/build_patch.py \
+            --base-dir "src/VaultSync.UI/bin/Release/net8.0/linux-x64/publish" \
+            --out-zip "patches/v${{ inputs.target_version }}/vaultsync-patch-linux-x64.zip" \
+            --out-manifest "patches/v${{ inputs.target_version }}/vaultsync-patch-linux-x64.json" \
+            --platform linux \
+            "${previous_args[@]}" \
+            --target "${{ inputs.target_version }}"
+          python3 scripts/build_patch.py \
+            --base-dir "src/VaultSync.UI/bin/Release/net8.0/linux-arm64/publish" \
+            --out-zip "patches/v${{ inputs.target_version }}/vaultsync-patch-linux-arm64.zip" \
+            --out-manifest "patches/v${{ inputs.target_version }}/vaultsync-patch-linux-arm64.json" \
+            --platform linux \
+            "${previous_args[@]}" \
+            --target "${{ inputs.target_version }}"
+
+      - name: Upload Linux artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-release-assets
+          path: |
+            dist/linux/VaultSync-*-linux-x64.tar.gz
+            dist/linux/VaultSync-*-linux-arm64.tar.gz
+            dist/linux/VaultSync-*-linux-x64.AppImage
+            patches/v${{ inputs.target_version }}/vaultsync-patch-linux-x64.json
+            patches/v${{ inputs.target_version }}/vaultsync-patch-linux-x64.zip
+            patches/v${{ inputs.target_version }}/vaultsync-patch-linux-arm64.json
+            patches/v${{ inputs.target_version }}/vaultsync-patch-linux-arm64.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 ﻿# Changelog
 ## [1.7.3] - Unreleased
+### Added
+- [VS-1805] Release asset builds now produce Linux `tar.gz` downloads for `x64` and `arm64`, plus a desktop-friendly `linux-x64` AppImage so direct Linux installs cover the widest practical audience.
+### Changed
+- [VS-1805] Linux update discovery now prefers architecture-specific installers and patch assets (`linux-x64` / `linux-arm64`) before falling back to generic Linux naming.
 ### Fixed
 - [BUG-17100] Tray panel screen detection, reopen behavior, and Linux/Wayland positioning are now resilient on Hyprland-class environments. Contributed by @JustH8Me in PR #216.
 - [BUG-17101] Fixed tooltip flickering and focus issues on Linux/Wayland by enabling overlay popups PR #217 (thanks @JustH8Me)
 - [BUG-17102] Fixed fatal AccessViolationException on Linux x64 during backup (thanks @JustH8Me, refs #218)
 - [BUG-17103] Fixed passwords being saved as 'null' on Linux and increased timeouts passwords (thanks @JustH8Me, refs #220)
--
+
 ## [1.7.2] - 09.04.2026
 ### Added
 - [VS-1727] Added an initial Microsoft Store packaging scaffold with the reserved Partner Center identity values, separate from the Direct installer path.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1503,6 +1503,60 @@
   - Acceptance:
     - enabling checkpointed retry no longer silently disables parallel archive uploads
     - interrupted parallel uploads can resume safely without re-sending already validated chunks
+- [ ] `BUG-17104` `P1` Keep Settings `Projects root` synchronized after config reloads in the cached Settings view.
+  - Scope: ensure `LoadFromConfig()` refreshes visible Settings fields reliably, avoids reload-time autosave churn, and keeps the persisted `ProjectsRoot` value visible after navigation or startup reloads.
+  - Current status:
+    - In progress: implemented on PR `#222`.
+    - Issue `#227` tracks the regression report and expected behavior.
+  - Acceptance:
+    - Settings no longer shows `Projects root` as blank when the config file still contains a valid value
+    - reload-time field refreshes do not trigger spurious saves
+- [ ] `BUG-17105` `P1` Repair blank project roots during startup when the project folder still exists under `ProjectsRoot`.
+  - Scope: reconcile blank `RootPath` values after startup initialization, repair from `ProjectsRoot\\ProjectName` when present, and prefer project-id-based updates where available.
+  - Current status:
+    - In progress: implemented on PR `#222`.
+    - Issue `#228` tracks the startup repair gap.
+  - Acceptance:
+    - projects with recoverable blank roots are repaired during startup without waiting for backup/restore flows
+    - project root repairs prefer stable project identity over name-only matching
+- [ ] `BUG-17106` `P2` Add explicit auto-scroll and selected-line copy controls to the in-app log console.
+  - Scope: expose an explicit tail-follow toggle, stop manual scroll from fighting live capture, and allow copying the selected log line via button and standard shortcut.
+  - Current status:
+    - In progress: implemented on PR `#222`.
+    - Issue `#229` tracks the user-facing log console controls.
+  - Acceptance:
+    - the log console exposes an explicit auto-scroll toggle
+    - users can copy the selected log line from the UI and with the platform shortcut
+- [ ] `BUG-17107` `P1` Preserve `Read-only` destination status for Linux paths that fail real write access.
+  - Scope: replace the Linux-unreliable read-only heuristic in background destination probes with a real writability check, and preserve read-only warning state instead of collapsing it back to green reachable success on status refresh.
+  - Current status:
+    - Reported via issue `#230`: `chmod 555` paths can flip from `Read-only` back to green `Reachable` during background/status refresh even though backups still fail with write denial.
+  - Acceptance:
+    - Linux read-only destinations stay visibly `Read-only` during background and navigation refreshes
+    - status refresh paths preserve warning/read-only state instead of repainting it as success
+- [ ] `BUG-17108` `P1` Make the in-app log console reliably surface runtime errors and exception paths.
+  - Scope: ensure exceptions and error-level diagnostics that currently only appear in terminal/stdout or external console paths are also routed into the in-app log console consistently across Linux and other desktop targets.
+  - Current status:
+    - Reported via issue `#231`: some reproducible runtime errors do not appear in the in-app log console even though they are visible from `dotnet run` output.
+  - Acceptance:
+    - reproducible runtime errors appear in the in-app log console without requiring an external terminal
+    - log console coverage is consistent for handled and surfaced error paths on supported desktop targets
+- [ ] `BUG-17109` `P1` Fix destination status localization staying stale after navigation with cached views.
+  - Scope: keep destination status state in invariant internal keys, localize only at display time, and force destination-status refreshes when localization changes so cached navigation does not resurrect stale-language labels.
+  - Current status:
+    - Reported via issue `#223`.
+    - Related work lives on PR `#222`.
+  - Acceptance:
+    - destination status cards always render in the active UI language after navigation and menu reopen flows
+    - cached view reuse does not keep stale localized destination labels alive
+- [ ] `VS-1805` `P1` Add Linux release assets and architecture-aware patch packaging to the release workflow.
+  - Scope: build Linux `tar.gz` assets for `x64` and `arm64`, produce a desktop-friendly `linux-x64` AppImage, generate Linux patch assets, and make updater asset selection architecture-aware.
+  - Current status:
+    - In progress: workflow, updater, and docs changes are prepared locally on `Dev`.
+    - Issue `#232` tracks the release-asset work item.
+  - Acceptance:
+    - release-assets workflow uploads Linux install artifacts and Linux patch assets
+    - Linux update discovery prefers architecture-specific installers and patch assets before generic Linux fallback
 
 ## 1.8.x
 - [ ] `VS-1723` `P1` Refactor SettingsViewModel into feature partials.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,4 +1,4 @@
-﻿# Releasing VaultSync (Windows and macOS)
+# Releasing VaultSync (Windows, macOS, and Linux)
 
 This document defines the current release packaging flow.
 
@@ -25,7 +25,20 @@ This document defines the current release packaging flow.
 2. Build `.app` and `.dmg` using repository scripts.
 3. Upload both DMGs to release assets.
 
-## 3) Patch/Updater Assets
+## 3) Linux Direct Assets
+1. Publish both Linux architectures:
+   ```bash
+   dotnet publish src/VaultSync.UI/VaultSync.UI.csproj -c Release -f net8.0 -r linux-x64 --self-contained true
+   dotnet publish src/VaultSync.UI/VaultSync.UI.csproj -c Release -f net8.0 -r linux-arm64 --self-contained true
+   ```
+2. Build Linux archives:
+   ```bash
+   bash scripts/build_linux_release.sh 1.7.3 x64 src/VaultSync.UI/bin/Release/net8.0/linux-x64/publish
+   bash scripts/build_linux_release.sh 1.7.3 arm64 src/VaultSync.UI/bin/Release/net8.0/linux-arm64/publish
+   ```
+3. Upload the generated `.tar.gz` artifacts and the `linux-x64` `.AppImage`.
+
+## 4) Patch/Updater Assets
 Create patch manifest and patch archives as described in `docs/UPDATER.md`.
 
 For `VS-1724` multi-base patch support:
@@ -59,7 +72,7 @@ This produces one manifest with:
 
 Older or unlisted installs must fall back to the full installer.
 
-## 4) Release Checklist
+## 5) Release Checklist
 - Run the release gate before publishing:
   ```powershell
   powershell -ExecutionPolicy Bypass -File scripts/release_readiness_gate.ps1
@@ -72,14 +85,20 @@ Older or unlisted installs must fall back to the full installer.
 - `docs/WHATS_NEW.md` updated
 - relevant wiki/help docs updated
 - build/test validation captured
-- release assets uploaded (installer/DMG/patch assets)
+- release assets uploaded (installer/DMG/Linux archives/patch assets)
 
-## 5) Unsigned Build Note
+## 6) Unsigned Build Note
 VaultSync builds are currently unsigned.
 
 macOS users may need to run:
 ```bash
 xattr -dr com.apple.quarantine /Applications/VaultSync.app
+```
+
+Linux AppImage users may need to run:
+```bash
+chmod +x VaultSync-<version>-linux-x64.AppImage
+./VaultSync-<version>-linux-x64.AppImage
 ```
 
 ## Related Docs

--- a/docs/UPDATER.md
+++ b/docs/UPDATER.md
@@ -15,10 +15,18 @@ VaultSync uses GitHub Releases for update discovery and supports patch assets to
   - `VaultSyncInstaller.exe`
 - macOS bundles:
   - architecture-specific DMGs
+- Linux bundles:
+  - `VaultSync-<version>-linux-x64.AppImage`
+  - `VaultSync-<version>-linux-x64.tar.gz`
+  - `VaultSync-<version>-linux-arm64.tar.gz`
 
 macOS can use architecture-specific patch names:
 - `vaultsync-patch-macos-apple-silicon.*`
 - `vaultsync-patch-macos-intel.*`
+
+Linux can use architecture-specific patch names:
+- `vaultsync-patch-linux-x64.*`
+- `vaultsync-patch-linux-arm64.*`
 
 ## Runtime Expectations
 - Updater checks according to Settings policy.

--- a/docs/wiki/Updates.md
+++ b/docs/wiki/Updates.md
@@ -15,6 +15,7 @@ VaultSync supports two Windows update models:
 - If a patch fails, the installer fallback is offered.
 - Patch assets are named `vaultsync-patch-<platform>.json` and `vaultsync-patch-<platform>.zip`.
   - macOS checks for arch-specific assets first (`vaultsync-patch-macos-apple-silicon.*` or `vaultsync-patch-macos-intel.*`).
+  - Linux checks for arch-specific assets first (`vaultsync-patch-linux-x64.*` or `vaultsync-patch-linux-arm64.*`).
 - Patch eligibility is exact:
   - the manifest must explicitly list the installed version as an allowed base version
   - unlisted or older installs fall back to the full installer

--- a/scripts/build_linux_release.sh
+++ b/scripts/build_linux_release.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "Usage: $0 <version> <arch> <publish-dir>" >&2
+  exit 1
+fi
+
+version="$1"
+arch="$2"
+publish_dir="$3"
+
+if [[ "$arch" != "x64" && "$arch" != "arm64" ]]; then
+  echo "Unsupported Linux arch: $arch" >&2
+  exit 1
+fi
+
+if [[ ! -d "$publish_dir" ]]; then
+  echo "Publish directory not found: $publish_dir" >&2
+  exit 1
+fi
+
+dist_dir="dist/linux"
+mkdir -p "$dist_dir"
+
+base_name="VaultSync-${version}-linux-${arch}"
+tarball_path="${dist_dir}/${base_name}.tar.gz"
+tar -C "$publish_dir" -czf "$tarball_path" .
+
+if [[ "$arch" != "x64" ]]; then
+  exit 0
+fi
+
+appimage_tool_url="https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
+tool_dir="$(mktemp -d)"
+appdir="$(mktemp -d)"
+trap 'rm -rf "$tool_dir" "$appdir"' EXIT
+
+appimage_tool="${tool_dir}/appimagetool-x86_64.AppImage"
+curl -fsSL "$appimage_tool_url" -o "$appimage_tool"
+chmod +x "$appimage_tool"
+
+mkdir -p \
+  "${appdir}/usr/bin" \
+  "${appdir}/usr/share/applications" \
+  "${appdir}/usr/share/icons/hicolor/256x256/apps"
+
+cp -a "${publish_dir}/." "${appdir}/usr/bin/"
+cp "${publish_dir}/Assets/vaultsync-tray.png" "${appdir}/usr/share/icons/hicolor/256x256/apps/vaultsync.png"
+cp "${publish_dir}/Assets/vaultsync-tray.png" "${appdir}/vaultsync.png"
+
+cat > "${appdir}/AppRun" <<'EOF'
+#!/bin/sh
+HERE="$(dirname "$(readlink -f "$0")")"
+exec "${HERE}/usr/bin/VaultSync.UI" "$@"
+EOF
+chmod +x "${appdir}/AppRun"
+
+cat > "${appdir}/vaultsync.desktop" <<'EOF'
+[Desktop Entry]
+Type=Application
+Name=VaultSync
+Comment=Backup and synchronization tool
+Exec=VaultSync.UI
+Icon=vaultsync
+Categories=Utility;Archiving;
+Terminal=false
+StartupWMClass=VaultSync
+EOF
+
+cp "${appdir}/vaultsync.desktop" "${appdir}/usr/share/applications/vaultsync.desktop"
+
+appimage_path="${dist_dir}/${base_name}.AppImage"
+APPIMAGE_EXTRACT_AND_RUN=1 ARCH=x86_64 "$appimage_tool" "$appdir" "$appimage_path"

--- a/src/VaultSync.UI/Services/GitHubUpdateService.cs
+++ b/src/VaultSync.UI/Services/GitHubUpdateService.cs
@@ -485,7 +485,18 @@ namespace VaultSync.UI.Services
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                asset = assets.FirstOrDefault(a =>
+                foreach (var suffix in GetLinuxAssetSuffixes())
+                {
+                    asset = assets.FirstOrDefault(a =>
+                        a.Name is not null &&
+                        a.Name.Contains(suffix, StringComparison.OrdinalIgnoreCase) &&
+                        (a.Name.EndsWith(".AppImage", StringComparison.OrdinalIgnoreCase) ||
+                         a.Name.EndsWith(".tar.gz", StringComparison.OrdinalIgnoreCase)));
+                    if (asset != null)
+                        break;
+                }
+
+                asset ??= assets.FirstOrDefault(a =>
                     a.Name is not null &&
                     (a.Name.EndsWith(".AppImage", StringComparison.OrdinalIgnoreCase) ||
                      a.Name.EndsWith(".tar.gz", StringComparison.OrdinalIgnoreCase)));
@@ -511,8 +522,30 @@ namespace VaultSync.UI.Services
                 return new List<string> { suffix, "macos" };
             }
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                return new List<string> { "linux" };
+            {
+                var suffixes = GetLinuxPatchSuffixes();
+                suffixes.Add("linux");
+                return suffixes;
+            }
             return new List<string>();
+        }
+
+        private static List<string> GetLinuxPatchSuffixes()
+        {
+            return RuntimeInformation.ProcessArchitecture switch
+            {
+                Architecture.Arm64 => new List<string> { "linux-arm64" },
+                _ => new List<string> { "linux-x64" }
+            };
+        }
+
+        private static List<string> GetLinuxAssetSuffixes()
+        {
+            return RuntimeInformation.ProcessArchitecture switch
+            {
+                Architecture.Arm64 => new List<string> { "linux-arm64", "arm64", "aarch64" },
+                _ => new List<string> { "linux-x64", "x64", "x86_64", "amd64" }
+            };
         }
 
         private static string DescribeRelease(GitHubRelease? release)


### PR DESCRIPTION
## Summary
- add Linux release assets and Linux patch packaging to the release-assets workflow
- make Linux updater asset selection architecture-aware for x64 and arm64
- align roadmap tracking for the current 1.7.x follow-up issue set

## Related issue
Closes #232

## Included work
- VS-1805 Linux release workflow and updater support
- roadmap entries for BUG-17104 through BUG-17109 and VS-1805 so the current 1.7.x issue set is tracked consistently

## Validation
- dotnet build src/VaultSync.UI/VaultSync.UI.csproj -c Debug -f net8.0
- dotnet test tests/VaultSync.Core.Tests/VaultSync.Core.Tests.csproj --no-build