### PR TITLE
Fix Linux read-only status and sync Test button results (#230)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [BUG-17103] Fixed passwords being saved as 'null' on Linux and increased timeouts passwords (thanks @JustH8Me, refs #220)
 - [BUG-17104] Settings now refreshes persisted values correctly after config reloads, preventing fields like Projects root from appearing blank even when the saved config is intact.
 - [BUG-17105] Startup now repairs blank project root paths from the configured Projects root when the matching project folder still exists on disk, reducing missing-path issues after relaunch.
+- [BUG-17107] Fixed false "Reachable" status for Read-Only directories on Linux and eliminated UI list flickering (thanks @JustH8Me, refs #230)
 ## [1.7.2] - 09.04.2026
 ### Added
 - [VS-1727] Added an initial Microsoft Store packaging scaffold with the reserved Partner Center identity values, separate from the Direct installer path.

--- a/src/VaultSync.UI/ViewModels/AppViewModel.ConfigurationOps.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.ConfigurationOps.cs
@@ -83,8 +83,7 @@ namespace VaultSync.UI.ViewModels
                     var summaries = GetDestinationProbeSummaries(cfg);
                     foreach (var summary in summaries)
                     {
-                        var severity = summary.Reachable ? BackupsViewModel.SeverityStatus.Success : BackupsViewModel.SeverityStatus.Error;
-                        vm.UpdateDestinationStatus(summary.Id, summary.Message, severity);
+                        vm.UpdateDestinationStatus(summary.Id, summary.Message, summary.Severity, summary.Alias);
                     }
                 }
                 catch (Exception ex)
@@ -1308,6 +1307,10 @@ namespace VaultSync.UI.ViewModels
         private void OnSettingsChanged(object? sender, PropertyChangedEventArgs e)
         {
             var propertyName = e.PropertyName ?? string.Empty;
+            if (propertyName == nameof(SettingsViewModel.SaveStatus))
+            {
+                return;
+            }
             QueueConfigReload(cfg =>
             {
                 _config = cfg;
@@ -1400,13 +1403,15 @@ namespace VaultSync.UI.ViewModels
 
         private void OnDestinationViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
-            if (sender is not BackupDestinationViewModel)
+            if (sender is not BackupDestinationViewModel dest)
                 return;
 
             if (e.PropertyName is nameof(BackupDestinationViewModel.Alias)
                 or nameof(BackupDestinationViewModel.Path)
                 or nameof(BackupDestinationViewModel.Active))
             {
+                var targetId = DestinationStatusItem.GetId(new BackupDestination { Path = dest.Path, Alias = dest.Alias });
+                _destinationProbeSummaries.TryRemove(targetId, out _);
                 RefreshDestinationOptionSources();
                 RefreshDestinationStatusOverview();
             }

--- a/src/VaultSync.UI/ViewModels/AppViewModel.RuntimeOps.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.RuntimeOps.cs
@@ -202,9 +202,7 @@ namespace VaultSync.UI.ViewModels
                 : result.Message;
 
             var severity = result.Reachable
-                ? (message.Contains(LStatic("Destinations.Test.ReadOnly", "Read-only"), StringComparison.OrdinalIgnoreCase)
-                    ? BackupsViewModel.SeverityStatus.Warning
-                    : BackupsViewModel.SeverityStatus.Success)
+                ? (result.Writable ? BackupsViewModel.SeverityStatus.Success : BackupsViewModel.SeverityStatus.Warning)
                 : BackupsViewModel.SeverityStatus.Error;
 
             _destinationProbeSummaries[id] = new DestinationProbeSummary(
@@ -213,9 +211,10 @@ namespace VaultSync.UI.ViewModels
                 dest.Path ?? string.Empty,
                 result.Reachable,
                 message,
-                DateTime.UtcNow);
+                DateTime.UtcNow,
+                severity);
 
-            BackupsViewModel.UpdateDestinationStatus(id, message, severity);
+            BackupsViewModel.UpdateDestinationStatus(id, message, severity, dest.Alias);
         }
 
         private void OnRefreshHistoryRequested()
@@ -759,6 +758,11 @@ namespace VaultSync.UI.ViewModels
 
             try
             {
+                if (OperatingSystem.IsLinux())
+                {
+                    return TryWriteProbeFile(path);
+                }
+
                 var info = new DirectoryInfo(path);
                 if (!info.Exists)
                     return false;
@@ -1369,6 +1373,32 @@ namespace VaultSync.UI.ViewModels
             }
 
             return Task.CompletedTask;
+        }
+        private static bool TryWriteProbeFile(string effectivePath)
+        {
+            var testFile = Path.Combine(effectivePath, $".vaultsync_destination_test_{Guid.NewGuid():N}");
+            try
+            {
+                File.WriteAllText(testFile, "ok");
+                File.Delete(testFile);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+            finally
+            {
+                try
+                {
+                    if (File.Exists(testFile))
+                        File.Delete(testFile);
+                }
+                catch
+                {
+                    // best effort cleanup
+                }
+            }
         }
 
     }

--- a/src/VaultSync.UI/ViewModels/AppViewModel.StartupOps.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.StartupOps.cs
@@ -77,7 +77,6 @@ namespace VaultSync.UI.ViewModels
                 UpdateDestinationProbeSummary(dest, testResult);
             };
 
