### PR TITLE
BUG-17115: simplify native tray menu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: dotnet restore VaultSync.sln
 
       - name: Build
-        run: dotnet build VaultSync.sln --configuration Release --no-restore -warnaserror -p:UseSharedCompilation=false
+        run: dotnet build VaultSync.sln --configuration Release --no-restore -warnaserror -p:UseSharedCompilation=false -m:1
 
       - name: Test
         run: dotnet test tests\VaultSync.Core.Tests\VaultSync.Core.Tests.csproj --configuration Release --no-build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ﻿# Changelog
 ## [1.8.0] - Unreleased
 ### Fixed
+- [BUG-17115] Windows/Linux tray right-click now uses a compact native menu that opens the richer tray panel instead of fragile nested submenus, making tray actions selectable on Linux desktop environments.
 - [BUG-18001] Tray panel action buttons now wrap localized labels within the fixed popover width, preventing longer non-English text from clipping or overflowing.
 
 ## [1.7.3] - 23.04.2026

--- a/Localization/strings.ar.json
+++ b/Localization/strings.ar.json
@@ -1128,6 +1128,7 @@
   "Tray.Notification.BackgroundTitle": "لا يزال VaultSync قيد التشغيل",
   "Tray.Tooltip": "VaultSync - اللقطات والنسخ الاحتياطية",
   "Tray.Open": "افتح فولت سينك",
+  "Tray.Panel.Open": "فتح لوحة علبة النظام",
   "Tray.Policy.Active": "السياسة: {0}",
   "Tray.Quit": "قم بإنهاء VaultSync",
   "Tray.Recent.ActionFormat": "   * {0}",

--- a/Localization/strings.bn.json
+++ b/Localization/strings.bn.json
@@ -1128,6 +1128,7 @@
   "Tray.Notification.BackgroundTitle": "VaultSync এখনও চলছে",
   "Tray.Tooltip": "VaultSync - স্ন্যাপশট ও ব্যাকআপ",
   "Tray.Open": "VaultSync খুলুন",
+  "Tray.Panel.Open": "ট্রে প্যানেল খুলুন",
   "Tray.Policy.Active": "নীতি: {0}",
   "Tray.Quit": "VaultSync বন্ধ করুন",
   "Tray.Recent.ActionFormat": "   * {0}",

--- a/Localization/strings.de.json
+++ b/Localization/strings.de.json
@@ -1128,6 +1128,7 @@
   "Tray.Notification.BackgroundTitle": "VaultSync läuft weiter",
   "Tray.Tooltip": "VaultSync - Snapshots & Sicherungen",
   "Tray.Open": "VaultSync öffnen",
+  "Tray.Panel.Open": "Tray-Panel öffnen",
   "Tray.Policy.Active": "Richtlinie: {0}",
   "Tray.Quit": "VaultSync beenden",
   "Tray.Recent.ActionFormat": "   * {0}",

--- a/Localization/strings.en.json
+++ b/Localization/strings.en.json
@@ -1141,6 +1141,7 @@
   "Tray.Notification.BackgroundTitle": "VaultSync is still running",
   "Tray.Tooltip": "VaultSync - snapshots and backups",
   "Tray.Open": "Open VaultSync",
+  "Tray.Panel.Open": "Open tray panel",
   "Tray.Policy.Active": "Policy: {0}",
   "Tray.Quit": "Quit VaultSync",
   "Tray.Recent.ActionFormat": "   * {0}",

--- a/Localization/strings.es.json
+++ b/Localization/strings.es.json
@@ -1128,6 +1128,7 @@
   "Tray.Notification.BackgroundTitle": "VaultSync sigue en ejecución",
   "Tray.Tooltip": "VaultSync - instantáneas y respaldos",
   "Tray.Open": "Abrir VaultSync",
+  "Tray.Panel.Open": "Abrir panel de bandeja",
   "Tray.Policy.Active": "Política: {0}",
   "Tray.Quit": "Salir de VaultSync",
   "Tray.Recent.ActionFormat": "   * {0}",

--- a/Localization/strings.fr.json
+++ b/Localization/strings.fr.json
@@ -1128,6 +1128,7 @@
   "Tray.Notification.BackgroundTitle": "VaultSync continue de tourner",
   "Tray.Tooltip": "VaultSync - instantanés et sauvegardes",
   "Tray.Open": "Ouvrir VaultSync",
+  "Tray.Panel.Open": "Ouvrir le panneau de la zone de notification",
   "Tray.Policy.Active": "Politique : {0}",
   "Tray.Quit": "Quitter VaultSync",
   "Tray.Recent.ActionFormat": "   * {0}",

--- a/Localization/strings.hi.json
+++ b/Localization/strings.hi.json
@@ -1128,6 +1128,7 @@
   "Tray.Notification.BackgroundTitle": "VaultSync अभी भी चल रहा है",
   "Tray.Tooltip": "VaultSync - स्नैपशॉट और बैकअप",
   "Tray.Open": "VaultSync खोलें",
+  "Tray.Panel.Open": "ट्रे पैनल खोलें",
   "Tray.Policy.Active": "नीति: {0}",
   "Tray.Quit": "VaultSync बंद करें",
   "Tray.Recent.ActionFormat": "   * {0}",

--- a/Localization/strings.it.json
+++ b/Localization/strings.it.json
@@ -1128,6 +1128,7 @@
   "Tray.Notification.BackgroundTitle": "VaultSync continua a funzionare",
   "Tray.Tooltip": "VaultSync - snapshot e backup",
   "Tray.Open": "Apri VaultSync",
+  "Tray.Panel.Open": "Apri pannello della tray",
   "Tray.Policy.Active": "Politica: {0}",
   "Tray.Quit": "Chiudi VaultSync",
   "Tray.Recent.ActionFormat": "   * {0}",

