### PR TITLE
fix(settings): preserve roots during status autosaves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - [BUG-17107] Fixed false "Reachable" status for Read-Only directories on Linux and eliminated UI list flickering (thanks @JustH8Me, refs #230)
 - [BUG-17109] Backup All and auto-backup no-change runs now create real first backup artifacts instead of empty destination folders.
 - [BUG-17110] Metadata imports now compare restore-needed state against the pre-import local backup baseline, so newly imported backups no longer suppress their own restore prompt.
+- [BUG-17111] Settings/background saves now preserve existing project roots, backup roots, and destinations when transient UI state is blank.
+- [BUG-17112] Command state refreshes now marshal back to Avalonia's UI thread, preventing background startup checks from crashing button command validation.
 - [BUG-17113] Individual project backup buttons now resolve destinations from the latest saved config and refresh destination choices after backup destination settings change.
 ## [1.7.2] - 09.04.2026
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - [BUG-17107] Fixed false "Reachable" status for Read-Only directories on Linux and eliminated UI list flickering (thanks @JustH8Me, refs #230)
 - [BUG-17109] Backup All and auto-backup no-change runs now create real first backup artifacts instead of empty destination folders.
 - [BUG-17110] Metadata imports now compare restore-needed state against the pre-import local backup baseline, so newly imported backups no longer suppress their own restore prompt.
-- [BUG-17111] Settings/background saves now preserve existing project roots, backup roots, and destinations when transient UI state is blank.
+- [BUG-17111] Background settings saves now preserve existing project roots, backup roots, and advanced destinations when transient UI snapshots are blank.
 - [BUG-17112] Command state refreshes now marshal back to Avalonia's UI thread, preventing background startup checks from crashing button command validation.
 - [BUG-17113] Individual project backup buttons now resolve destinations from the latest saved config and refresh destination choices after backup destination settings change.
 ## [1.7.2] - 09.04.2026

--- a/src/VaultSync.Core/Config/AppConfigStore.cs
+++ b/src/VaultSync.Core/Config/AppConfigStore.cs
@@ -103,6 +103,7 @@ namespace VaultSync.Core.Config
         public static void Save(AppConfig config)
         {
             Directory.CreateDirectory(ConfigDir);
+            PreserveDurableConfigValues(config);
             var json = JsonSerializer.Serialize(config, JsonOptions);
             WriteConfigWithRetry(json);
             RememberLastKnownGood(config);
@@ -112,6 +113,7 @@ namespace VaultSync.Core.Config
         public static async Task SaveAsync(AppConfig config, CancellationToken ct = default)
         {
             Directory.CreateDirectory(ConfigDir);
+            PreserveDurableConfigValues(config);
             var json = JsonSerializer.Serialize(config, JsonOptions);
             await WriteConfigWithRetryAsync(json, ct).ConfigureAwait(false);
             RememberLastKnownGood(config);
@@ -340,6 +342,37 @@ namespace VaultSync.Core.Config
                     return fallback;
 
                 throw;
+            }
+        }
+
+        private static void PreserveDurableConfigValues(AppConfig config)
+        {
+            if (!string.IsNullOrWhiteSpace(config.ProjectsRoot))
+                return;
+
+            var persisted = TryLoadPersistedConfigForPreservation(ConfigFilePath)
+                            ?? TryLoadPersistedConfigForPreservation(ConfigBackupFilePath)
+                            ?? GetLastKnownGoodClone();
+            if (string.IsNullOrWhiteSpace(persisted?.ProjectsRoot))
+                return;
+
+            config.ProjectsRoot = persisted.ProjectsRoot.Trim();
+            RuntimeLog.WriteVerbose("[Config] Save preserved existing ProjectsRoot because the pending save had an empty value.");
+        }
+
+        private static AppConfig? TryLoadPersistedConfigForPreservation(string path)
+        {
+            if (!File.Exists(path))
+                return null;
+
+            try
+            {
+                var json = ReadConfigWithRetry(path);
+                return JsonSerializer.Deserialize<AppConfig>(json, JsonOptions);
+            }
+            catch
+            {
+                return null;
             }
         }
 

--- a/src/VaultSync.UI/Infrastructure/RelayCommand.cs
+++ b/src/VaultSync.UI/Infrastructure/RelayCommand.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Windows.Input;
+using Avalonia.Threading;
 
 namespace VaultSync.UI.Infrastructure
 {
@@ -23,6 +24,15 @@ namespace VaultSync.UI.Infrastructure
 
         public void Execute(object? parameter) => _execute(parameter);
 
-        public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+        public void RaiseCanExecuteChanged()
+        {
+            if (Dispatcher.UIThread.CheckAccess())
+            {
+                CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+                return;
+            }
+
+            Dispatcher.UIThread.Post(() => CanExecuteChanged?.Invoke(this, EventArgs.Empty));
+        }
     }
 }

--- a/src/VaultSync.UI/ViewModels/BackupsViewModel.cs
+++ b/src/VaultSync.UI/ViewModels/BackupsViewModel.cs
@@ -5075,7 +5075,15 @@ namespace VaultSync.UI.ViewModels
         public void Execute(object? parameter)    => _execute(parameter);
 
         public event EventHandler? CanExecuteChanged;
-        public void RaiseCanExecuteChanged() =>
-            CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+        public void RaiseCanExecuteChanged()
+        {
+            if (Dispatcher.UIThread.CheckAccess())
+            {
+                CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+                return;
+            }
+
+            Dispatcher.UIThread.Post(() => CanExecuteChanged?.Invoke(this, EventArgs.Empty));
+        }
     }
 }

