### PR TITLE
fix(metadata): export project settings without backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [BUG-17109] Backup All and auto-backup no-change runs now create real first backup artifacts instead of empty destination folders.
 - [BUG-17110] Metadata imports now compare restore-needed state against the pre-import local backup baseline, so newly imported backups no longer suppress their own restore prompt.
 - [BUG-17113] Individual project backup buttons now resolve destinations from the latest saved config and refresh destination choices after backup destination settings change.
+- [BUG-17114] Project auto-backup settings now export through metadata before the first backup, so toggles travel across machines earlier.
 ## [1.7.2] - 09.04.2026
 ### Added
 - [VS-1727] Added an initial Microsoft Store packaging scaffold with the reserved Partner Center identity values, separate from the Direct installer path.

--- a/src/VaultSync.Core/Services/MetadataSyncService.cs
+++ b/src/VaultSync.Core/Services/MetadataSyncService.cs
@@ -1205,6 +1205,164 @@ public sealed class MetadataSyncService
             .GetAwaiter().GetResult();
     }
 
+    public MetadataSyncResult ExportProjectToStore(string rootPath, int projectId, string appVersion, string machineId)
+    {
+        return ExportProjectToStoreAsync(rootPath, projectId, appVersion, machineId, CancellationToken.None)
+            .GetAwaiter().GetResult();
+    }
+
+    public async Task<MetadataSyncResult> ExportProjectToStoreAsync(
+        string rootPath,
+        int projectId,
+        string appVersion,
+        string machineId,
+        CancellationToken ct = default)
+    {
+        await MetadataIoGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await WaitForNetworkReadyAsync(rootPath, ct).ConfigureAwait(false);
+            var retryDelays = new[]
+            {
+                TimeSpan.FromMilliseconds(200),
+                TimeSpan.FromMilliseconds(500),
+                TimeSpan.FromMilliseconds(1000)
+            };
+
+            for (var attempt = 0; attempt <= retryDelays.Length; attempt++)
+            {
+                try
+                {
+                    return ExportProjectToStoreInternal(rootPath, projectId, appVersion, machineId);
+                }
+                catch (SqliteException ex) when (IsCannotOpenOrLocked(ex))
+                {
+                    if (attempt >= retryDelays.Length)
+                    {
+                        Console.WriteLine($"[MetadataSync] Project export failed after retries: {ex.Message}");
+                        return MetadataSyncResult.Failure(MetadataSyncStatus.WriteFailed, ex.Message);
+                    }
+
+                    var delay = retryDelays[attempt];
+                    Console.WriteLine($"[MetadataSync] Project export store locked; retrying in {delay.TotalMilliseconds:0}ms.");
+                    await Task.Delay(delay, ct).ConfigureAwait(false);
+                }
+            }
+
+            return MetadataSyncResult.Failure(MetadataSyncStatus.WriteFailed, "Project export failed after retries.");
+        }
+        finally
+        {
+            MetadataIoGate.Release();
+        }
+    }
+
+    private MetadataSyncResult ExportProjectToStoreInternal(string rootPath, int projectId, string appVersion, string machineId)
+    {
+        if (string.IsNullOrWhiteSpace(rootPath))
+        {
+            Console.WriteLine("[MetadataSync] Project export failed: root path is empty.");
+            return MetadataSyncResult.Failure(MetadataSyncStatus.InvalidPath, "Root path is empty.");
+        }
+
+        TryFlushDeferredExport(rootPath);
+
+        var storeRoot = rootPath;
+        var isDeferred = false;
+        var destMetaDir = GetMetaDir(rootPath);
+        if (!TryEnsureMetadataDirWritable(destMetaDir))
+        {
+            storeRoot = GetDeferredExportRoot(rootPath);
+            isDeferred = true;
+        }
+
+        var store = new MetadataStore(storeRoot);
+        Console.WriteLine($"[MetadataSync] Project export target store: '{store.DatabasePath}'.");
+        try
+        {
+            store.EnsureSchema();
+        }
+        catch (Exception ex)
+        {
+            if (ex is SqliteException sqliteEx && IsCannotOpenOrLocked(sqliteEx))
+                throw;
+            Console.WriteLine($"[MetadataSync] Project export failed: store init error at '{rootPath}': {ex.Message}");
+            return MetadataSyncResult.Failure(MetadataSyncStatus.WriteFailed, ex.Message);
+        }
+
+        var project = _repo.GetProjectById(projectId);
+        if (project == null)
+        {
+            Console.WriteLine($"[MetadataSync] Project export failed: project {projectId} not found.");
+            return MetadataSyncResult.Failure(MetadataSyncStatus.InvalidStore, "Project not found.");
+        }
+
+        var projectExternalId = EnsureProjectExternalId(project);
+        var now = DateTime.UtcNow;
+        var metaInfo = store.GetMetaInfo();
+        if (metaInfo == null)
+        {
+            metaInfo = new MetaInfo
+            {
+                SchemaVersion = MetadataStore.CurrentSchemaVersion,
+                CreatedUtc = now,
+                LastWriteUtc = now,
+                WriterAppVersion = appVersion,
+                WriterMachineId = machineId
+            };
+        }
+        else
+        {
+            metaInfo.LastWriteUtc = now;
+            metaInfo.WriterAppVersion = appVersion;
+            metaInfo.WriterMachineId = machineId;
+        }
+
+        try
+        {
+            store.UpsertMetaInfo(metaInfo);
+            store.UpsertProject(new MetaProject
+            {
+                ExternalId = projectExternalId,
+                Name = project.Name,
+                Preset = project.Preset,
+                RootPathHint = project.RootPath,
+                CreatedUtc = project.CreatedUtc,
+                SettingsJson = BuildProjectSettingsJson(project),
+                UpdatedUtc = now
+            });
+        }
+        catch (Exception ex)
+        {
+            if (ex is SqliteException sqliteEx && IsCannotOpenOrLocked(sqliteEx))
+                throw;
+            Console.WriteLine($"[MetadataSync] Project export failed writing store '{rootPath}': {ex.Message}");
+            return MetadataSyncResult.Failure(MetadataSyncStatus.WriteFailed, ex.Message);
+        }
+
+        var exportResult = new MetadataSyncResult(
+            MetadataSyncStatus.Success,
+            1,
+            0,
+            0,
+            0,
+            string.Empty);
+        Console.WriteLine($"[MetadataSync] Project export complete for project '{project.Name}' to '{storeRoot}'.");
+        LogStoreCounts(store);
+
+        if (isDeferred)
+        {
+            if (TryFlushDeferredExport(rootPath))
+                return exportResult;
+
+            return MetadataSyncResult.Failure(
+                MetadataSyncStatus.WriteFailed,
+                "Project export queued: destination not writable. Will retry when available.");
+        }
+
+        return exportResult;
+    }
+
     public async Task<MetadataSyncResult> ExportBackupToStoreAsync(
         string rootPath,
         int backupId,

--- a/src/VaultSync.UI/ViewModels/AppViewModel.ConfigurationOps.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.ConfigurationOps.cs
@@ -1023,6 +1023,8 @@ namespace VaultSync.UI.ViewModels
 
                     cfg.Backups.AutoBackupDisabledProjects = list;
                     AppConfigStore.Save(cfg);
+                    DiagnosticsLogger.Record(
+                        $"[AutoBackup] Preference changed. ProjectId={projectId}; Enabled={enabled}; DisabledCount={list.Count}.");
 
                     Dispatcher.UIThread.Post(() =>
                     {
@@ -1072,6 +1074,8 @@ namespace VaultSync.UI.ViewModels
 
                     cfg.Backups.AutoBackupDisabledProjects = list;
                     AppConfigStore.Save(cfg);
+                    DiagnosticsLogger.Record(
+                        $"[AutoBackup] Group preference changed. ProjectIds={string.Join(',', ids)}; Enabled={enabled}; DisabledCount={list.Count}.");
 
                     Dispatcher.UIThread.Post(() =>
                     {

--- a/src/VaultSync.UI/ViewModels/AppViewModel.RuntimeOps.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.RuntimeOps.cs
@@ -1236,34 +1236,54 @@ namespace VaultSync.UI.ViewModels
                     return;
 
                 var latestBackup = _repo.GetLatestBackupForProject(projectId);
-                if (latestBackup is null || latestBackup.Id <= 0)
-                    return;
-
                 var cfg = await Task.Run(() => AppConfigStore.GetSnapshot());
                 var destinations = ResolveDestinationsForProject(project, cfg).Destinations;
                 if (destinations.Count == 0)
+                {
+                    DiagnosticsLogger.Record($"[MetadataSync] Project settings export skipped: no destinations for projectId={projectId}.");
                     return;
+                }
 
                 foreach (var dest in destinations)
                 {
                     if (!IsMetadataSyncEnabled(cfg, dest))
+                    {
+                        DiagnosticsLogger.Record($"[MetadataSync] Project settings export skipped: metadata disabled for destination '{dest.Alias ?? dest.Path}'.");
                         continue;
+                    }
 
                     var resolution = await PrepareDestinationAsync(dest, cfg);
                     if (!resolution.IsSuccess || string.IsNullOrWhiteSpace(resolution.EffectivePath))
+                    {
+                        DiagnosticsLogger.Record($"[MetadataSync] Project settings export skipped: destination unavailable for projectId={projectId}; destination='{dest.Alias ?? dest.Path}'; message='{resolution.Message}'.");
                         continue;
+                    }
 
-                    TryExportMetadataForBackup(
-                        cfg,
-                        dest,
+                    if (latestBackup is { Id: > 0 })
+                    {
+                        TryExportMetadataForBackup(
+                            cfg,
+                            dest,
+                            resolution.EffectivePath,
+                            latestBackup.Id,
+                            forceBackfillOverride: true);
+                        continue;
+                    }
+
+                    var name = string.IsNullOrWhiteSpace(dest.Alias) ? dest.Path : dest.Alias!;
+                    DiagnosticsLogger.Record($"[MetadataSync] Project-only settings export started for projectId={projectId} -> '{name}'.");
+                    var result = await _metadataSyncService.ExportProjectToStoreAsync(
                         resolution.EffectivePath,
-                        latestBackup.Id,
-                        forceBackfillOverride: true);
+                        projectId,
+                        _currentVersionString,
+                        Environment.MachineName);
+                    DiagnosticsLogger.Record($"[MetadataSync] Project-only settings export ({name}) result: {result.Status}; message='{result.Message}'.");
                 }
             }
             catch (Exception ex)
             {
                 Console.WriteLine($"[MetadataSync] Project settings export failed for projectId={projectId}: {ex.Message}");
+                DiagnosticsLogger.Record($"[MetadataSync] Project settings export failed for projectId={projectId}: {ex.GetType().Name} - {ex.Message}");
             }
         }
 

--- a/tests/VaultSync.Core.Tests/MetadataSyncTests.cs
+++ b/tests/VaultSync.Core.Tests/MetadataSyncTests.cs
@@ -758,6 +758,60 @@ public sealed class MetadataSyncTests : IDisposable
     }
 
     [Fact]
+    public void ExportProjectToStore_ProjectSettings_TransportAutoBackupEnabledWithoutBackup()
+    {
+        var metaRoot = CreateTempDir();
+        var sourceDbPath = Path.Combine(CreateTempDir(), "vaultsync-source.db");
+        var targetDbPath = Path.Combine(CreateTempDir(), "vaultsync-target.db");
+        var originalConfig = CloneConfig(AppConfigStore.Load());
+
+        try
+        {
+            var sourceRepo = CreateRepository(sourceDbPath);
+            var projectId = sourceRepo.AddProject(new Project
+            {
+                Name = "Project Settings Only",
+                RootPath = CreateTempDir(),
+                Preset = "unity",
+                CreatedUtc = DateTime.UtcNow
+            });
+
+            var cfg = CloneConfig(originalConfig);
+            cfg.Backups.AutoBackupDisabledProjects = new List<int> { projectId };
+            AppConfigStore.Save(cfg);
+
+            var exportService = new MetadataSyncService(sourceRepo);
+            var exportResult = exportService.ExportProjectToStore(metaRoot, projectId, "1.7.3", "machine-source");
+            Assert.Equal(MetadataSyncStatus.Success, exportResult.Status);
+
+            var store = new MetadataStore(metaRoot);
+            var metaProject = store.ListProjects().Single();
+            using (var doc = JsonDocument.Parse(metaProject.SettingsJson))
+            {
+                Assert.True(doc.RootElement.TryGetProperty("autoBackupEnabled", out var autoBackupEnabled));
+                Assert.False(autoBackupEnabled.GetBoolean());
+            }
+
+            cfg.Backups.AutoBackupDisabledProjects.Clear();
+            AppConfigStore.Save(cfg);
+
+            var targetRepo = CreateRepository(targetDbPath);
+            var importService = new MetadataSyncService(targetRepo);
+            var importResult = importService.ImportFromStore(metaRoot, MetadataSyncOptions.Default);
+            Assert.Equal(MetadataSyncStatus.Success, importResult.Status);
+
+            var importedProject = targetRepo.GetProjectByName("Project Settings Only");
+            Assert.NotNull(importedProject);
+            var refreshedConfig = AppConfigStore.Load();
+            Assert.Contains(importedProject!.Id, refreshedConfig.Backups.AutoBackupDisabledProjects);
+        }
+        finally
+        {
+            AppConfigStore.Save(originalConfig);
+        }
+    }
+
+    [Fact]
     public void ExportBackupToStore_ProjectSettings_IncludeDestinationRestoreVerificationAndTags()
     {
         var metaRoot = CreateTempDir();


### PR DESCRIPTION
## Summary
- Export project settings metadata even when a project has no backup yet
- Let auto-backup enable/disable state travel through metadata sync on settings changes
- Keep the existing latest-backup export path when a backup exists
- Add diagnostics around project settings export skips and failures
- Add regression coverage for transporting auto-backup-disabled state without a backup

## Why
Project-level auto-backup state was saved locally but did not reliably travel to other machines unless a backup had already been created. That made toggles appear reset after sync/restart scenarios.

## Tracking
Fixes #243
Related to #240

## Validation
- `dotnet test tests/VaultSync.Core.Tests/VaultSync.Core.Tests.csproj --filter MetadataSyncTests`
- `dotnet build VaultSync.sln`