### PR TITLE
fix(metadata): compare restore state before backup import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [BUG-17104] Settings now refreshes persisted values correctly after config reloads, preventing fields like Projects root from appearing blank even when the saved config is intact.
 - [BUG-17105] Startup now repairs blank project root paths from the configured Projects root when the matching project folder still exists on disk, reducing missing-path issues after relaunch.
 - [BUG-17107] Fixed false "Reachable" status for Read-Only directories on Linux and eliminated UI list flickering (thanks @JustH8Me, refs #230)
+- [BUG-17110] Metadata imports now compare restore-needed state against the pre-import local backup baseline, so newly imported backups no longer suppress their own restore prompt.
 ## [1.7.2] - 09.04.2026
 ### Added
 - [VS-1727] Added an initial Microsoft Store packaging scaffold with the reserved Partner Center identity values, separate from the Direct installer path.

--- a/src/VaultSync.Core/Services/MetadataSyncService.cs
+++ b/src/VaultSync.Core/Services/MetadataSyncService.cs
@@ -410,6 +410,7 @@ public sealed class MetadataSyncService
 
         var backupExternalMap = _repo.GetBackupExternalIdMap();
         var missingBackupExternalIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var localLatestByProjectBeforeBackupImport = _repo.GetLatestBackupUtcByProject();
 
         foreach (var metaBackup in metaBackups)
         {
@@ -530,20 +531,21 @@ public sealed class MetadataSyncService
         };
         if (opts.MarkNeedsRestoreOnImport)
         {
-        var liveBackups = metaBackups
-            .Where(b => !string.IsNullOrWhiteSpace(b.ExternalId) && !tombstonedBackupIds.Contains(b.ExternalId));
-            UpdateNeedsRestoreFlags(projectMap, liveBackups);
+            var liveBackups = metaBackups
+                .Where(b => !string.IsNullOrWhiteSpace(b.ExternalId) && !tombstonedBackupIds.Contains(b.ExternalId));
+            UpdateNeedsRestoreFlags(projectMap, liveBackups, localLatestByProjectBeforeBackupImport);
         }
         Console.WriteLine($"[MetadataSync] Import complete from '{rootPath}': projects={importedProjects}, snapshots={importedSnapshots}, backups={importedBackups}, tombstones={appliedTombstones}.");
         return result;
     }
 
-    private void UpdateNeedsRestoreFlags(IReadOnlyDictionary<string, int> projectMap, IEnumerable<MetaBackup> metaBackups)
+    private void UpdateNeedsRestoreFlags(
+        IReadOnlyDictionary<string, int> projectMap,
+        IEnumerable<MetaBackup> metaBackups,
+        IReadOnlyDictionary<int, DateTime> localLatestByProject)
     {
         if (projectMap.Count == 0)
             return;
-
-        var localLatestByProject = _repo.GetLatestBackupUtcByProject();
 
         var importedLatestByExternalId = metaBackups
             .Where(b => !string.IsNullOrWhiteSpace(b.ProjectExternalId))


### PR DESCRIPTION
This fixes how restore state is calculated during metadata import.

The issue was that we were importing missing backups into the local database first, and only after that checking what the “latest local backup” was. At that point, the imported backup could already be considered the latest one, so it ended up suppressing its own restore flag. That made NeedsRestore depend on timestamp precision rather than the actual state before the import.

The fix is to snapshot the local backup state before importing anything:

    var localLatestByProjectBeforeBackupImport = _repo.GetLatestBackupUtcByProject();

Then UpdateNeedsRestoreFlags compares metadata against that pre-import baseline instead of the already-updated database.

So now the logic is:
“Did this import introduce a backup newer than what this machine had before?”
instead of comparing the backup against itself after insertion.

Ran the metadata tests and a full build locally — everything passes cleanly.