--- a/src/VaultSync.UI/ViewModels/SettingsViewModel.cs
+++ b/src/VaultSync.UI/ViewModels/SettingsViewModel.cs
@@ -895,7 +895,7 @@ namespace VaultSync.UI
             // Reload latest disabled list to avoid clobbering project-level auto-backup toggles.
             _autoBackupDisabledProjects = cfg.Backups.AutoBackupDisabledProjects ?? new List<int>();
 
-            cfg.ProjectsRoot      = ProjectsRootPath;
+            cfg.ProjectsRoot      = ResolveProjectsRootForSave(ProjectsRootPath, cfg.ProjectsRoot);
             cfg.ResumeLastSession = ResumeLastSession;
 
             cfg.Behavior.LaunchOnLogin           = _launchOnLogin;
@@ -909,11 +909,17 @@ namespace VaultSync.UI
             cfg.Backups.IntervalMinutes             = ClampInt(AutoBackupIntervalMinutes, 1, 10080, 30);
             cfg.Backups.MaxSnapshotsPerProject      = ClampInt(MaxSnapshotsPerProject, 1, 10000, 20);
             cfg.Backups.AutoBackupDisabledProjects  = _autoBackupDisabledProjects;
+            var preserveExistingDestinations =
+                UseAdvancedDestinations &&
+                destinationSnapshot.Count == 0 &&
+                cfg.Backups.Destinations is { Count: > 0 };
             var fallbackRoot = UseAdvancedDestinations
-                ? (Destinations.FirstOrDefault(d => d.Active)?.Path ?? Destinations.FirstOrDefault()?.Path)
+                ? (destinationSnapshot.FirstOrDefault(d => d.Active)?.Path ?? destinationSnapshot.FirstOrDefault()?.Path)
                 : BackupLocationPath;
