### PR TITLE
fix(metadata): compare restore state before backup import

### DIFF
--- a/src/VaultSync.Core/Services/MetadataSyncService.cs
+++ b/src/VaultSync.Core/Services/MetadataSyncService.cs
@@ -410,6 +410,7 @@ public sealed class MetadataSyncService
 
         var backupExternalMap = _repo.GetBackupExternalIdMap();
         var missingBackupExternalIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var localLatestByProjectBeforeBackupImport = _repo.GetLatestBackupUtcByProject();
 
         foreach (var metaBackup in metaBackups)
         {
@@ -530,20 +531,21 @@ public sealed class MetadataSyncService
         };
         if (opts.MarkNeedsRestoreOnImport)
         {
-        var liveBackups = metaBackups
-            .Where(b => !string.IsNullOrWhiteSpace(b.ExternalId) && !tombstonedBackupIds.Contains(b.ExternalId));
-            UpdateNeedsRestoreFlags(projectMap, liveBackups);
+            var liveBackups = metaBackups
+                .Where(b => !string.IsNullOrWhiteSpace(b.ExternalId) && !tombstonedBackupIds.Contains(b.ExternalId));
+            UpdateNeedsRestoreFlags(projectMap, liveBackups, localLatestByProjectBeforeBackupImport);
         }
         Console.WriteLine($"[MetadataSync] Import complete from '{rootPath}': projects={importedProjects}, snapshots={importedSnapshots}, backups={importedBackups}, tombstones={appliedTombstones}.");
         return result;
     }
 
-    private void UpdateNeedsRestoreFlags(IReadOnlyDictionary<string, int> projectMap, IEnumerable<MetaBackup> metaBackups)
+    private void UpdateNeedsRestoreFlags(
+        IReadOnlyDictionary<string, int> projectMap,
+        IEnumerable<MetaBackup> metaBackups,
+        IReadOnlyDictionary<int, DateTime> localLatestByProject)
     {
         if (projectMap.Count == 0)
             return;
-
-        var localLatestByProject = _repo.GetLatestBackupUtcByProject();
 
         var importedLatestByExternalId = metaBackups
             .Where(b => !string.IsNullOrWhiteSpace(b.ProjectExternalId))


### PR DESCRIPTION
This fixes how restore state is calculated during metadata import.

The issue was that we were importing missing backups into the local database first, and only after that asking “what is the latest local backup?”. At that point, the imported backup could already be considered the latest one, so it would end up suppressing its own restore flag. That made NeedsRestore depend on timestamp precision rather than the actual state before the import.

The fix is to snapshot the local backup state before importing anything:

    var localLatestByProjectBeforeBackupImport = _repo.GetLatestBackupUtcByProject();

Then UpdateNeedsRestoreFlags compares metadata against that pre-import baseline instead of the already-mutated database.

So now the logic is:
“Did this import introduce a backup newer than what this machine had before?”
instead of comparing the backup against itself after insertion.

I ran the metadata sync tests and a full build locally and everything passes cleanly.