-            _settingsViewModel.UpdateUpdateCheckStatus(null, null);
             foreach (var dest in _settingsViewModel.Destinations)
             {
                 TrackDestinationViewModel(dest);

--- a/src/VaultSync.UI/ViewModels/AppViewModel.StartupOps.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.StartupOps.cs
@@ -71,6 +71,13 @@ namespace VaultSync.UI.ViewModels
             _settingsViewModel.LockEncryptedOpenWorkspacesRequested += OnLockEncryptedOpenWorkspacesRequested;
             _settingsViewModel.UpdateUpdateCheckStatus(null, null);
             _settingsViewModel.Destinations.CollectionChanged += OnDestinationsCollectionChanged;
+            _settingsViewModel.DestinationTested += (dest, success, writable, message) =>
+            {
+                var testResult = new DestinationTestResult(success, writable, dest.Path ?? string.Empty, message);
+                UpdateDestinationProbeSummary(dest, testResult);
+            };
+
+            _settingsViewModel.UpdateUpdateCheckStatus(null, null);
             foreach (var dest in _settingsViewModel.Destinations)
             {
                 TrackDestinationViewModel(dest);

--- a/src/VaultSync.UI/ViewModels/AppViewModel.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.cs
@@ -82,7 +82,8 @@ namespace VaultSync.UI.ViewModels
             string Path,
             bool Reachable,
             string Message,
-            DateTime LastChecked);
+            DateTime LastChecked,
+            BackupsViewModel.SeverityStatus Severity);
 
         public event Action? TrayMenuRefreshRequested;
 

--- a/src/VaultSync.UI/ViewModels/BackupsViewModel.cs
+++ b/src/VaultSync.UI/ViewModels/BackupsViewModel.cs
@@ -1855,7 +1855,7 @@ namespace VaultSync.UI.ViewModels
         {
             if (!Dispatcher.UIThread.CheckAccess())
             {
-                Dispatcher.UIThread.Post(() => UpdateDestinationStatus(id, status, severity));
+                Dispatcher.UIThread.Post(() => UpdateDestinationStatus(id, status, severity, alias));
                 return;
             }
 

--- a/src/VaultSync.UI/ViewModels/BackupsViewModel.cs
+++ b/src/VaultSync.UI/ViewModels/BackupsViewModel.cs
@@ -1763,30 +1763,47 @@ namespace VaultSync.UI.ViewModels
 
             ShowDestinationToggles = allowToggle;
 
-            foreach (var item in DestinationStatuses)
+            var activeIds = list.Select(DestinationStatusItem.GetId).ToHashSet();
+
+            for (int i = DestinationStatuses.Count - 1; i >= 0; i--)
             {
-                item.PropertyChanged -= OnDestinationItemPropertyChanged;
+                if (!activeIds.Contains(DestinationStatuses[i].Id))
+                {
+                    DestinationStatuses[i].PropertyChanged -= OnDestinationItemPropertyChanged;
+                    DestinationStatuses.RemoveAt(i);
+                }
             }
-            DestinationStatuses.Clear();
+
             foreach (var dest in list)
             {
-                var status = dest.Active ? DestinationStatus.Pending : DestinationStatus.Inactive;
-                var severity = SeverityStatus.None;
-                var item = new DestinationStatusItem
+                var id = DestinationStatusItem.GetId(dest);
+                var existing = DestinationStatuses.FirstOrDefault(x => x.Id == id);
+                if (existing == null)
                 {
-                    Id     = DestinationStatusItem.GetId(dest),
-                    Alias  = string.IsNullOrWhiteSpace(dest.Alias) ? dest.Path : dest.Alias ?? dest.Path,
-                    Path   = dest.Path,
-                    Status = status,
-                    Severity = severity,
-                    DotBrush = GetDestinationDotBrush(status, severity),
-                    LastCheckedUtc = null,
-                    IsActive = dest.Active,
-                    IsConfigurable = allowToggle
-                };
-                ApplyDestinationQuotaPlan(item);
-                item.PropertyChanged += OnDestinationItemPropertyChanged;
-                DestinationStatuses.Add(item);
+                    var status = dest.Active ? DestinationStatus.Pending : DestinationStatus.Inactive;
+                    var severity = SeverityStatus.None;
+                    var item = new DestinationStatusItem
+                    {
+                        Id = DestinationStatusItem.GetId(dest),
+                        Alias = string.IsNullOrWhiteSpace(dest.Alias) ? dest.Path : dest.Alias ?? dest.Path,
+                        Path = dest.Path,
+                        Status = status,
+                        Severity = severity,
+                        DotBrush = GetDestinationDotBrush(status, severity),
+                        LastCheckedUtc = null,
+                        IsActive = dest.Active,
+                        IsConfigurable = allowToggle
+                    };
+                    ApplyDestinationQuotaPlan(item);
+                    item.PropertyChanged += OnDestinationItemPropertyChanged;
+                    DestinationStatuses.Add(item);
+                }
+                else
+                {
+                    existing.IsActive = dest.Active;
+                    existing.IsConfigurable = allowToggle;
+                    existing.Alias = string.IsNullOrWhiteSpace(dest.Alias) ? dest.Path : dest.Alias ?? dest.Path;
+                }
             }
             RebuildActiveDestinationStatuses();
             OnPropertyChanged(nameof(HasDestinationStatuses));
