### PR TITLE
BUG-17116: harden notification auto-dismiss cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [VS-1739] CLI command implementations were updated for the current Spectre.Console.Cli command override model.
 - [VS-1740] Refreshed the safe dependency set for 1.7.4, including Avalonia 11.3.14, LiveCharts 2.0.2, ReactiveUI 23.2.27, SQLite/ProtectedData/System.Text.Json 10.0.7, Spectre.Console 0.55.x, and the current DBus/test SDK packages.
 ### Fixed
+- [BUG-17116] Notification dismiss and auto-dismiss cleanup now avoid disposed-token races, preventing soft crash reports after toast-heavy UI flows.
 - [BUG-17118] Log console rows now show readable time, source, and message fields.
 - [BUG-17108] In-app logs now capture runtime errors without verbose logging.
 - [BUG-17115] Windows/Linux tray menus now open the richer tray panel reliably.

--- a/src/VaultSync.UI/ViewModels/NotificationState.cs
+++ b/src/VaultSync.UI/ViewModels/NotificationState.cs
@@ -176,9 +176,8 @@ namespace VaultSync.UI.ViewModels.Notifications
                 if (!IsVisible && string.IsNullOrWhiteSpace(Message))
                     return;
 
-                CancellationTokenSource? previous = Interlocked.Exchange(ref _cts, null);
-                previous?.Cancel();
-                previous?.Dispose();
+                var previous = Interlocked.Exchange(ref _cts, null);
+                CancelAndDispose(previous);
 
                 Message = string.Empty;
                 Title = string.Empty;
@@ -198,10 +197,9 @@ namespace VaultSync.UI.ViewModels.Notifications
 
         private async Task StartAutoDismissAsync(TimeSpan duration)
         {
-            CancellationTokenSource? previous = Interlocked.Exchange(ref _cts, new CancellationTokenSource());
-            previous?.Cancel();
-            previous?.Dispose();
-            CancellationTokenSource local = _cts!;
+            var previous = Interlocked.Exchange(ref _cts, new CancellationTokenSource());
+            CancelAndDispose(previous);
+            var local = _cts!;
 
             try
             {
@@ -218,11 +216,29 @@ namespace VaultSync.UI.ViewModels.Notifications
             finally
             {
                 // Dispose only if still current; avoid disposing a newer token source.
-                if (ReferenceEquals(_cts, local))
+                if (Interlocked.CompareExchange(ref _cts, null, local) == local)
                 {
                     local.Dispose();
-                    _cts = null;
                 }
+            }
+        }
+
+        private static void CancelAndDispose(CancellationTokenSource? cts)
+        {
+            if (cts is null)
+                return;
+
+            try
+            {
+                cts.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // Another UI/background path already retired this auto-dismiss token.
+            }
+            finally
+            {
+                cts.Dispose();
             }
         }
 


### PR DESCRIPTION
## Summary
- Removes the disposed-token race between manual notification dismiss and auto-dismiss cleanup.
- Uses atomic token retirement before disposal so `Clear()` cannot cancel a stale disposed source.
- Keeps existing toast grouping, replacement, manual dismiss, and auto-dismiss behavior unchanged.

## Tracking
Fixes #257 