-            var nextBackupRoot = string.IsNullOrWhiteSpace(fallbackRoot) ? null : fallbackRoot;
-            var nextDestinations = destinationSnapshot.Select(d => new BackupDestination
+            var nextBackupRoot = ResolveBackupRootForSave(fallbackRoot, cfg.Backups.BackupRoot ?? cfg.Backups.Location);
+            var nextDestinations = preserveExistingDestinations
+                ? cfg.Backups.Destinations.ToList()
+                : destinationSnapshot.Select(d => new BackupDestination
             {
                 Alias          = d.Alias,
                 Path           = d.Path,
@@ -1147,6 +1153,26 @@ namespace VaultSync.UI
             return true;
         }
 
+        internal static string ResolveProjectsRootForSave(string? requestedRoot, string? persistedRoot)
+        {
+            if (!string.IsNullOrWhiteSpace(requestedRoot))
+                return requestedRoot.Trim();
+
+            return string.IsNullOrWhiteSpace(persistedRoot)
+                ? string.Empty
+                : persistedRoot.Trim();
+        }
+
+        internal static string? ResolveBackupRootForSave(string? requestedRoot, string? persistedRoot)
+        {
+            if (!string.IsNullOrWhiteSpace(requestedRoot))
+                return requestedRoot.Trim();
+
+            return string.IsNullOrWhiteSpace(persistedRoot)
+                ? null
+                : persistedRoot.Trim();
+        }
+
         private bool ValidateTransferPolicy(bool notifyOnError)
         {
             if (EnableBandwidthLimit && (MaxBandwidthMbps < 1 || MaxBandwidthMbps > 5000))
@@ -1316,11 +1342,30 @@ namespace VaultSync.UI
 
         private void OnSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
-            if (_isReloadingFromConfig || e.PropertyName is null)
+            if (_isReloadingFromConfig || e.PropertyName is null || !ShouldAutoSaveProperty(e.PropertyName))
                 return;
 
             TriggerAutoSave();
         }
+
+        internal static bool ShouldAutoSaveProperty(string propertyName)
+            => propertyName switch
+            {
+                nameof(BackupLocationStatus) => false,
+                nameof(RsyncStatusHint) => false,
+                nameof(ShowRsyncStatusHint) => false,
+                nameof(BackupEncryptionSecretStatus) => false,
+                nameof(SaveStatus) => false,
+                nameof(BackupIndexRepairStatus) => false,
+                nameof(ProjectMetadataConflictStatus) => false,
+                nameof(RetentionSimulationStatus) => false,
+                nameof(UpdateCheckStatusText) => false,
+                nameof(UpdateCheckErrorText) => false,
+                nameof(UpdateDiagnosticsText) => false,
+                nameof(StartupDiagnosticsText) => false,
+                nameof(CheckpointResumeDiagnosticsText) => false,
+                _ => true
+            };
 
         private void AddTagColorRule()
         {

--- a/tests/VaultSync.Core.Tests/SettingsPersistencePolicyTests.cs
+++ b/tests/VaultSync.Core.Tests/SettingsPersistencePolicyTests.cs
@@ -1,0 +1,58 @@
+using VaultSync.UI;
+using Xunit;
+
+namespace VaultSync.Core.Tests;
+
+public sealed class SettingsPersistencePolicyTests
+{
+    [Fact]
+    public void ResolveProjectsRootForSave_PreservesPersistedRootWhenRequestedRootIsBlank()
+    {
+        var persisted = @"D:\Projects";
+
+        var resolved = SettingsViewModel.ResolveProjectsRootForSave("   ", persisted);
+
+        Assert.Equal(persisted, resolved);
+    }
+
+    [Fact]
+    public void ResolveProjectsRootForSave_UsesRequestedRootWhenProvided()
+    {
+        var resolved = SettingsViewModel.ResolveProjectsRootForSave(@" E:\Work ", @"D:\Projects");
+
+        Assert.Equal(@"E:\Work", resolved);
+    }
+
+    [Fact]
+    public void ResolveBackupRootForSave_PreservesPersistedRootWhenRequestedRootIsBlank()
+    {
+        var persisted = @"F:\VaultSyncBackups";
+
+        var resolved = SettingsViewModel.ResolveBackupRootForSave(null, persisted);
+
+        Assert.Equal(persisted, resolved);
+    }
+
+    [Fact]
+    public void ResolveBackupRootForSave_AllowsEmptyWhenNoPersistedRootExists()
+    {
+        var resolved = SettingsViewModel.ResolveBackupRootForSave("", "");
+
+        Assert.Null(resolved);
+    }
+
+    [Fact]
+    public void ShouldAutoSaveProperty_IgnoresStatusOnlyProperties()
+    {
+        Assert.False(SettingsViewModel.ShouldAutoSaveProperty(nameof(SettingsViewModel.SaveStatus)));
+        Assert.False(SettingsViewModel.ShouldAutoSaveProperty(nameof(SettingsViewModel.UpdateDiagnosticsText)));
+        Assert.False(SettingsViewModel.ShouldAutoSaveProperty(nameof(SettingsViewModel.BackupLocationStatus)));
+    }
+
+    [Fact]
+    public void ShouldAutoSaveProperty_AllowsEditableRootProperties()
+    {
+        Assert.True(SettingsViewModel.ShouldAutoSaveProperty(nameof(SettingsViewModel.ProjectsRootPath)));
+        Assert.True(SettingsViewModel.ShouldAutoSaveProperty(nameof(SettingsViewModel.BackupLocationPath)));
+    }
+}


### PR DESCRIPTION
This fixes a settings persistence issue where blank values could get written back to the config during background/status updates.

The root of the problem is that autosave reacts to every property change. Some status-only properties can update while the settings view is still initializing or while destination data has not been populated yet. If autosave runs at that moment, it can end up saving empty values for things like `ProjectsRootPath`, `BackupLocationPath`, or destinations, overwriting valid config.

The fix is to be more defensive during saves:
- Do not overwrite the project root if the incoming value is blank
- Do not overwrite the backup root if the incoming value is blank
- In advanced mode, do not clear destinations if the current snapshot is temporarily empty
- Ignore status-only property changes so UI/diagnostic updates do not trigger config writes
- Guard `AppConfigStore` against pending saves that would blank an existing project root

This also fixes a startup crash where background command-state refreshes could raise `CanExecuteChanged` off the Avalonia UI thread.

Also added focused tests around root preservation and autosave filtering to make sure this does not regress.

## Tracking
Fixes #245
Fixes #246

## Validation
- `dotnet test tests/VaultSync.Core.Tests/VaultSync.Core.Tests.csproj --filter SettingsPersistencePolicyTests`
- `dotnet build VaultSync.sln`
- `dotnet build src/VaultSync.UI/VaultSync.UI.csproj`