### PR TITLE
fix(settings): preserve roots during status autosaves

### DIFF
--- a/src/VaultSync.UI/ViewModels/SettingsViewModel.cs
+++ b/src/VaultSync.UI/ViewModels/SettingsViewModel.cs
@@ -893,7 +893,7 @@ namespace VaultSync.UI
             // Reload latest disabled list to avoid clobbering project-level auto-backup toggles.
             _autoBackupDisabledProjects = cfg.Backups.AutoBackupDisabledProjects ?? new List<int>();
 
-            cfg.ProjectsRoot      = ProjectsRootPath;
+            cfg.ProjectsRoot      = ResolveProjectsRootForSave(ProjectsRootPath, cfg.ProjectsRoot);
             cfg.ResumeLastSession = ResumeLastSession;
 
             cfg.Behavior.LaunchOnLogin           = _launchOnLogin;
@@ -911,10 +911,14 @@ namespace VaultSync.UI
             // Sync legacy backup root so older code paths still work.
             // - Simple mode: BackupLocationPath is authoritative.
             // - Advanced mode: use the first active destination as the canonical root.
+            var preserveExistingDestinations =
+                UseAdvancedDestinations &&
+                destinationSnapshot.Count == 0 &&
+                cfg.Backups.Destinations is { Count: > 0 };
             var fallbackRoot = UseAdvancedDestinations
-                ? (Destinations.FirstOrDefault(d => d.Active)?.Path ?? Destinations.FirstOrDefault()?.Path)
+                ? (destinationSnapshot.FirstOrDefault(d => d.Active)?.Path ?? destinationSnapshot.FirstOrDefault()?.Path)
                 : BackupLocationPath;
-            cfg.Backups.BackupRoot = string.IsNullOrWhiteSpace(fallbackRoot) ? null : fallbackRoot;
+            cfg.Backups.BackupRoot = ResolveBackupRootForSave(fallbackRoot, cfg.Backups.BackupRoot ?? cfg.Backups.Location);
             cfg.Backups.Location   = cfg.Backups.BackupRoot;
             cfg.Backups.UseCompression              = UseBackupCompression;
             cfg.Backups.UseRsyncDelta               = UseRsyncDelta;
@@ -940,24 +944,27 @@ namespace VaultSync.UI
             cfg.Backups.Encryption.KeyRef = string.IsNullOrWhiteSpace(_backupEncryptionKeyRef)
                 ? string.Empty
                 : _backupEncryptionKeyRef;
-            cfg.Backups.Destinations                = destinationSnapshot.Select(d => new BackupDestination
+            if (!preserveExistingDestinations)
             {
-                Alias          = d.Alias,
-                Path           = d.Path,
-                CredentialName = d.CredentialName,
-                Active         = d.Active,
-                AutoMount      = d.AutoMount,
-                AutoUnmount    = d.AutoUnmount,
-                PreMounted     = d.PreMounted,
-                EnableMetadataSync = d.EnableMetadataSync,
-                AutoImportMetadata = d.AutoImportMetadata,
-                ForceMetadataBackfill = d.ForceMetadataBackfill,
-                RetryMaxAttempts = ClampInt(d.RetryMaxAttempts, 1, 10, 1),
-                RetryBackoffSeconds = ClampInt(d.RetryBackoffSeconds, 1, 300, 10),
-                EnableCheckpointResume = d.EnableCheckpointResume,
-                SoftQuotaBytes = d.SoftQuotaBytes,
-                QuotaWarningPercent = ClampInt(d.QuotaWarningPercent, 50, 99, 85)
-            }).ToList();
+                cfg.Backups.Destinations                = destinationSnapshot.Select(d => new BackupDestination
+                {
+                    Alias          = d.Alias,
+                    Path           = d.Path,
+                    CredentialName = d.CredentialName,
+                    Active         = d.Active,
+                    AutoMount      = d.AutoMount,
+                    AutoUnmount    = d.AutoUnmount,
+                    PreMounted     = d.PreMounted,
+                    EnableMetadataSync = d.EnableMetadataSync,
+                    AutoImportMetadata = d.AutoImportMetadata,
+                    ForceMetadataBackfill = d.ForceMetadataBackfill,
+                    RetryMaxAttempts = ClampInt(d.RetryMaxAttempts, 1, 10, 1),
+                    RetryBackoffSeconds = ClampInt(d.RetryBackoffSeconds, 1, 300, 10),
+                    EnableCheckpointResume = d.EnableCheckpointResume,
+                    SoftQuotaBytes = d.SoftQuotaBytes,
+                    QuotaWarningPercent = ClampInt(d.QuotaWarningPercent, 50, 99, 85)
+                }).ToList();
+            }
 
             cfg.Storage.PreferExternalDrives = PreferExternalDrives;
             cfg.Storage.ShowDriveWarnings    = ShowDriveHealthWarnings;
@@ -1102,6 +1109,26 @@ namespace VaultSync.UI
             }
 
             return true;
+        }
+
+        internal static string ResolveProjectsRootForSave(string? requestedRoot, string? persistedRoot)
+        {
+            if (!string.IsNullOrWhiteSpace(requestedRoot))
+                return requestedRoot.Trim();
+
+            return string.IsNullOrWhiteSpace(persistedRoot)
+                ? string.Empty
+                : persistedRoot.Trim();
+        }
+
+        internal static string? ResolveBackupRootForSave(string? requestedRoot, string? persistedRoot)
+        {
+            if (!string.IsNullOrWhiteSpace(requestedRoot))
+                return requestedRoot.Trim();
+
+            return string.IsNullOrWhiteSpace(persistedRoot)
+                ? null
+                : persistedRoot.Trim();
         }
 
         private bool ValidateTransferPolicy(bool notifyOnError)