@@ -1834,7 +1851,7 @@ namespace VaultSync.UI.ViewModels
             OnPropertyChanged(nameof(HasActiveDestinationStatuses));
         }
 
-        public void UpdateDestinationStatus(string id, string status, SeverityStatus severity = SeverityStatus.None)
+        public void UpdateDestinationStatus(string id, string status, SeverityStatus severity = SeverityStatus.None, string? alias = null)
         {
             if (!Dispatcher.UIThread.CheckAccess())
             {
@@ -1843,85 +1860,44 @@ namespace VaultSync.UI.ViewModels
             }
 
             var item = DestinationStatuses.FirstOrDefault(d => d.Id == id);
+            if (item is null && !string.IsNullOrWhiteSpace(alias))
+            {
+                item = DestinationStatuses.FirstOrDefault(d => string.Equals(d.Alias, alias, StringComparison.OrdinalIgnoreCase));
+            }
+
             if (item is null)
                 return;
 
-            string rawText = status;
-            if (rawText == null)
+            if (severity == SeverityStatus.None)
             {
-                rawText = string.Empty;
+                var rawText = status ?? string.Empty;
+                if (rawText.Contains("Read-only", StringComparison.CurrentCultureIgnoreCase )||
+                        rawText.Contains("ReadOnly", StringComparison.CurrentCultureIgnoreCase))
+                {
+                    severity = SeverityStatus.Warning;
+                }
+                else if (rawText.Contains("Unavailable", StringComparison.CurrentCultureIgnoreCase) ||
+                          rawText.Contains("Unreachable", StringComparison.CurrentCultureIgnoreCase) ||
+                          rawText.Contains("Error", StringComparison.CurrentCultureIgnoreCase))
+                {
+                    severity = SeverityStatus.Error;
+                }
+                else if (!string.IsNullOrWhiteSpace(rawText))
+                {
+                    severity = SeverityStatus.Success;
+                }
             }
-
-            DestinationStatus newStatus = DestinationStatus.None;
-
-            newStatus = severity switch
+            DestinationStatus newStatus = severity switch
             {
                 SeverityStatus.Success => DestinationStatus.Reachable,
                 SeverityStatus.Warning => DestinationStatus.ReadOnly,
                 SeverityStatus.Error => DestinationStatus.Unavailable,
                 _ => DestinationStatus.None
             };
-            if (newStatus != DestinationStatus.None)
-            {
-                if (rawText.Contains("Using pre-mounted", StringComparison.OrdinalIgnoreCase) ||
-                    rawText.Contains("Reachable", StringComparison.OrdinalIgnoreCase) ||
-                    rawText.Contains("Completed", StringComparison.OrdinalIgnoreCase) ||
-                    rawText.Contains("No changes", StringComparison.OrdinalIgnoreCase) ||
-                    rawText.Contains("No backup", StringComparison.OrdinalIgnoreCase))
-                {
-                    newStatus = DestinationStatus.Reachable;
-                }
-                else if (rawText.Contains("Read-only", StringComparison.OrdinalIgnoreCase) ||
-                         rawText.Contains("Read only", StringComparison.OrdinalIgnoreCase))
-                {
-                    newStatus = DestinationStatus.ReadOnly;
-                }
-                else if (rawText.Contains("Unavailable", StringComparison.OrdinalIgnoreCase) ||
-                         rawText.Contains("Unreachable", StringComparison.OrdinalIgnoreCase))
-                {
-                    newStatus = DestinationStatus.Unavailable;
-                }
-                else
-                {
-                    if (severity == SeverityStatus.Success)
-                    {
-                        newStatus = DestinationStatus.Reachable;
-                    }
-                    else if (severity == SeverityStatus.Warning)
-                    {
-                        newStatus = DestinationStatus.ReadOnly;
-                    }
-                    else if (severity == SeverityStatus.Error)
-                    {
-                        newStatus = DestinationStatus.Unavailable;
-                    }
-                }
-            }
-
-            var severityToUse = severity;
-            if (severity == SeverityStatus.None)
-            {
-                if (newStatus == DestinationStatus.Reachable)
-                {
-                    severityToUse = SeverityStatus.Success;
-                }
-                else if (newStatus == DestinationStatus.Unavailable)
-                {
-                    severityToUse = SeverityStatus.Error;
-                }
-                else if (newStatus == DestinationStatus.ReadOnly)
-                {
-                    severityToUse = SeverityStatus.Warning;
-                }
-                else if (newStatus == DestinationStatus.None)
-                {
-                    severityToUse = item.Severity;
-                }
-            }
 
             item.Status   = newStatus;
-            item.Severity = severityToUse;
-            item.DotBrush = GetDestinationDotBrush(newStatus, severityToUse);
+            item.Severity = severity;
+            item.DotBrush = GetDestinationDotBrush(newStatus, severity);
             item.LastCheckedUtc = DateTime.UtcNow;
         }
 

