### PR TITLE
fix(backups): repair Backup All and auto no-change skips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - [BUG-17107] Fixed false "Reachable" status for Read-Only directories on Linux and eliminated UI list flickering (thanks @JustH8Me, refs #230)
 - [BUG-17109] Backup All and auto-backup no-change runs now create real first backup artifacts instead of empty destination folders.
 - [BUG-17110] Metadata imports now compare restore-needed state against the pre-import local backup baseline, so newly imported backups no longer suppress their own restore prompt.
-- [BUG-17111] Individual project backup buttons now resolve destinations from the latest saved config and refresh destination choices after backup destination settings change.
+- [BUG-17113] Individual project backup buttons now resolve destinations from the latest saved config and refresh destination choices after backup destination settings change.
 ## [1.7.2] - 09.04.2026
 ### Added
 - [VS-1727] Added an initial Microsoft Store packaging scaffold with the reserved Partner Center identity values, separate from the Direct installer path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [BUG-17104] Settings now refreshes persisted values correctly after config reloads, preventing fields like Projects root from appearing blank even when the saved config is intact.
 - [BUG-17105] Startup now repairs blank project root paths from the configured Projects root when the matching project folder still exists on disk, reducing missing-path issues after relaunch.
 - [BUG-17107] Fixed false "Reachable" status for Read-Only directories on Linux and eliminated UI list flickering (thanks @JustH8Me, refs #230)
+- [BUG-17109] Backup All and auto-backup no-change runs now create real first backup artifacts instead of empty destination folders.
 - [BUG-17110] Metadata imports now compare restore-needed state against the pre-import local backup baseline, so newly imported backups no longer suppress their own restore prompt.
 ## [1.7.2] - 09.04.2026
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [BUG-17107] Fixed false "Reachable" status for Read-Only directories on Linux and eliminated UI list flickering (thanks @JustH8Me, refs #230)
 - [BUG-17109] Backup All and auto-backup no-change runs now create real first backup artifacts instead of empty destination folders.
 - [BUG-17110] Metadata imports now compare restore-needed state against the pre-import local backup baseline, so newly imported backups no longer suppress their own restore prompt.
+- [BUG-17111] Individual project backup buttons now resolve destinations from the latest saved config and refresh destination choices after backup destination settings change.
 ## [1.7.2] - 09.04.2026
 ### Added
 - [VS-1727] Added an initial Microsoft Store packaging scaffold with the reserved Partner Center identity values, separate from the Direct installer path.

--- a/src/VaultSync.Core/Services/BackupService.cs
+++ b/src/VaultSync.Core/Services/BackupService.cs
@@ -842,7 +842,7 @@ public sealed class BackupService
         // Timestamped folder name: 2025-11-16_15-47-30
         var timestamp = DateTime.UtcNow;
         var folderName = timestamp.ToString("yyyy-MM-dd_HH-mm-ss");
-        var backupFolder = Path.Combine(projectBackupRoot, folderName);
+        var backupFolder = GetAvailableBackupFolder(projectBackupRoot, folderName);
         Directory.CreateDirectory(backupFolder);
         WriteMarkerFile(backupFolder, InProgressMarkerFileName, $"started:{DateTime.UtcNow:O}");
         var backupRootUsed = backupRoot;
@@ -876,10 +876,11 @@ public sealed class BackupService
                 useScanCache,
                 aggressiveScanCache);
 
-            var outcome = SnapshotService.LastOutcome;
+            var outcome = snapshotService.LastCreatedOutcome;
             if (skipIfNoChanges &&
                 !reuseSnapshotId.HasValue &&
-                outcome is { Added: 0, Modified: 0, Deleted: 0 })
+                outcome is { Added: 0, Modified: 0, Deleted: 0 } &&
+                HasUsableBackupForDestination(project.Id, backupRoot))
             {
                 // No file changes: remove the empty backup folder and snapshot, then skip.
                 DeletePartialBackup(backupFolderUsed);
@@ -2768,6 +2769,91 @@ public sealed class BackupService
     }
 
     public static string GetProjectBackupFolderName(string name) => Slugify(name);
+
+    private static string GetAvailableBackupFolder(string projectBackupRoot, string folderName)
+    {
+        var candidate = Path.Combine(projectBackupRoot, folderName);
+        if (!Directory.Exists(candidate))
+            return candidate;
+
+        for (var i = 2; i < 1000; i++)
+        {
+            candidate = Path.Combine(projectBackupRoot, $"{folderName}-{i}");
+            if (!Directory.Exists(candidate))
+                return candidate;
+        }
+
+        return Path.Combine(projectBackupRoot, $"{folderName}-{Guid.NewGuid():N}");
+    }
+
+    private bool HasUsableBackupForDestination(int projectId, string backupRoot)
+    {
+        List<Backup> backups;
+        try
+        {
+            backups = _repo.GetBackupsForProject(projectId).ToList();
+        }
+        catch (Exception ex)
+        {
+            RuntimeLog.WriteVerbose($"[BackupService] Cannot verify existing backups for projectId={projectId}: {ex.Message}");
+            return false;
+        }
+
+        foreach (var backup in backups)
+        {
+            var root = string.IsNullOrWhiteSpace(backup.DestinationPath)
+                ? backupRoot
+                : backup.DestinationPath;
+            if (!PathsEqual(root, backupRoot))
+                continue;
+
+            var backupPath = Path.IsPathRooted(backup.Path)
+                ? backup.Path
+                : Path.Combine(root, backup.Path);
+            if (DirectoryHasBackupContent(backupPath))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool DirectoryHasBackupContent(string path)
+    {
+        try
+        {
+            return Directory.Exists(path) && Directory.EnumerateFileSystemEntries(path).Any();
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool PathsEqual(string? left, string? right)
+    {
+        if (string.IsNullOrWhiteSpace(left) || string.IsNullOrWhiteSpace(right))
+            return false;
+
+        try
+        {
+            left = Path.GetFullPath(left);
+            right = Path.GetFullPath(right);
+        }
+        catch
+        {
+            left = left.Trim();
+            right = right.Trim();
+        }
+
+        var comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        return string.Equals(
+            left.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+            right.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+            comparison);
+    }
+
     private void ApplyBackupRetention(int projectId, string backupRoot, int? maxSnapshotsToKeep)
     {
         if (!maxSnapshotsToKeep.HasValue || maxSnapshotsToKeep.Value <= 0)

--- a/src/VaultSync.Core/Services/SnapshotService.cs
+++ b/src/VaultSync.Core/Services/SnapshotService.cs
@@ -9,6 +9,7 @@ public class SnapshotService
 {
     private readonly SqliteRepository _repo;
     private readonly HashService _hash;
+    public SnapshotOutcome? LastCreatedOutcome { get; private set; }
 
     public SnapshotService(SqliteRepository repo, HashService hash)
     {
@@ -183,7 +184,7 @@ public class SnapshotService
                     }
                 }
 
-                LastOutcome = new SnapshotOutcome
+                LastCreatedOutcome = new SnapshotOutcome
                 (
                     Added:      added.Count,
                     Modified:   modified.Count,
@@ -192,6 +193,7 @@ public class SnapshotService
                     TotalFiles: snapshotEntries.Count,
                     TotalBytes: snapshotTotalBytes
                 );
+                LastOutcome = LastCreatedOutcome;
 
                 Console.WriteLine($"[SnapshotService] Finished snapshot for '{project.Name}': " +
                                   $"added={added.Count}, modified={modified.Count}, deleted={deleted.Count}, unchanged={unchanged.Count}, totalFiles={snapshotEntries.Count}, totalBytes={snapshotTotalBytes}");
@@ -344,7 +346,7 @@ public class SnapshotService
             }
 
             // Attach summary for CLI
-            LastOutcome = new SnapshotOutcome
+            LastCreatedOutcome = new SnapshotOutcome
             (
                 Added:      added.Count,
                 Modified:   modified.Count,
@@ -353,6 +355,7 @@ public class SnapshotService
                 TotalFiles: entries.Count,
                 TotalBytes: totalBytes
             );
+            LastOutcome = LastCreatedOutcome;
 
             Console.WriteLine($"[SnapshotService] Finished snapshot for '{project.Name}': " +
                               $"added={added.Count}, modified={modified.Count}, deleted={deleted.Count}, unchanged={unchanged.Count}, totalFiles={entries.Count}, totalBytes={totalBytes}");

--- a/src/VaultSync.UI/ViewModels/AppViewModel.ConfigurationOps.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.ConfigurationOps.cs
@@ -340,7 +340,7 @@ namespace VaultSync.UI.ViewModels
 
         private BackupProjectPreparation CreateManualBackupPreparation(int projectId)
         {
-            var cfg = _config;
+            var cfg = AppConfigStore.GetSnapshot();
             var project = _repo.GetProjectById(projectId);
             var selection = project is null
                 ? new ProjectDestinationSelection(GetActiveDestinations(cfg), null, null)
@@ -1356,11 +1356,21 @@ namespace VaultSync.UI.ViewModels
 
                 if (propertyName is nameof(SettingsViewModel.UseAdvancedDestinations))
                 {
-                    RefreshDestinationOptionSources();
+                    RefreshDestinationOptionSources(cfg);
                 }
 
                 RefreshDestinationStatusOverview();
             }, "settings-change");
+        }
+
+        private void OnDestinationSettingsSaved()
+        {
+            QueueConfigReload(cfg =>
+            {
+                _config = cfg;
+                RefreshDestinationOptionSources(cfg);
+                RefreshDestinationStatusOverview();
+            }, "settings-saved");
         }
 
         private void OnDestinationsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
@@ -1421,9 +1431,15 @@ namespace VaultSync.UI.ViewModels
         {
             QueueConfigReload(config =>
             {
-                _projectsViewModel.RefreshDestinationOptions(config);
-                BackupsViewModel.RefreshDestinationOptions(config);
+                _config = config;
+                RefreshDestinationOptionSources(config);
             }, "destinations-options");
+        }
+
+        private void RefreshDestinationOptionSources(AppConfig config)
+        {
+            _projectsViewModel.RefreshDestinationOptions(config);
+            BackupsViewModel.RefreshDestinationOptions(config);
         }
 
         private void UpdateLogConsoleSettings()

--- a/src/VaultSync.UI/ViewModels/AppViewModel.StartupOps.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.StartupOps.cs
@@ -63,6 +63,7 @@ namespace VaultSync.UI.ViewModels
             _backupsViewModel = null;
             _settingsViewModel = new SettingsViewModel(_localizationService);
             _settingsViewModel.PropertyChanged += OnSettingsChanged;
+            _settingsViewModel.DestinationSettingsSaved += OnDestinationSettingsSaved;
             _settingsViewModel.OpenLogConsoleRequested += OnOpenLogConsoleRequested;
             _settingsViewModel.UpdateCheckRequested += OnUpdateCheckRequested;
             _settingsViewModel.RefreshHistoryRequested += OnRefreshHistoryRequested;

--- a/src/VaultSync.UI/ViewModels/SettingsViewModel.cs
+++ b/src/VaultSync.UI/ViewModels/SettingsViewModel.cs
@@ -164,6 +164,7 @@ namespace VaultSync.UI
         public event Action? RotateEncryptedBackupsRequested;
         public event Action? EnrollProjectEncryptionRequested;
         public event Action? LockEncryptedOpenWorkspacesRequested;
+        public event Action? DestinationSettingsSaved;
         public event Action<BackupDestination, bool, bool, string>? DestinationTested;
 
         private sealed record DestinationSnapshot(
@@ -908,14 +909,35 @@ namespace VaultSync.UI
             cfg.Backups.IntervalMinutes             = ClampInt(AutoBackupIntervalMinutes, 1, 10080, 30);
             cfg.Backups.MaxSnapshotsPerProject      = ClampInt(MaxSnapshotsPerProject, 1, 10000, 20);
             cfg.Backups.AutoBackupDisabledProjects  = _autoBackupDisabledProjects;
-            cfg.Backups.UseAdvancedDestinations     = UseAdvancedDestinations;
-            // Sync legacy backup root so older code paths still work.
-            // - Simple mode: BackupLocationPath is authoritative.
-            // - Advanced mode: use the first active destination as the canonical root.
             var fallbackRoot = UseAdvancedDestinations
                 ? (Destinations.FirstOrDefault(d => d.Active)?.Path ?? Destinations.FirstOrDefault()?.Path)
                 : BackupLocationPath;
-            cfg.Backups.BackupRoot = string.IsNullOrWhiteSpace(fallbackRoot) ? null : fallbackRoot;
+            var nextBackupRoot = string.IsNullOrWhiteSpace(fallbackRoot) ? null : fallbackRoot;
+            var nextDestinations = destinationSnapshot.Select(d => new BackupDestination
+            {
+                Alias          = d.Alias,
+                Path           = d.Path,
+                CredentialName = d.CredentialName,
+                Active         = d.Active,
+                AutoMount      = d.AutoMount,
+                AutoUnmount    = d.AutoUnmount,
+                PreMounted     = d.PreMounted,
+                EnableMetadataSync = d.EnableMetadataSync,
+                AutoImportMetadata = d.AutoImportMetadata,
+                ForceMetadataBackfill = d.ForceMetadataBackfill,
+                RetryMaxAttempts = ClampInt(d.RetryMaxAttempts, 1, 10, 1),
+                RetryBackoffSeconds = ClampInt(d.RetryBackoffSeconds, 1, 300, 10),
+                EnableCheckpointResume = d.EnableCheckpointResume,
+                SoftQuotaBytes = d.SoftQuotaBytes,
+                QuotaWarningPercent = ClampInt(d.QuotaWarningPercent, 50, 99, 85)
+            }).ToList();
+            var destinationSettingsChanged =
+                cfg.Backups.UseAdvancedDestinations != UseAdvancedDestinations ||
+                !string.Equals(cfg.Backups.BackupRoot ?? string.Empty, nextBackupRoot ?? string.Empty, StringComparison.Ordinal) ||
+                !BackupDestinationsEqual(cfg.Backups.Destinations, nextDestinations);
+
+            cfg.Backups.UseAdvancedDestinations = UseAdvancedDestinations;
+            cfg.Backups.BackupRoot = nextBackupRoot;
             cfg.Backups.Location   = cfg.Backups.BackupRoot;
             cfg.Backups.UseCompression              = UseBackupCompression;
             cfg.Backups.UseRsyncDelta               = UseRsyncDelta;
@@ -941,24 +963,7 @@ namespace VaultSync.UI
             cfg.Backups.Encryption.KeyRef = string.IsNullOrWhiteSpace(_backupEncryptionKeyRef)
                 ? string.Empty
                 : _backupEncryptionKeyRef;
-            cfg.Backups.Destinations                = destinationSnapshot.Select(d => new BackupDestination
-            {
-                Alias          = d.Alias,
-                Path           = d.Path,
-                CredentialName = d.CredentialName,
-                Active         = d.Active,
-                AutoMount      = d.AutoMount,
-                AutoUnmount    = d.AutoUnmount,
-                PreMounted     = d.PreMounted,
-                EnableMetadataSync = d.EnableMetadataSync,
-                AutoImportMetadata = d.AutoImportMetadata,
-                ForceMetadataBackfill = d.ForceMetadataBackfill,
-                RetryMaxAttempts = ClampInt(d.RetryMaxAttempts, 1, 10, 1),
-                RetryBackoffSeconds = ClampInt(d.RetryBackoffSeconds, 1, 300, 10),
-                EnableCheckpointResume = d.EnableCheckpointResume,
-                SoftQuotaBytes = d.SoftQuotaBytes,
-                QuotaWarningPercent = ClampInt(d.QuotaWarningPercent, 50, 99, 85)
-            }).ToList();
+            cfg.Backups.Destinations                = nextDestinations;
 
             cfg.Storage.PreferExternalDrives = PreferExternalDrives;
             cfg.Storage.ShowDriveWarnings    = ShowDriveHealthWarnings;
@@ -1043,6 +1048,10 @@ namespace VaultSync.UI
             }
 
             await AppConfigStore.SaveAsync(cfg);
+            if (destinationSettingsChanged)
+            {
+                DestinationSettingsSaved?.Invoke();
+            }
 
             SaveStatus = string.Format(
                 CultureInfo.CurrentCulture,
@@ -1100,6 +1109,39 @@ namespace VaultSync.UI
                     return false;
                 }
 
+            }
+
+            return true;
+        }
+
+        private static bool BackupDestinationsEqual(IReadOnlyList<BackupDestination>? current, IReadOnlyList<BackupDestination> next)
+        {
+            current ??= Array.Empty<BackupDestination>();
+            if (current.Count != next.Count)
+                return false;
+
+            for (var i = 0; i < current.Count; i++)
+            {
+                var left = current[i];
+                var right = next[i];
+                if (!string.Equals(left.Alias ?? string.Empty, right.Alias ?? string.Empty, StringComparison.Ordinal) ||
+                    !string.Equals(left.Path ?? string.Empty, right.Path ?? string.Empty, StringComparison.Ordinal) ||
+                    !string.Equals(left.CredentialName ?? string.Empty, right.CredentialName ?? string.Empty, StringComparison.Ordinal) ||
+                    left.Active != right.Active ||
+                    left.AutoMount != right.AutoMount ||
+                    left.AutoUnmount != right.AutoUnmount ||
+                    left.PreMounted != right.PreMounted ||
+                    left.EnableMetadataSync != right.EnableMetadataSync ||
+                    left.AutoImportMetadata != right.AutoImportMetadata ||
+                    left.ForceMetadataBackfill != right.ForceMetadataBackfill ||
+                    left.RetryMaxAttempts != right.RetryMaxAttempts ||
+                    left.RetryBackoffSeconds != right.RetryBackoffSeconds ||
+                    left.EnableCheckpointResume != right.EnableCheckpointResume ||
+                    left.SoftQuotaBytes != right.SoftQuotaBytes ||
+                    left.QuotaWarningPercent != right.QuotaWarningPercent)
+                {
+                    return false;
+                }
             }
 
             return true;

--- a/tests/VaultSync.Core.Tests/BackupSkipNoChangesTests.cs
+++ b/tests/VaultSync.Core.Tests/BackupSkipNoChangesTests.cs
@@ -1,0 +1,174 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using VaultSync.Core.Models;
+using VaultSync.Core.Repositories;
+using VaultSync.Core.Services;
+using Xunit;
+
+namespace VaultSync.Core.Tests;
+
+public sealed class BackupSkipNoChangesTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _dbPath;
+
+    public BackupSkipNoChangesTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"vaultsync-skip-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _dbPath = Path.Combine(_tempDir, "vaultsync.db");
+    }
+
+    [Fact]
+    public async Task RunBackupAsync_DoesNotSkipNoChanges_WhenNoUsableBackupExists()
+    {
+        var repo = new SqliteRepository(_dbPath);
+        repo.EnsureSchema();
+        var project = CreateProject(repo);
+        await CreateBaselineSnapshotAsync(repo, project);
+
+        var backupRoot = Path.Combine(_tempDir, "backups");
+        Directory.CreateDirectory(backupRoot);
+        var service = new BackupService(repo);
+
+        var result = await service.RunBackupAsync(
+            project,
+            backupRoot,
+            isAuto: true,
+            useArchiveMode: true,
+            skipIfNoChanges: true);
+
+        Assert.False(result.SkippedForNoChanges);
+        Assert.True(result.BackupId > 0);
+        var backup = repo.GetBackupById(result.BackupId);
+        Assert.NotNull(backup);
+        Assert.True(Directory.Exists(Path.Combine(backupRoot, backup!.Path)));
+        Assert.NotEmpty(Directory.EnumerateFileSystemEntries(Path.Combine(backupRoot, backup.Path)));
+    }
+
+    [Fact]
+    public async Task RunBackupAsync_SkipsNoChanges_WhenUsableBackupAlreadyExists()
+    {
+        var repo = new SqliteRepository(_dbPath);
+        repo.EnsureSchema();
+        var project = CreateProject(repo);
+        var backupRoot = Path.Combine(_tempDir, "backups");
+        Directory.CreateDirectory(backupRoot);
+        var service = new BackupService(repo);
+
+        var first = await service.RunBackupAsync(
+            project,
+            backupRoot,
+            isAuto: true,
+            useArchiveMode: true,
+            skipIfNoChanges: true);
+
+        Assert.False(first.SkippedForNoChanges);
+        Assert.True(first.BackupId > 0);
+
+        var second = await service.RunBackupAsync(
+            project,
+            backupRoot,
+            isAuto: true,
+            useArchiveMode: true,
+            skipIfNoChanges: true);
+
+        Assert.True(second.SkippedForNoChanges);
+        Assert.Equal(0, second.BackupId);
+        Assert.Single(repo.GetBackupsForProject(project.Id));
+        var firstBackup = repo.GetBackupById(first.BackupId);
+        Assert.NotNull(firstBackup);
+        Assert.True(Directory.Exists(Path.Combine(backupRoot, firstBackup!.Path)));
+    }
+
+    [Fact]
+    public async Task RunBackupAsync_BackupAllStyleParallelRun_CreatesUsableBackupsForAllProjects()
+    {
+        var repo = new SqliteRepository(_dbPath);
+        repo.EnsureSchema();
+        var projects = new[]
+        {
+            CreateProject(repo, "Project One", "one.txt", "one"),
+            CreateProject(repo, "Project Two", "two.txt", "two"),
+            CreateProject(repo, "Project Three", "three.txt", "three")
+        };
+
+        foreach (var project in projects)
+        {
+            await CreateBaselineSnapshotAsync(repo, project);
+        }
+
+        var backupRoot = Path.Combine(_tempDir, "backups");
+        Directory.CreateDirectory(backupRoot);
+        var service = new BackupService(repo);
+
+        var results = await Task.WhenAll(projects.Select(project =>
+            service.RunBackupAsync(
+                project,
+                backupRoot,
+                isAuto: false,
+                useArchiveMode: true,
+                skipIfNoChanges: true)));
+
+        Assert.All(results, result =>
+        {
+            Assert.False(result.SkippedForNoChanges);
+            Assert.True(result.BackupId > 0);
+        });
+
+        foreach (var result in results)
+        {
+            var backup = repo.GetBackupById(result.BackupId);
+            Assert.NotNull(backup);
+            var backupPath = Path.Combine(backupRoot, backup!.Path);
+            Assert.True(Directory.Exists(backupPath));
+            Assert.NotEmpty(Directory.EnumerateFileSystemEntries(backupPath));
+        }
+    }
+
+    private Project CreateProject(SqliteRepository repo)
+        => CreateProject(repo, "Project One", "data.txt", "backup me");
+
+    private Project CreateProject(SqliteRepository repo, string name, string fileName, string contents)
+    {
+        var sourceRoot = Path.Combine(_tempDir, name.Replace(' ', '-'));
+        Directory.CreateDirectory(sourceRoot);
+        File.WriteAllText(Path.Combine(sourceRoot, fileName), contents, Encoding.UTF8);
+
+        var projectId = repo.AddProject(new Project
+        {
+            Name = name,
+            RootPath = sourceRoot,
+            Preset = string.Empty
+        });
+
+        return repo.GetProjectById(projectId)!;
+    }
+
+    private static async Task CreateBaselineSnapshotAsync(SqliteRepository repo, Project project)
+    {
+        var snapshotService = new SnapshotService(repo, new HashService());
+        await snapshotService.CreateSnapshotAsync(
+            project,
+            fullHash: false,
+            hashNow: false,
+            maxSnapshotsToKeep: null,
+            ct: CancellationToken.None);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDir))
+                Directory.Delete(_tempDir, recursive: true);
+        }
+        catch
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Fix Backup All / auto-backup no-change runs so they only skip when a usable backup already exists at the destination
- Use the per-snapshot outcome instead of the static snapshot outcome when deciding whether to skip
- Avoid same-second destination folder collisions during parallel backup runs
- Resolve individual project backup destinations from the latest saved config and refresh destination choices after destination settings are saved
- Add regression coverage for first no-change backup, subsequent no-change skip, and Backup All-style parallel runs

## Why
PR #240 comments showed single project backups worked, but Backup All and auto-backups could create empty project folders. The skip path was allowed to treat a no-change snapshot as complete even when there was no usable backup content at the destination.

Follow-up testing also showed individual backup buttons could keep using stale destination state after Settings changed. Backup All already read the latest saved config; individual project backups now do the same and the destination option lists refresh when destination settings are persisted.

## Tracking
Fixes #244
Fixes #247
Related to #240

## Validation
- `dotnet build VaultSync.sln --configuration Release /p:UseSharedCompilation=false`
- `dotnet test tests/VaultSync.Core.Tests/VaultSync.Core.Tests.csproj --configuration Release --no-build /p:UseSharedCompilation=false`