@@ -1273,11 +1300,30 @@ namespace VaultSync.UI
 
         private void OnSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
-            if (_isReloadingFromConfig || e.PropertyName is null)
+            if (_isReloadingFromConfig || e.PropertyName is null || !ShouldAutoSaveProperty(e.PropertyName))
                 return;
 
             TriggerAutoSave();
         }
+
+        internal static bool ShouldAutoSaveProperty(string propertyName)
+            => propertyName switch
+            {
+                nameof(BackupLocationStatus) => false,
+                nameof(RsyncStatusHint) => false,
+                nameof(ShowRsyncStatusHint) => false,
+                nameof(BackupEncryptionSecretStatus) => false,
+                nameof(SaveStatus) => false,
+                nameof(BackupIndexRepairStatus) => false,
+                nameof(ProjectMetadataConflictStatus) => false,
+                nameof(RetentionSimulationStatus) => false,
+                nameof(UpdateCheckStatusText) => false,
+                nameof(UpdateCheckErrorText) => false,
+                nameof(UpdateDiagnosticsText) => false,
+                nameof(StartupDiagnosticsText) => false,
+                nameof(CheckpointResumeDiagnosticsText) => false,
+                _ => true
+            };
 
         private void AddTagColorRule()
         {

--- a/tests/VaultSync.Core.Tests/SettingsPersistencePolicyTests.cs
+++ b/tests/VaultSync.Core.Tests/SettingsPersistencePolicyTests.cs
@@ -1,0 +1,58 @@
+using VaultSync.UI;
+using Xunit;
+
+namespace VaultSync.Core.Tests;
+
+public sealed class SettingsPersistencePolicyTests
+{
+    [Fact]
+    public void ResolveProjectsRootForSave_PreservesPersistedRootWhenRequestedRootIsBlank()
+    {
+        var persisted = @"D:\Projects";
+
+        var resolved = SettingsViewModel.ResolveProjectsRootForSave("   ", persisted);
+
+        Assert.Equal(persisted, resolved);
+    }
+
+    [Fact]
+    public void ResolveProjectsRootForSave_UsesRequestedRootWhenProvided()
+    {
+        var resolved = SettingsViewModel.ResolveProjectsRootForSave(@" E:\Work ", @"D:\Projects");
+
+        Assert.Equal(@"E:\Work", resolved);
+    }
+
+    [Fact]
+    public void ResolveBackupRootForSave_PreservesPersistedRootWhenRequestedRootIsBlank()
+    {
+        var persisted = @"F:\VaultSyncBackups";
+
+        var resolved = SettingsViewModel.ResolveBackupRootForSave(null, persisted);
+
+        Assert.Equal(persisted, resolved);
+    }
+
+    [Fact]
+    public void ResolveBackupRootForSave_AllowsEmptyWhenNoPersistedRootExists()
+    {
+        var resolved = SettingsViewModel.ResolveBackupRootForSave("", "");
+
+        Assert.Null(resolved);
+    }
+
+    [Fact]
+    public void ShouldAutoSaveProperty_IgnoresStatusOnlyProperties()
+    {
+        Assert.False(SettingsViewModel.ShouldAutoSaveProperty(nameof(SettingsViewModel.SaveStatus)));
+        Assert.False(SettingsViewModel.ShouldAutoSaveProperty(nameof(SettingsViewModel.UpdateDiagnosticsText)));
+        Assert.False(SettingsViewModel.ShouldAutoSaveProperty(nameof(SettingsViewModel.BackupLocationStatus)));
+    }
+
+    [Fact]
+    public void ShouldAutoSaveProperty_AllowsEditableRootProperties()
+    {
+        Assert.True(SettingsViewModel.ShouldAutoSaveProperty(nameof(SettingsViewModel.ProjectsRootPath)));
+        Assert.True(SettingsViewModel.ShouldAutoSaveProperty(nameof(SettingsViewModel.BackupLocationPath)));
+    }
+}


### PR DESCRIPTION
﻿## Summary

This fixes a settings persistence path that could write blank root values back to config during background/status updates.

## Root cause

Settings autosave currently reacts to every property change. Several status-only properties can change while the settings view is still settling or while destination data is not populated. If that autosave runs while `ProjectsRootPath`, `BackupLocationPath`, or the advanced destination snapshot is temporarily blank, the save path can overwrite the persisted project root, backup root, or destination list with empty values.

## Change

- Preserve the persisted project root when the requested UI value is blank.
- Preserve the persisted backup root when the requested UI value is blank.
- Preserve existing advanced destinations when advanced mode is enabled but the current destination snapshot is empty.
- Ignore status-only property changes for settings autosave so diagnostics/status refreshes do not persist configuration.
- Add focused tests for root preservation and autosave filtering.

## Validation

- `dotnet test tests\VaultSync.Core.Tests\VaultSync.Core.Tests.csproj --configuration Release -warnaserror -p:UseSharedCompilation=false`
- `dotnet build VaultSync.sln --configuration Release --no-restore -warnaserror -p:UseSharedCompilation=false`