--- a/src/VaultSync.UI/ViewModels/SettingsViewModel.cs
+++ b/src/VaultSync.UI/ViewModels/SettingsViewModel.cs
@@ -164,6 +164,7 @@ namespace VaultSync.UI
         public event Action? RotateEncryptedBackupsRequested;
         public event Action? EnrollProjectEncryptionRequested;
         public event Action? LockEncryptedOpenWorkspacesRequested;
+        public event Action<BackupDestination, bool, bool, string>? DestinationTested;
 
         private sealed record DestinationSnapshot(
             string Alias,
@@ -2918,6 +2919,7 @@ namespace VaultSync.UI
                     _networkMountService.Cleanup(resolution);
                 }
             });
+            DestinationTested?.Invoke(destModel, result.success, result.writable, result.message);
 
             if (!result.success)
             {

--- a/src/VaultSync.UI/ViewModels/SettingsViewModel.cs
+++ b/src/VaultSync.UI/ViewModels/SettingsViewModel.cs
@@ -3033,15 +3033,38 @@ namespace VaultSync.UI
                 return (false, false);
             }
 
-            bool canWrite = TryWriteProbeFile(path);
+            try
+            {
+                Directory.CreateDirectory(path);
+            }
+            catch (Exception ex)
+            {
+                BackupLocationStatus = "Not accessible";
+                if (notifyOnSuccess)
+                {
+                    GlobalNotificationCenter.Instance.Show(
+                        $"Backup location not accessible: {ex.Message}",
+                        NotificationSeverity.Error,
+                        "Backup location");
+                }
+                return (false, false);
+            }
+
+            var canWrite = TryWriteProbeFile(path);
             if (!canWrite)
             {
                 BackupLocationStatus = "Not writable";
+                if (notifyOnSuccess)
+                {
+                    GlobalNotificationCenter.Instance.Show(
+                        "Backup location is not writable.",
+                        NotificationSeverity.Error,
+                        "Backup location");
+                }
                 return (true, false);
             }
 
             // Check free space against the configured minimum threshold.