--- a/Localization/strings.pt.json
+++ b/Localization/strings.pt.json
@@ -1128,6 +1128,7 @@
   "Tray.Notification.BackgroundTitle": "VaultSync continua em execução",
   "Tray.Tooltip": "VaultSync - instantâneos e backups",
   "Tray.Open": "Abrir VaultSync",
+  "Tray.Panel.Open": "Abrir painel da bandeja",
   "Tray.Policy.Active": "Política: {0}",
   "Tray.Quit": "Sair do VaultSync",
   "Tray.Recent.ActionFormat": "   * {0}",

--- a/Localization/strings.ru.json
+++ b/Localization/strings.ru.json
@@ -1128,6 +1128,7 @@
   "Tray.Notification.BackgroundTitle": "VaultSync продолжает работать",
   "Tray.Tooltip": "VaultSync — снимки и резервные копии",
   "Tray.Open": "Открыть VaultSync",
+  "Tray.Panel.Open": "Открыть панель трея",
   "Tray.Policy.Active": "Политика: {0}",
   "Tray.Quit": "Выйти из VaultSync",
   "Tray.Recent.ActionFormat": "   * {0}",

--- a/Localization/strings.zh.json
+++ b/Localization/strings.zh.json
@@ -1128,6 +1128,7 @@
   "Tray.Notification.BackgroundTitle": "VaultSync 正在后台运行",
   "Tray.Tooltip": "VaultSync — 快照与备份",
   "Tray.Open": "打开 VaultSync",
+  "Tray.Panel.Open": "打开托盘面板",
   "Tray.Policy.Active": "策略：{0}",
   "Tray.Quit": "退出 VaultSync",
   "Tray.Recent.ActionFormat": "   * {0}",

--- a/src/VaultSync.UI/App.axaml.cs
+++ b/src/VaultSync.UI/App.axaml.cs
@@ -633,6 +633,12 @@ public partial class App : Application
         IReadOnlyList<AppViewModel.TrayProjectBackups>? recentBackups = null,
         string? policySummary = null)
     {
+        if (!OperatingSystem.IsMacOS())
+        {
+            PopulateCompactTrayMenu(menu, desktop, policySummary);
+            return;
+        }
+
         // Build a small context menu: header / Open / Backup / Snapshot / Recent backups / Quit.
         menu.Items.Clear();
 
@@ -690,6 +696,67 @@ public partial class App : Application
         menu.Items.Add(separator2);
         menu.Items.Add(quitItem);
 
+    }
+
+    private void PopulateCompactTrayMenu(
+        NativeMenu menu,
+        IClassicDesktopStyleApplicationLifetime desktop,
+        string? policySummary = null)
+    {
+        menu.Items.Clear();
+
+        AddTrayHeader(menu);
+
+        var destinationSummaries = AppViewModelInstance?.GetDestinationProbeSummaries()
+                                   ?? Array.Empty<AppViewModel.DestinationProbeSummary>();
+        var cfg = AppConfigStore.GetSnapshot();
+        var configuredDestinations = GetConfiguredDestinations(cfg);
+        var (destinationsTitle, destinationsStatus) =
+            GetDestinationStatus(destinationSummaries, configuredDestinations);
+
+        menu.Items.Add(new NativeMenuItem($"{destinationsTitle} - {destinationsStatus}") { IsEnabled = false });
+        if (!string.IsNullOrWhiteSpace(policySummary))
+        {
+            menu.Items.Add(new NativeMenuItem(policySummary) { IsEnabled = false });
+        }
+
+        menu.Items.Add(new NativeMenuItemSeparator());
+
+        var panelItem = new NativeMenuItem(L("Tray.Panel.Open", "Open tray panel"));
+        panelItem.Click += (_, _) => _trayPanelService?.Show();
+        menu.Items.Add(panelItem);
+        menu.Items.Add(BuildOpenTrayItem(desktop));
+
+        var backupAllItem = new NativeMenuItem(L("Tray.Backup.All", "Backup all projects"));
+        backupAllItem.Click += (_, _) =>
+        {
+            BringWindowToFrontIfUserWants(desktop);
+            AppViewModelInstance?.RequestBackupAllFromTray();
+        };
+        menu.Items.Add(backupAllItem);
+
+        var snapshotAllItem = new NativeMenuItem(L("Tray.Snapshot.All", "Snapshot all projects"));
+        snapshotAllItem.Click += async (_, _) =>
+        {
+            BringWindowToFrontIfUserWants(desktop);
+            if (AppViewModelInstance is not null)
+            {
+                await AppViewModelInstance.TakeSnapshotAllFromTrayAsync();
+            }
+        };
+        menu.Items.Add(snapshotAllItem);
+
+        var openBackupsItem = new NativeMenuItem(L("Tray.Recent.OpenInApp", "Open in VaultSync"));
+        openBackupsItem.Click += (_, _) =>
+        {
+            BringMainWindowToFront(desktop);
+            AppViewModelInstance?.NavigateBackups?.Execute(null);
+        };
+        menu.Items.Add(openBackupsItem);
+
+        menu.Items.Add(new NativeMenuItemSeparator());
+        menu.Items.Add(BuildTraySettingsItem(desktop));
+        menu.Items.Add(BuildQuitTrayItem(desktop));
     }
 
     private void AddTrayHeader(NativeMenu menu)


### PR DESCRIPTION
## Summary
- Replaces the fragile nested Windows/Linux native tray menu with a compact native fallback.
- Adds an explicit entry to open the richer tray panel for detailed tray actions.
- Adds the new tray panel label across localization files.

Fixes #250