-            bool lowSpace = false;
             try
             {
                 var drive = new DriveInfo(path);
@@ -3055,7 +3078,6 @@ namespace VaultSync.UI
                             $"Free space below threshold ({freePercent:0.#}% available, threshold {MinimumFreeSpacePercent}%).",
                             NotificationSeverity.Warning,
                             "Backup location");
-                        lowSpace = true;
                     }
                     else
                     {
@@ -3067,7 +3089,6 @@ namespace VaultSync.UI
                                 NotificationSeverity.Info,
                                 "Backup location");
                         }
-                        lowSpace = false;
                     }
                 }
             }

--- a/src/VaultSync.UI/ViewModels/SettingsViewModel.cs
+++ b/src/VaultSync.UI/ViewModels/SettingsViewModel.cs
@@ -1488,7 +1488,11 @@ namespace VaultSync.UI
             {
                 if (SetField(ref _backupLocationPath, value))
                 {
-                    ValidateBackupLocation(value);
+                    var (reachable, writable) = ValidateBackupLocation(value, notifyOnSuccess: false);
+                    if (_isInitialized)
+                    {
+                        DestinationTested?.Invoke(new BackupDestination { Alias = "Primary", Path = value, Active = true, PreMounted = true }, reachable, writable, BackupLocationStatus);
+                    }
                 }
             }
         }
@@ -3021,46 +3025,23 @@ namespace VaultSync.UI
             Dispatcher.UIThread.Post(Raise);
         }
 
-        private void ValidateBackupLocation(string path, bool notifyOnSuccess = true)
+        private (bool isReachable, bool isWritable) ValidateBackupLocation(string path, bool notifyOnSuccess = true)
         {
             if (string.IsNullOrWhiteSpace(path))
             {
                 BackupLocationStatus = string.Empty;
-                return;
+                return (false, false);
             }
 
-            try
-            {
-                Directory.CreateDirectory(path);
-            }
-            catch (Exception ex)
-            {
-                BackupLocationStatus = "Not accessible";
-                GlobalNotificationCenter.Instance.Show(
-                    $"Backup location not accessible: {ex.Message}",
-                    NotificationSeverity.Error,
-                    "Backup location");
-                return;
-            }
-
-            // Write test file to ensure we can write to the target.
-            var testFile = Path.Combine(path, ".vaultsync_write_test");
-            try
-            {
-                File.WriteAllText(testFile, "ok");
-                File.Delete(testFile);
-            }
-            catch (Exception ex)
+            bool canWrite = TryWriteProbeFile(path);
+            if (!canWrite)
             {
                 BackupLocationStatus = "Not writable";
-                GlobalNotificationCenter.Instance.Show(
-                    $"Backup location is not writable: {ex.Message}",
-                    NotificationSeverity.Error,
-                    "Backup location");
-                return;
+                return (true, false);
             }
 
             // Check free space against the configured minimum threshold.
+            bool lowSpace = false;
             try
             {
                 var drive = new DriveInfo(path);
@@ -3074,6 +3055,7 @@ namespace VaultSync.UI
                             $"Free space below threshold ({freePercent:0.#}% available, threshold {MinimumFreeSpacePercent}%).",
                             NotificationSeverity.Warning,
                             "Backup location");
+                        lowSpace = true;
                     }
                     else
                     {
@@ -3085,6 +3067,7 @@ namespace VaultSync.UI
                                 NotificationSeverity.Info,
                                 "Backup location");
                         }
+                        lowSpace = false;
                     }
                 }
             }
@@ -3093,6 +3076,7 @@ namespace VaultSync.UI
                 BackupLocationStatus = "OK";
                 // Ignore disk space failures; path/write checks already passed.
             }
+            return (true, true);
         }
 
         private void ForgetAllProjects()


### PR DESCRIPTION
Hi! I fixed issue #230.

On Linux, updated the background check to try writing a real file. This stops Linux from showing a "Reachable" status when a folder is actually Read-Only.

I also fixed a few other things:

    The "test" button (and simply entering text for non-backup assignment mode) now immediately updates the status on the main screen and in backups.

    The list of drives doesn't flicker or blink anymore when it updates.

    Fixed unnecessary reloads.
    
    Almost completely got rid of string checks for drive statuses in UpdateDestinationStatus and UpdateDestinationProbeSummary
I used your TryWriteProbeFile code to keep it simple

Quick question for you:
I saw that before, the "Test" button didn't update the main dashboard status right away (only after the timer). Was this on purpose for performance?

I added an immediate update because it was a bit confusing for me during tests. But if you want to keep it like before, I can remove that part. What do you think?