### PR TITLE
fix(backups): prevent recursive backup growth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 - [VS-1737] Added VS Code Linux debug launch/tasks for the UI, CLI, and full test suite.
 - [VS-1738] Linux tarball releases now include rootless install/uninstall scripts that create a user desktop launcher, icon, and `vaultsync` command across distro families.
 - [VS-1739] CLI JSON-producing commands now share a single indented serializer configuration so config, destination, snapshot, sync, restore, and prune output stays consistent.
-
 ### Changed
 - [BUG-17119] Startup metadata import now also checks reachable backup destinations.
 - [BUG-17119] UI metadata imports now treat source stores as read-only.
@@ -28,6 +27,13 @@
 - [BUG-17128] System notification service creation now records fallback exceptions instead of swallowing an empty catch.
 - [BUG-17129] Drive health checks now prefer `smartctl` when available across platforms and avoid surfacing SMART health rows for network destinations where local drive data is unavailable.
 - [BUG-17130] Metadata tombstone exports now treat Linux mount roots as network-style SQLite stores, avoiding WAL locks on mounted backup destinations.
+- [BUG-18002] The log console now formats live diagnostics into readable time/source/message rows with fixed color-coded source chips while keeping raw lines available for copy and export.
+- [BUG-17108] The in-app log console now captures live output when opened and mirrors diagnostics-session errors, so runtime failures are visible without enabling verbose logging first.
+- [BUG-17115] Windows/Linux tray right-click now uses a compact native menu that opens the richer tray panel instead of fragile nested submenus, making tray actions selectable on Linux desktop environments.
+- [BUG-18001] Tray panel action buttons now wrap localized labels within the fixed popover width, preventing longer non-English text from clipping or overflowing.
+- [BUG-18003] Backup safety now blocks source/destination overlap, keeps offline staging outside project trees, and always excludes VaultSync-owned backup artifacts from scans to prevent recursive backup growth. Refs #281.
+- [BUG-18004] Backup delete cards now stay visible while overlapping deletes continue and show destination, target, current file, file counts, and removed bytes during deletion. Refs #279.
+- [BUG-18005] Manual metadata refresh now keeps import work off the UI thread and ignores VaultSync temporary root hints, preventing Refresh History hangs and temp-root project mappings. Refs #280.
 
 ## [1.7.3] - 23.04.2026
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [VS-1737] Added VS Code Linux debug launch/tasks for the UI, CLI, and full test suite.
 - [VS-1738] Linux tarball releases now include rootless install/uninstall scripts that create a user desktop launcher, icon, and `vaultsync` command across distro families.
 - [VS-1739] CLI JSON-producing commands now share a single indented serializer configuration so config, destination, snapshot, sync, restore, and prune output stays consistent.
+
 ### Changed
 - [BUG-17119] Startup metadata import now also checks reachable backup destinations.
 - [BUG-17119] UI metadata imports now treat source stores as read-only.
@@ -12,7 +13,9 @@
 - [VS-1724] Patch manifest compatibility tests now cover empty allowlists, build metadata normalization, and prerelease mismatch edge cases.
 - [VS-1739] CLI command implementations were updated for the current Spectre.Console.Cli command override model.
 - [VS-1740] Refreshed the safe dependency set for 1.7.4, including Avalonia 11.3.14, LiveCharts 2.0.2, ReactiveUI 23.2.27, SQLite/ProtectedData/System.Text.Json 10.0.7, Spectre.Console 0.55.x, and the current DBus/test SDK packages.
+
 ### Fixed
+- [BUG-17116] Notification dismiss and auto-dismiss cleanup now avoid disposed-token races, preventing soft crash reports after toast-heavy UI flows.
 - [BUG-17118] Log console rows now show readable time, source, and message fields.
 - [BUG-17108] In-app logs now capture runtime errors without verbose logging.
 - [BUG-17115] Windows/Linux tray menus now open the richer tray panel reliably.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1632,6 +1632,25 @@
     - imported history distinguishes source-created time from local imported/discovered time.
     - future metadata sync can reconcile equal content across machines via a stable content fingerprint.
 
+- [x] `BUG-18003` `P0` Prevent recursive backup growth from nested backup destinations. _(Done in PR #278, issue #281)_
+  - Scope: block source/destination overlap, move offline staging outside project trees, force reserved VaultSync backup artifact exclusions, and prune reserved backup folders before scanner descent.
+  - Acceptance:
+    - backup roots inside project roots, project roots inside backup roots, and same-path roots are blocked
+    - offline staging is outside the project tree
+    - reserved VaultSync backup folders/files are excluded without requiring user ignore rules
+- [x] `BUG-18004` `P1` Keep backup delete operation cards visible and informative. _(Done in PR #278, issue #279)_
+  - Scope: keep the active-operation panel visible while operations remain, avoid delayed progress-card resurrection, and show delete target/progress details.
+  - Acceptance:
+    - overlapping backup deletes do not hide the active card area early
+    - delete cards show destination, target, current file, file counts, and removed bytes
+    - delete progress becomes determinate once file counts are known
+- [x] `BUG-18005` `P0` Keep metadata refresh/import work off the UI thread and ignore temp root hints. _(Done in PR #278, issue #280)_
+  - Scope: run manual metadata refresh/import work off the UI thread and reject VaultSync transient temp paths as imported project roots.
+  - Acceptance:
+    - accepting Refresh History changes does not freeze the app shell
+    - imported root hints under VaultSync temp folders fall back to the configured Projects Root
+    - temp root mapping behavior has regression coverage
+
 ## Future backlog
 - [ ] `VS-1733` `P1` Multi-destination health scoring and auto-failover.
 - [ ] `VS-1734` `P1` Cloud targets (S3-compatible, Backblaze, etc.) with encryption.

--- a/src/VaultSync.Core/Services/BackupSafetyService.cs
+++ b/src/VaultSync.Core/Services/BackupSafetyService.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using VaultSync.Core.Models;
+
+namespace VaultSync.Core.Services;
+
+/// <summary>
+/// Centralized guardrails for backup source/destination separation and VaultSync-owned backup artifacts.
+/// These checks intentionally fail closed: a backup destination must never be inside the project tree.
+/// </summary>
+public static class BackupSafetyService
+{
+    public const string LegacyProjectTempBackupDirectoryName = ".vaultsync-temp-backups";
+    public const string OfflineStagingDirectoryName = "pending-backups";
+
+    private static readonly string[] ReservedDirectoryNames =
+    {
+        ".vaultsync",
+        LegacyProjectTempBackupDirectoryName,
+        "Backup",
+        "Backups"
+    };
+
+    private static readonly string[] ReservedFileNames =
+    {
+        ".vaultsync_inprogress",
+        ".vaultsync_complete",
+        ".vaultsync_resume.json"
+    };
+
+    public static IReadOnlyList<string> ReservedIgnorePatterns { get; } =
+    [
+        ".vaultsync/**",
+        $"{LegacyProjectTempBackupDirectoryName}/**",
+        "Backup/**",
+        "Backups/**",
+        ".vaultsync_inprogress",
+        ".vaultsync_complete",
+        ".vaultsync_resume.json"
+    ];
+
+    public static IEnumerable<string> AddReservedIgnorePatterns(IEnumerable<string> patterns)
+    {
+        foreach (var pattern in patterns)
+        {
+            if (!string.IsNullOrWhiteSpace(pattern))
+                yield return pattern;
+        }
+
+        foreach (var pattern in ReservedIgnorePatterns)
+            yield return pattern;
+    }
+
+    public static string GetOfflineStagingRoot(Project project)
+    {
+        ArgumentNullException.ThrowIfNull(project);
+        var projectKey = project.Id > 0 ? project.Id.ToString() : Slugify(project.Name);
+        return Path.Combine(GetVaultSyncHomeDirectory(), OfflineStagingDirectoryName, projectKey);
+    }
+
+    public static string GetLegacyProjectTempRoot(Project project)
+    {
+        ArgumentNullException.ThrowIfNull(project);
+        if (string.IsNullOrWhiteSpace(project.RootPath))
+            throw new InvalidOperationException("Project.RootPath is not set.");
+
+        return Path.Combine(project.RootPath, LegacyProjectTempBackupDirectoryName);
+    }
+
+    public static void EnsureSafeBackupRoot(Project project, string backupRoot)
+    {
+        ArgumentNullException.ThrowIfNull(project);
+        EnsureSafeBackupRoot(project.RootPath, backupRoot);
+    }
+
+    public static void EnsureSafeBackupRoot(string projectRoot, string backupRoot)
+    {
+        if (string.IsNullOrWhiteSpace(projectRoot))
+            throw new InvalidOperationException("Project.RootPath is not set.");
+        if (string.IsNullOrWhiteSpace(backupRoot))
+            throw new InvalidOperationException("Backup root is empty. Configure a backup location in Settings.");
+
+        var source = NormalizeDirectoryPath(projectRoot);
+        var target = NormalizeDirectoryPath(backupRoot);
+
+        if (IsSameOrChildPath(source, target))
+        {
+            throw new InvalidOperationException(
+                "Unsafe backup destination: the backup location is inside the project root. " +
+                "VaultSync blocked this backup to prevent recursively backing up backups into backups.");
+        }
+
+        if (IsSameOrChildPath(target, source))
+        {
+            throw new InvalidOperationException(
+                "Unsafe backup destination: the project root is inside the backup location. " +
+                "Choose a backup location outside the project tree.");
+        }
+    }
+
+    public static bool IsReservedPath(string projectRoot, string fullPath)
+    {
+        if (string.IsNullOrWhiteSpace(projectRoot) || string.IsNullOrWhiteSpace(fullPath))
+            return false;
+
+        string relative;
+        try
+        {
+            relative = Path.GetRelativePath(projectRoot, fullPath).Replace('\\', '/');
+        }
+        catch
+        {
+            return false;
+        }
+
+        if (relative.Length == 0 || relative == "." || relative.StartsWith("../", StringComparison.Ordinal) || Path.IsPathRooted(relative))
+            return false;
+
+        var segments = relative.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length == 0)
+            return false;
+
+        if (ReservedDirectoryNames.Any(name => segments.Any(segment => string.Equals(segment, name, StringComparison.OrdinalIgnoreCase))))
+            return true;
+
+        var fileName = segments[^1];
+        return ReservedFileNames.Any(name => string.Equals(fileName, name, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string NormalizeDirectoryPath(string path)
+    {
+        var full = Path.GetFullPath(path)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        return full + Path.DirectorySeparatorChar;
+    }
+
+    private static bool IsSameOrChildPath(string parent, string child)
+    {
+        var comparison = OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        return child.StartsWith(parent, comparison);
+    }
+
+    private static string GetVaultSyncHomeDirectory()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrWhiteSpace(home))
+            home = Path.GetTempPath();
+
+        return Path.Combine(home, ".vaultsync");
+    }
+
+    private static string Slugify(string? value)
+    {
+        var input = string.IsNullOrWhiteSpace(value) ? "project" : value.Trim();
+        var invalid = Path.GetInvalidFileNameChars();
+        var chars = input.Select(ch => invalid.Contains(ch) || char.IsWhiteSpace(ch) ? '-' : char.ToLowerInvariant(ch)).ToArray();
+        var slug = new string(chars).Trim('-');
+        return string.IsNullOrWhiteSpace(slug) ? "project" : slug;
+    }
+}

--- a/src/VaultSync.Core/Services/FilterService.cs
+++ b/src/VaultSync.Core/Services/FilterService.cs
@@ -1,6 +1,6 @@
 using System.Collections.Concurrent;
-using System.Text.RegularExpressions;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 
 namespace VaultSync.Core.Services;
 
@@ -22,13 +22,17 @@ public class FilterService
     /// <summary>
     /// The normalized ignore patterns used by this filter. These patterns use forward
     /// slashes and have directory rules normalized (trailing '/' turned into '/*').
+    /// VaultSync-owned backup artifacts are always appended as safety exclusions.
     /// </summary>
     public IReadOnlyList<string> RawPatterns => _patterns;
 
     public FilterService(IEnumerable<string> patterns)
     {
-        _patterns = [.. patterns.Select(Normalize)];
-        _compiledPatterns = [.. _patterns.Select(CompilePattern)];
+        _patterns = BackupSafetyService.AddReservedIgnorePatterns(patterns)
+            .Select(Normalize)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        _compiledPatterns = _patterns.Select(CompilePattern).ToList();
     }
 
     public static FilterService FromPresetAndLocal(string projectRoot, string presetName, string? presetsDir = null)
@@ -67,7 +71,7 @@ public class FilterService
             patterns.AddRange(localLines);
         }
 
-        Console.WriteLine($"[FilterService] Total rules in combined filter: {patterns.Count}");
+        Console.WriteLine($"[FilterService] Total rules in combined filter: {patterns.Count} user/preset + {BackupSafetyService.ReservedIgnorePatterns.Count} reserved safety rules");
 
         return new FilterService(patterns);
     }
@@ -165,8 +169,11 @@ public class FilterService
 
     public bool ShouldExclude(string root, string fullPath)
     {
-        string rel = Path.GetRelativePath(root, fullPath).Replace('\\', '/');
-        foreach (Regex rx in _compiledPatterns)
+        if (BackupSafetyService.IsReservedPath(root, fullPath))
+            return true;
+
+        var rel = Path.GetRelativePath(root, fullPath).Replace('\\', '/');
+        foreach (var rx in _compiledPatterns)
             if (rx.IsMatch(rel)) return true;
         return false;
     }

--- a/src/VaultSync.Core/Services/MetadataSyncService.cs
+++ b/src/VaultSync.Core/Services/MetadataSyncService.cs
@@ -1322,6 +1322,9 @@ public sealed class MetadataSyncService(SqliteRepository repo)
         if (string.IsNullOrWhiteSpace(trimmed))
             return string.Empty;
 
+        if (IsVaultSyncTransientTempPath(trimmed))
+            return string.Empty;
+
         // Preserve the original imported hint when we cannot safely map it
         // to a local existing directory, so the path is never silently erased.
         return trimmed;
@@ -1341,6 +1344,9 @@ public sealed class MetadataSyncService(SqliteRepository repo)
         try
         {
             string fullPath = Path.GetFullPath(path);
+            if (IsVaultSyncTransientTempPath(fullPath))
+                return false;
+
             return Directory.Exists(fullPath);
         }
         catch
@@ -1380,6 +1386,46 @@ public sealed class MetadataSyncService(SqliteRepository repo)
         return string.IsNullOrWhiteSpace(cleaned)
             ? "ImportedProject"
             : cleaned;
+    }
+
+    private static bool IsVaultSyncTransientTempPath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return false;
+
+        try
+        {
+            var fullPath = Path.GetFullPath(path)
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            var tempRoot = Path.GetFullPath(Path.GetTempPath())
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+            var comparison = OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+
+            if (!fullPath.StartsWith(tempRoot + Path.DirectorySeparatorChar, comparison))
+                return false;
+
+            var relative = Path.GetRelativePath(tempRoot, fullPath);
+            if (relative.StartsWith("..", StringComparison.Ordinal) || Path.IsPathRooted(relative))
+                return false;
+
+            var firstSegment = relative
+                .Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                .FirstOrDefault(segment => !string.IsNullOrWhiteSpace(segment));
+
+            return firstSegment is not null &&
+                   (string.Equals(firstSegment, "vaultsync-meta-import", comparison) ||
+                    string.Equals(firstSegment, "vaultsync-meta-export", comparison) ||
+                    string.Equals(firstSegment, "vaultsync-archive-root", comparison) ||
+                    firstSegment.StartsWith("vaultsync-open-", comparison) ||
+                    firstSegment.StartsWith("vaultsync-restore-", comparison));
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     private static void TryExportMissingBackupTombstones(string rootPath, IReadOnlyCollection<string> missingExternalIds)

--- a/src/VaultSync.Core/Services/RsyncRunner.cs
+++ b/src/VaultSync.Core/Services/RsyncRunner.cs
@@ -25,13 +25,9 @@ namespace VaultSync.Core.Services
 
         public string Name => "rsync";
 
-        // ISyncRunner implementation (without progress callback)
         public Task<int> SyncAsync(Project project, string destination, bool dryRun, CancellationToken ct)
             => SyncAsync(project, destination, dryRun, progressCallback: null, linkDest: null, ct: ct);
 
-        /// <summary>
-        /// Run rsync to mirror project.RootPath into destination, optionally reporting progress.
-        /// </summary>
         public async Task<int> SyncAsync(
             Project project,
             string destination,
@@ -41,7 +37,8 @@ namespace VaultSync.Core.Services
             int? maxBandwidthKbps = null,
             CancellationToken ct = default)
         {
-            // Build ignore filter file based on project's preset and local .vaultsyncignore
+            BackupSafetyService.EnsureSafeBackupRoot(project, destination);
+
             var filter = FilterService.FromPresetAndLocal(project.RootPath, project.Preset);
             string? tempExcludeFile = null;
 
@@ -72,23 +69,18 @@ namespace VaultSync.Core.Services
                 ? project.RootPath
                 : project.RootPath + Path.DirectorySeparatorChar;
 
-            // common flags: archive, delete extra files at dest
             psi.ArgumentList.Add("-a");
             psi.ArgumentList.Add("--delete");
             psi.ArgumentList.Add("--human-readable");
-
-            // Fast LAN / local copy optimizations: do not compress, optionally send whole files.
-            psi.ArgumentList.Add("--no-compress"); // avoid wasting CPU on compression over LAN / local FS
+            psi.ArgumentList.Add("--no-compress");
             if (_useWholeFile)
-                psi.ArgumentList.Add("--whole-file");  // skip delta algorithm, faster for LAN and mounted shares
+                psi.ArgumentList.Add("--whole-file");
 
             if (maxBandwidthKbps is > 0)
                 psi.ArgumentList.Add($"--bwlimit={maxBandwidthKbps.Value}");
 
-            // Make rsync actually print progress lines with percentages.
             psi.ArgumentList.Add("--progress");
 
-            // progress2 gives us aggregate stats; only available on newer rsync builds.
             if (GetCapabilities(_rsyncPath).SupportsInfoProgress2)
             {
                 psi.ArgumentList.Add("--info=progress2");
@@ -100,14 +92,12 @@ namespace VaultSync.Core.Services
                 psi.ArgumentList.Add($"--link-dest={linkPath}");
             }
 
-            // macOS: avoid metadata noise; on Linux it's harmless
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 psi.ArgumentList.Add("--force");
 
             if (dryRun)
                 psi.ArgumentList.Add("--dry-run");
 
-            // Apply exclude-from file if we generated one
             if (OperatingSystem.IsWindows())
             {
                 if (tempExcludeFile != null)
@@ -133,7 +123,6 @@ namespace VaultSync.Core.Services
 
             string? currentFile = null;
 
-            // Helper to parse progress from any rsync output line (stdout or stderr)
             void HandleProgressLine(string? data)
             {
                 if (ct.IsCancellationRequested)
@@ -148,7 +137,6 @@ namespace VaultSync.Core.Services
                 // We treat lines without '%' as potential file names and remember them.
                 if (!line.Contains('%'))
                 {
-                    // Heuristic: ignore generic status lines, keep likely paths.
                     if (!line.StartsWith("sending incremental file list", StringComparison.OrdinalIgnoreCase) &&
                         !line.StartsWith("sent ", StringComparison.OrdinalIgnoreCase) &&
                         !line.StartsWith("total size is ", StringComparison.OrdinalIgnoreCase) &&
@@ -198,17 +186,16 @@ namespace VaultSync.Core.Services
             catch (OperationCanceledException)
             {
                 Console.WriteLine("[RsyncRunner] Cancellation requested; stopping rsync process.");
-                try { proc.CancelErrorRead(); } catch { /* ignore */ }
-                try { proc.CancelOutputRead(); } catch { /* ignore */ }
-                try { proc.Kill(entireProcessTree: true); } catch { /* ignore */ }
+                try { proc.CancelErrorRead(); } catch { }
+                try { proc.CancelOutputRead(); } catch { }
+                try { proc.Kill(entireProcessTree: true); } catch { }
                 throw;
             }
             finally
             {
-                // Cleanup temp exclude file
                 if (tempExcludeFile != null && File.Exists(tempExcludeFile))
                 {
-                    try { File.Delete(tempExcludeFile); } catch { /* ignore */ }
+                    try { File.Delete(tempExcludeFile); } catch { }
                 }
             }
 
@@ -248,7 +235,7 @@ namespace VaultSync.Core.Services
 
                 if (!proc.WaitForExit(2000))
                 {
-                    try { proc.Kill(entireProcessTree: true); } catch { /* ignore */ }
+                    try { proc.Kill(entireProcessTree: true); } catch { }
                     return new RsyncCapabilities(null, false);
                 }
 

--- a/src/VaultSync.Core/Services/ScannerService.cs
+++ b/src/VaultSync.Core/Services/ScannerService.cs
@@ -19,7 +19,7 @@ public class ScannerService
     /// </summary>
     public IEnumerable<FileEntry> Scan(string root)
     {
-        foreach (string path in Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))
+        foreach (var path in EnumerateFilesSafely(root, CancellationToken.None))
         {
             if (_filter.ShouldExclude(root, path))
                 continue;
@@ -44,7 +44,7 @@ public class ScannerService
         {
             var results = new List<FileEntry>();
 
-            foreach (string path in Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))
+            foreach (var path in EnumerateFilesSafely(root, ct))
             {
                 ct.ThrowIfCancellationRequested();
 
@@ -73,4 +73,64 @@ public class ScannerService
             return results;
         }, ct);
     }
+
+    private IEnumerable<string> EnumerateFilesSafely(string root, CancellationToken ct)
+    {
+        var stack = new Stack<string>();
+        stack.Push(root);
+
+        while (stack.Count > 0)
+        {
+            ct.ThrowIfCancellationRequested();
+            var current = stack.Pop();
+
+            if (!string.Equals(Path.GetFullPath(root), Path.GetFullPath(current), GetPathComparison()) &&
+                (BackupSafetyService.IsReservedPath(root, current) || _filter.ShouldExclude(root, current)))
+            {
+                continue;
+            }
+
+            IEnumerable<string> files;
+            try
+            {
+                files = Directory.EnumerateFiles(current);
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is DirectoryNotFoundException)
+            {
+                Console.WriteLine($"[ScannerService] Skipping directory '{current}': {ex.Message}");
+                continue;
+            }
+
+            foreach (var file in files)
+            {
+                ct.ThrowIfCancellationRequested();
+                yield return file;
+            }
+
+            IEnumerable<string> directories;
+            try
+            {
+                directories = Directory.EnumerateDirectories(current);
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is DirectoryNotFoundException)
+            {
+                Console.WriteLine($"[ScannerService] Skipping subdirectory scan for '{current}': {ex.Message}");
+                continue;
+            }
+
+            foreach (var directory in directories)
+            {
+                ct.ThrowIfCancellationRequested();
+                if (BackupSafetyService.IsReservedPath(root, directory) || _filter.ShouldExclude(root, directory))
+                    continue;
+
+                stack.Push(directory);
+            }
+        }
+    }
+
+    private static StringComparison GetPathComparison()
+        => OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
 }

--- a/src/VaultSync.UI/ViewModels/AppViewModel.BackupHistoryHandlers.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.BackupHistoryHandlers.cs
@@ -68,7 +68,20 @@ namespace VaultSync.UI.ViewModels
 
             BackupsViewModel.PinExpandedProject(snapshot.ProjectId);
 
-            BackupsViewModel.ShowTransientOperation(cardId, projectName, AppViewModel.L("Backups.Status.Deleting", "Deleting backup files..."));
+            var destinationLabel = string.IsNullOrWhiteSpace(backup.DestinationAlias)
+                ? backup.DestinationPath
+                : backup.DestinationAlias;
+            var deleteSizeLabel = BackupSnapshotItem.FormatSize(backup.TotalBytes);
+            var deleteTargetLabel = string.IsNullOrWhiteSpace(backup.Path)
+                ? L("Backups.Delete.TargetUnknown", "backup folder")
+                : backup.Path;
+
+            BackupsViewModel.ShowTransientOperation(
+                cardId,
+                projectName,
+                L("Backups.Delete.StageResolving", "Resolving backup destination..."),
+                Lf("Backups.Delete.DetailQueued", "Queued delete: {0} from {1}", deleteSizeLabel, deleteTargetLabel),
+                destinationLabel);
 
             BackupsViewModel.IsBusy      = true;
             BackupsViewModel.BusyMessage = AppViewModel.L("Backups.Status.Deleting", AppViewModel.L("Backups.Status.Deleting", "Deleting backup files..."));
@@ -142,8 +155,17 @@ namespace VaultSync.UI.ViewModels
                         }
                     }
 
-                    string relativePath = backup.Path ?? string.Empty;
-                    if (!TryCombinePathUnderRoot(backupRoot, relativePath, out string? fullPath, out string? combineError))
+                    BackupsViewModel.UpdateActiveBackup(
+                        cardId,
+                        projectName,
+                        0,
+                        L("Backups.Delete.StageResolving", "Resolving backup destination..."),
+                        Lf("Backups.Delete.DetailTarget", "{0} at {1}", deleteSizeLabel, deleteTargetLabel),
+                        allowCancel: false,
+                        destinationLabel: destinationLabel);
+
+                    var relativePath = backup.Path ?? string.Empty;
+                    if (!TryCombinePathUnderRoot(backupRoot, relativePath, out var fullPath, out var combineError))
                     {
                         deleteError = combineError ?? AppViewModel.L("Backups.Delete.Error", "Delete failed");
                         deleteSucceeded = false;
@@ -156,7 +178,21 @@ namespace VaultSync.UI.ViewModels
                         {
                             if (Directory.Exists(fullPath))
                             {
-                                deleteSucceeded = DeleteDirectoryRobust(fullPath, out string? deleteFailure, out bool deletePermissionDenied);
+                                deleteSucceeded = DeleteDirectoryRobust(
+                                    fullPath,
+                                    out var deleteFailure,
+                                    out var deletePermissionDenied,
+                                    progress =>
+                                    {
+                                        BackupsViewModel.UpdateActiveBackup(
+                                            cardId,
+                                            projectName,
+                                            progress.Percent,
+                                            progress.CurrentPath,
+                                            progress.Detail,
+                                            allowCancel: false,
+                                            destinationLabel: destinationLabel);
+                                    });
                                 if (!deleteSucceeded && string.IsNullOrWhiteSpace(deleteError))
                                     deleteError = deleteFailure ?? AppViewModel.L("Backups.Delete.Error", "Delete failed");
                                 if (deletePermissionDenied)
@@ -164,6 +200,15 @@ namespace VaultSync.UI.ViewModels
                             }
                             else if (File.Exists(fullPath))
                             {
+                                var fileInfo = new FileInfo(fullPath);
+                                BackupsViewModel.UpdateActiveBackup(
+                                    cardId,
+                                    projectName,
+                                    10,
+                                    fileInfo.Name,
+                                    Lf("Backups.Delete.DetailFile", "Deleting file: {0}", BackupSnapshotItem.FormatSize(fileInfo.Length)),
+                                    allowCancel: false,
+                                    destinationLabel: destinationLabel);
                                 File.Delete(fullPath);
                                 deleteSucceeded = !File.Exists(fullPath);
                             }
@@ -691,15 +736,56 @@ namespace VaultSync.UI.ViewModels
         private static bool DeleteDirectoryRobust(string path, out string? error)
             => DeleteDirectoryRobust(path, out error, out _);
 
-        private static bool DeleteDirectoryRobust(string path, out string? error, out bool permissionDenied)
+        private static bool DeleteDirectoryRobust(
+            string path,
+            out string? error,
+            out bool permissionDenied,
+            Action<DeleteDirectoryProgress>? progress = null)
         {
             error = null;
             permissionDenied = false;
             if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path))
                 return true;
 
+            List<string> files;
+            List<string> directories;
+            long totalBytes = 0;
+
+            try
+            {
+                progress?.Invoke(DeleteDirectoryProgress.Scanning(path));
+                files = Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories).ToList();
+                directories = Directory.EnumerateDirectories(path, "*", SearchOption.AllDirectories)
+                    .OrderByDescending(d => d.Length)
+                    .ToList();
+
+                foreach (var file in files)
+                {
+                    try
+                    {
+                        totalBytes += new FileInfo(file).Length;
+                    }
+                    catch
+                    {
+                    }
+                }
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                permissionDenied = true;
+                error = ex.Message;
+                return false;
+            }
+            catch (Exception ex)
+            {
+                error = ex.Message;
+                return false;
+            }
+
+            progress?.Invoke(DeleteDirectoryProgress.Preparing(path, files.Count, totalBytes));
+
             // Clear read-only attributes on files and dirs before deletion.
-            foreach (string file in Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories))
+            foreach (var file in files)
             {
                 try
                 {
@@ -707,17 +793,14 @@ namespace VaultSync.UI.ViewModels
                     if ((attrs & FileAttributes.ReadOnly) != 0)
                         File.SetAttributes(file, attrs & ~FileAttributes.ReadOnly);
                 }
-                catch (UnauthorizedAccessException)
-                {
-                    permissionDenied = true;
-                }
+                catch (UnauthorizedAccessException) { permissionDenied = true; }
                 catch
                 {
                     // ignore individual failures; deletion will surface issues later
                 }
             }
 
-            foreach (string? dir in Directory.EnumerateDirectories(path, "*", SearchOption.AllDirectories).Reverse())
+            foreach (var dir in directories)
             {
                 try
                 {
@@ -725,19 +808,76 @@ namespace VaultSync.UI.ViewModels
                     if ((attrs & FileAttributes.ReadOnly) != 0)
                         File.SetAttributes(dir, attrs & ~FileAttributes.ReadOnly);
                 }
-                catch (UnauthorizedAccessException)
-                {
-                    permissionDenied = true;
-                }
+                catch (UnauthorizedAccessException) { permissionDenied = true; }
                 catch
                 {
-                    // ignore
+                }
+            }
+
+            var deletedFiles = 0;
+            long deletedBytes = 0;
+            var lastProgressUtc = DateTime.MinValue;
+
+            foreach (var file in files)
+            {
+                var fileBytes = 0L;
+                try
+                {
+                    fileBytes = new FileInfo(file).Length;
+                    File.SetAttributes(file, FileAttributes.Normal);
+                    File.Delete(file);
+                    deletedFiles++;
+                    deletedBytes += fileBytes;
+
+                    var now = DateTime.UtcNow;
+                    if (progress is not null &&
+                        (deletedFiles == files.Count || now - lastProgressUtc >= TimeSpan.FromMilliseconds(200)))
+                    {
+                        lastProgressUtc = now;
+                        progress(DeleteDirectoryProgress.Deleting(
+                            file,
+                            deletedFiles,
+                            files.Count,
+                            deletedBytes,
+                            totalBytes));
+                    }
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    permissionDenied = true;
+                    error = ex.Message;
+                }
+                catch (Exception ex)
+                {
+                    error = ex.Message;
+                }
+            }
+
+            progress?.Invoke(DeleteDirectoryProgress.Cleaning(path, deletedFiles, files.Count, deletedBytes, totalBytes));
+
+            foreach (var dir in directories)
+            {
+                try
+                {
+                    if (Directory.Exists(dir))
+                        Directory.Delete(dir, recursive: false);
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    permissionDenied = true;
+                    error = ex.Message;
+                }
+                catch (Exception ex)
+                {
+                    error = ex.Message;
                 }
             }
 
             try
             {
-                Directory.Delete(path, recursive: true);
+                if (Directory.Exists(path))
+                    Directory.Delete(path, recursive: false);
+
                 return !Directory.Exists(path);
             }
             catch (UnauthorizedAccessException ex)
@@ -759,11 +899,81 @@ namespace VaultSync.UI.ViewModels
             }
             catch (Exception ex)
             {
-                if (IsAccessDenied(ex))
-                    permissionDenied = true;
                 error = ex.Message;
                 return false;
             }
+        }
+
+        private sealed record DeleteDirectoryProgress(
+            double Percent,
+            string CurrentPath,
+            string Detail)
+        {
+            private static string L(string key, string fallback) => LStatic(key, fallback);
+
+            private static string Lf(string key, string fallback, params object[] args)
+            {
+                var text = LStatic(key, fallback);
+                return args is { Length: > 0 }
+                    ? string.Format(CultureInfo.CurrentCulture, text, args)
+                    : text;
+            }
+
+            public static DeleteDirectoryProgress Scanning(string path) =>
+                new(
+                    0,
+                    path,
+                    L("Backups.Delete.DetailScanning", "Scanning backup contents..."));
+
+            public static DeleteDirectoryProgress Preparing(string path, int totalFiles, long totalBytes) =>
+                new(
+                    5,
+                    path,
+                    Lf(
+                        "Backups.Delete.DetailPreparing",
+                        "Preparing {0} files, {1} to remove.",
+                        totalFiles,
+                        BackupSnapshotItem.FormatSize(totalBytes)));
+
+            public static DeleteDirectoryProgress Deleting(
+                string currentPath,
+                int deletedFiles,
+                int totalFiles,
+                long deletedBytes,
+                long totalBytes)
+            {
+                var percent = totalFiles <= 0
+                    ? 50
+                    : 5 + (deletedFiles / (double)totalFiles * 85);
+
+                return new(
+                    Math.Clamp(percent, 5, 95),
+                    currentPath,
+                    Lf(
+                        "Backups.Delete.DetailDeleting",
+                        "Deleted {0}/{1} files, {2} of {3}.",
+                        deletedFiles,
+                        totalFiles,
+                        BackupSnapshotItem.FormatSize(deletedBytes),
+                        BackupSnapshotItem.FormatSize(totalBytes)));
+            }
+
+            public static DeleteDirectoryProgress Cleaning(
+                string path,
+                int deletedFiles,
+                int totalFiles,
+                long deletedBytes,
+                long totalBytes) =>
+                new(
+                    96,
+                    path,
+                    Lf(
+                        "Backups.Delete.DetailCleaning",
+                        "Cleaning folders after {0}/{1} files, {2} of {3}.",
+                        deletedFiles,
+                        totalFiles,
+                        BackupSnapshotItem.FormatSize(deletedBytes),
+                        BackupSnapshotItem.FormatSize(totalBytes)));
         }
 
         private static bool TryDeleteDirectoryManually(string path, ref bool permissionDenied, out string? error)

--- a/src/VaultSync.UI/ViewModels/AppViewModel.BackupOrchestration.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.BackupOrchestration.cs
@@ -66,10 +66,6 @@ namespace VaultSync.UI.ViewModels
             });
         }
 
-        /// <summary>
-        /// Resolve the effective backup root to use for a project, honoring preferences for external/NAS paths.
-        /// If the preferred NAS path is unavailable, a temporary backup folder is used next to the project.
-        /// </summary>
         private DestinationResolution PrepareDestination(BackupDestination dest, AppConfig cfg)
         {
             NetworkCredentialProfile? profile = cfg.Network.Credentials?
@@ -98,16 +94,10 @@ namespace VaultSync.UI.ViewModels
             return BackupAllPreparationResult.Success(cfg);
         }
 
-        private sealed record BackupAllPreparationResult(
-            bool IsReady,
-            string? FailureCode,
-            AppConfig? Config)
+        private sealed record BackupAllPreparationResult(bool IsReady, string? FailureCode, AppConfig? Config)
         {
-            public static BackupAllPreparationResult Failure(string reason) =>
-                new(false, reason, null);
-
-            public static BackupAllPreparationResult Success(AppConfig cfg) =>
-                new(true, null, cfg);
+            public static BackupAllPreparationResult Failure(string reason) => new(false, reason, null);
+            public static BackupAllPreparationResult Success(AppConfig cfg) => new(true, null, cfg);
         }
 
         private void ResolveBackupRoots(
@@ -116,36 +106,41 @@ namespace VaultSync.UI.ViewModels
             out string effectiveBackupRoot,
             out string? preferredFinalBackupRoot)
         {
+            BackupSafetyService.EnsureSafeBackupRoot(project, configuredBackupRoot);
+
             effectiveBackupRoot = configuredBackupRoot;
             preferredFinalBackupRoot = null;
 
-            if (_settingsViewModel?.PreferExternalDrives == true &&
-                IsNetworkPath(configuredBackupRoot))
+            if (_settingsViewModel?.PreferExternalDrives == true && IsNetworkPath(configuredBackupRoot))
             {
                 if (Directory.Exists(configuredBackupRoot))
                 {
-                    // If the NAS just came back, try to migrate any temp backups into it.
                     TryMigrateTempBackups(project, configuredBackupRoot);
                 }
                 else
                 {
-                    string tempRoot = Path.Combine(project.RootPath, ".vaultsync-temp-backups");
+                    var tempRoot = BackupSafetyService.GetOfflineStagingRoot(project);
                     Directory.CreateDirectory(tempRoot);
+                    BackupSafetyService.EnsureSafeBackupRoot(project, tempRoot);
 
                     effectiveBackupRoot = tempRoot;
                     preferredFinalBackupRoot = configuredBackupRoot;
                     EnsureNasMonitorStarted();
+                    RuntimeLog.WriteVerbose($"[Backup] Network destination unavailable for project '{project.Name}'. Using safe offline staging root '{tempRoot}'.");
                 }
             }
         }
 
         private static void TryMigrateTempBackups(Project project, string targetRoot)
         {
-            string tempRoot = Path.Combine(project.RootPath, ".vaultsync-temp-backups");
+            TryMigrateTempBackupsFromRoot(BackupSafetyService.GetOfflineStagingRoot(project), targetRoot);
+            TryMigrateTempBackupsFromRoot(BackupSafetyService.GetLegacyProjectTempRoot(project), targetRoot);
+        }
+
+        private static void TryMigrateTempBackupsFromRoot(string tempRoot, string targetRoot)
+        {
             if (!Directory.Exists(tempRoot))
-            {
                 return;
-            }
 
             Directory.CreateDirectory(targetRoot);
 
@@ -155,38 +150,28 @@ namespace VaultSync.UI.ViewModels
 
                 try
                 {
-                    if (Directory.Exists(dest))
-                    {
-                        continue;
-                    }
-
-                    Directory.Move(dir, dest);
+                    if (!Directory.Exists(dest))
+                        Directory.Move(dir, dest);
                 }
                 catch
                 {
-                    // Ignore and continue with other folders.
                 }
             }
 
             try
             {
                 if (!Directory.EnumerateFileSystemEntries(tempRoot).Any())
-                {
                     Directory.Delete(tempRoot, recursive: true);
-                }
             }
             catch
             {
-                // Ignore cleanup failures.
             }
         }
 
         private static bool IsNetworkPath(string path)
         {
             if (string.IsNullOrWhiteSpace(path))
-            {
                 return false;
-            }
 
             return path.StartsWith(@"\\", StringComparison.OrdinalIgnoreCase) ||
                    path.StartsWith(@"//", StringComparison.OrdinalIgnoreCase) ||

--- a/src/VaultSync.UI/ViewModels/AppViewModel.RuntimeOps.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.RuntimeOps.cs
@@ -237,7 +237,7 @@ namespace VaultSync.UI.ViewModels
         {
             try
             {
-                await RefreshMetadataNowAsync();
+                await Task.Run(RefreshMetadataNowAsync).ConfigureAwait(false);
             }
             catch
             {

--- a/src/VaultSync.UI/ViewModels/BackupsViewModel.cs
+++ b/src/VaultSync.UI/ViewModels/BackupsViewModel.cs
@@ -219,6 +219,7 @@ namespace VaultSync.UI.ViewModels
         // Active per-project backup progress items (for running backups)
         public ObservableCollection<BackupProgressItem> ActiveBackups { get; } =
             [];
+        public bool HasActiveBackups => ActiveBackups.Count > 0;
         private readonly DispatcherTimer _activeBackupTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
 
         // Per-destination status for the current backup run
@@ -981,7 +982,7 @@ namespace VaultSync.UI.ViewModels
                 RebuildActiveDestinationStatuses();
             };
             ActiveDestinationStatuses.CollectionChanged += (_, _) => OnPropertyChanged(nameof(HasActiveDestinationStatuses));
-            ActiveBackups.CollectionChanged += (_, _) => UpdateActiveBackupTimer();
+            ActiveBackups.CollectionChanged += (_, _) => OnActiveBackupsCollectionChanged();
             _activeBackupTimer.Tick += (_, _) => TickActiveBackupDurations();
 
             // NOTE:
@@ -994,6 +995,12 @@ namespace VaultSync.UI.ViewModels
             RefreshVerificationPolicyOptions();
             RefreshDestinationOptionsInternal(AppConfigStore.GetSnapshot());
             RefreshProjectSortOptions();
+        }
+
+        private void OnActiveBackupsCollectionChanged()
+        {
+            UpdateActiveBackupTimer();
+            OnPropertyChanged(nameof(HasActiveBackups));
         }
 
         private void UpdateActiveBackupTimer()
@@ -1660,6 +1667,8 @@ namespace VaultSync.UI.ViewModels
             if (string.IsNullOrWhiteSpace(projectId))
                 return;
 
+            _pendingActiveBackupUpdates.TryRemove(projectId, out _);
+
             if (!Dispatcher.UIThread.CheckAccess())
             {
                 Dispatcher.UIThread.Post(() => RemoveActiveBackup(projectId));
@@ -1928,9 +1937,14 @@ namespace VaultSync.UI.ViewModels
         /// <summary>
         /// Shows a non-cancellable transient operation (e.g., deleting a backup) in the active list.
         /// </summary>
-        public void ShowTransientOperation(string operationId, string title, string detail)
+        public void ShowTransientOperation(
+            string operationId,
+            string title,
+            string detail,
+            string etaText = "",
+            string? destinationLabel = null)
         {
-            UpdateActiveBackup(operationId, title, 0, detail, string.Empty, allowCancel: false);
+            UpdateActiveBackup(operationId, title, 0, detail, etaText, allowCancel: false, destinationLabel: destinationLabel);
         }
 
         /// <summary>
@@ -4698,7 +4712,7 @@ namespace VaultSync.UI.ViewModels
 
         public bool ShowPercent => AllowCancel && HasProgress && IsProgressReliable;
 
-        public bool IsIndeterminate => !AllowCancel || !IsProgressReliable || IsStageIndeterminate;
+        public bool IsIndeterminate => !IsProgressReliable || IsStageIndeterminate;
 
         public string ProgressLabel =>
             IsProgressReliable && HasProgress

--- a/src/VaultSync.UI/Views/BackupsView.axaml
+++ b/src/VaultSync.UI/Views/BackupsView.axaml
@@ -948,7 +948,7 @@
         <!-- RUNNING BACKUPS CARD (inline, below summary cards) -->
         <Expander Classes="backup-group"
                   IsExpanded="True"
-                  IsVisible="{Binding IsBusy}">
+                  IsVisible="{Binding HasActiveBackups}">
           <Expander.Header>
             <Grid ColumnDefinitions="*,Auto">
               <StackPanel Grid.Column="0"

--- a/tests/VaultSync.Core.Tests/BackupSafetyServiceTests.cs
+++ b/tests/VaultSync.Core.Tests/BackupSafetyServiceTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.IO;
+using System.Linq;
+using VaultSync.Core.Models;
+using VaultSync.Core.Services;
+using Xunit;
+
+namespace VaultSync.Core.Tests;
+
+public sealed class BackupSafetyServiceTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public BackupSafetyServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"vaultsync-safety-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    [Fact]
+    public void EnsureSafeBackupRoot_BlocksBackupRootInsideProjectRoot()
+    {
+        var projectRoot = Path.Combine(_tempDir, "project");
+        var backupRoot = Path.Combine(projectRoot, ".vaultsync-temp-backups");
+        Directory.CreateDirectory(projectRoot);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            BackupSafetyService.EnsureSafeBackupRoot(projectRoot, backupRoot));
+
+        Assert.Contains("inside the project root", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void EnsureSafeBackupRoot_BlocksProjectRootInsideBackupRoot()
+    {
+        var backupRoot = Path.Combine(_tempDir, "backups");
+        var projectRoot = Path.Combine(backupRoot, "project");
+        Directory.CreateDirectory(projectRoot);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            BackupSafetyService.EnsureSafeBackupRoot(projectRoot, backupRoot));
+
+        Assert.Contains("project root is inside", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void EnsureSafeBackupRoot_BlocksSameDirectory()
+    {
+        var projectRoot = Path.Combine(_tempDir, "project");
+        Directory.CreateDirectory(projectRoot);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            BackupSafetyService.EnsureSafeBackupRoot(projectRoot, projectRoot));
+    }
+
+    [Fact]
+    public void EnsureSafeBackupRoot_AllowsSiblingBackupRoot()
+    {
+        var projectRoot = Path.Combine(_tempDir, "project");
+        var backupRoot = Path.Combine(_tempDir, "backups");
+        Directory.CreateDirectory(projectRoot);
+        Directory.CreateDirectory(backupRoot);
+
+        BackupSafetyService.EnsureSafeBackupRoot(projectRoot, backupRoot);
+    }
+
+    [Fact]
+    public void GetOfflineStagingRoot_IsOutsideProjectRoot()
+    {
+        var projectRoot = Path.Combine(_tempDir, "project");
+        Directory.CreateDirectory(projectRoot);
+        var project = new Project { Id = 42, Name = "Project", RootPath = projectRoot };
+
+        var stagingRoot = BackupSafetyService.GetOfflineStagingRoot(project);
+
+        BackupSafetyService.EnsureSafeBackupRoot(project, stagingRoot);
+        Assert.DoesNotContain(projectRoot, stagingRoot, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void FilterService_AlwaysExcludesVaultSyncBackupArtifacts()
+    {
+        var projectRoot = Path.Combine(_tempDir, "project");
+        var tempBackupDir = Path.Combine(projectRoot, ".vaultsync-temp-backups", "Project", "2026-05-11_10-00-00");
+        var backupsDir = Path.Combine(projectRoot, "Backups", "Project", "2026-05-11_09-00-00");
+        Directory.CreateDirectory(tempBackupDir);
+        Directory.CreateDirectory(backupsDir);
+        File.WriteAllText(Path.Combine(projectRoot, "normal.txt"), "keep");
+        File.WriteAllText(Path.Combine(tempBackupDir, "runaway.bin"), "exclude");
+        File.WriteAllText(Path.Combine(backupsDir, "nested.bin"), "exclude");
+
+        var scanner = new ScannerService(new FilterService(Array.Empty<string>()));
+        var entries = scanner.Scan(projectRoot).Select(entry => entry.Path).ToArray();
+
+        Assert.Contains("normal.txt", entries);
+        Assert.DoesNotContain(entries, path => path.Contains("runaway", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(entries, path => path.Contains("nested", StringComparison.OrdinalIgnoreCase));
+        Assert.Single(entries);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDir))
+                Directory.Delete(_tempDir, recursive: true);
+        }
+        catch
+        {
+        }
+    }
+}

--- a/tests/VaultSync.Core.Tests/BackupSafetyServiceTests.cs
+++ b/tests/VaultSync.Core.Tests/BackupSafetyServiceTests.cs
@@ -69,7 +69,7 @@ public sealed class BackupSafetyServiceTests : IDisposable
     {
         var projectRoot = Path.Combine(_tempDir, "project");
         Directory.CreateDirectory(projectRoot);
-        var project = new Project { Id = 42, Name = "Project", RootPath = projectRoot };
+        var project = new Project { Id = 42, Name = "Project", RootPath = projectRoot, Preset = string.Empty };
 
         var stagingRoot = BackupSafetyService.GetOfflineStagingRoot(project);
 
@@ -90,7 +90,7 @@ public sealed class BackupSafetyServiceTests : IDisposable
         File.WriteAllText(Path.Combine(backupsDir, "nested.bin"), "exclude");
 
         var scanner = new ScannerService(new FilterService(Array.Empty<string>()));
-        var entries = scanner.Scan(projectRoot).Select(entry => entry.Path).ToArray();
+        var entries = scanner.Scan(projectRoot).Select(entry => entry.RelPath).ToArray();
 
         Assert.Contains("normal.txt", entries);
         Assert.DoesNotContain(entries, path => path.Contains("runaway", StringComparison.OrdinalIgnoreCase));

--- a/tests/VaultSync.Core.Tests/MetadataSyncTests.cs
+++ b/tests/VaultSync.Core.Tests/MetadataSyncTests.cs
@@ -421,6 +421,55 @@ public sealed class MetadataSyncTests : IDisposable
     }
 
     [Fact]
+    public void ImportFromStore_FallsBackToProjectsRootWhenRootHintIsVaultSyncTemp()
+    {
+        var metaRoot = CreateTempDir();
+        var dbPath = Path.Combine(CreateTempDir(), "vaultsync.db");
+        var localProjectsRoot = CreateTempDir();
+        var tempImportRoot = Path.Combine(
+            Path.GetTempPath(),
+            "vaultsync-meta-import",
+            Guid.NewGuid().ToString("N"));
+        var tempRootHint = Path.Combine(tempImportRoot, "Temp Root Project");
+        Directory.CreateDirectory(tempRootHint);
+        _tempDirs.Add(tempImportRoot);
+
+        var store = CreateStore(metaRoot);
+        store.UpsertProject(new MetaProject
+        {
+            ExternalId = "proj-temp-root",
+            Name = "Temp Root Project",
+            Preset = "dotnet",
+            RootPathHint = tempRootHint,
+            CreatedUtc = DateTime.UtcNow,
+            SettingsJson = "{}",
+            UpdatedUtc = DateTime.UtcNow
+        });
+
+        var repo = CreateRepository(dbPath);
+        var cfg = AppConfigStore.Load();
+        cfg.ProjectsRoot = localProjectsRoot;
+        AppConfigStore.Save(cfg);
+
+        try
+        {
+            var service = new MetadataSyncService(repo);
+            var result = service.ImportFromStore(metaRoot, new MetadataSyncOptions(true, false));
+
+            Assert.Equal(MetadataSyncStatus.Success, result.Status);
+
+            var project = repo.GetProjectByName("Temp Root Project");
+            Assert.NotNull(project);
+            Assert.Equal(Path.Combine(localProjectsRoot, "Temp Root Project"), project!.RootPath);
+        }
+        finally
+        {
+            cfg.ProjectsRoot = string.Empty;
+            AppConfigStore.Save(cfg);
+        }
+    }
+
+    [Fact]
     public void ImportFromStore_PreservesRootHint_WhenNoLocalMappingIsAvailable()
     {
         string metaRoot = CreateTempDir();


### PR DESCRIPTION
## Summary
- Adds a centralized `BackupSafetyService` for backup source/destination separation checks and reserved VaultSync backup artifact exclusions.
- Moves unavailable-network offline staging from `projectRoot/.vaultsync-temp-backups` to a safe app-data staging root under `~/.vaultsync/pending-backups/<project-id>`.
- Keeps migration support for existing legacy `.vaultsync-temp-backups` folders once the configured destination becomes available.
- Forces `FilterService` to append reserved safety exclusions even when presets or `.vaultsyncignore` do not mention them.
- Changes `ScannerService` to prune reserved backup directories before descending into them, preventing scan-time blowups from nested backup trees.
- Adds a defensive rsync destination overlap guard.
- Improves backup delete operation cards so overlapping deletes remain visible and show destination, target, current file, file counts, and removed bytes.
- Keeps manual metadata refresh/import work off the UI thread and rejects VaultSync transient temp paths as imported project roots.
- Adds regression coverage for destination overlap, safe offline staging, reserved backup scan exclusion, and temp-root metadata imports.

## Why
Issue #277 reports unexpectedly massive backup growth and nested backup folders. Investigation found that unavailable network/external destinations could fall back to a backup root inside the project tree, allowing backup artifacts to be scanned/copied by later runs.

Follow-up validation also found related reliability issues in backup deletion progress and metadata history refresh/root mapping, now tracked as #279, #280, and #281.

## Safety notes
This PR intentionally fails closed for source/destination overlap and makes VaultSync-owned backup artifacts reserved by default. Auto/manual backup flows should never require users to add `.vaultsyncignore` rules to prevent VaultSync from backing up its own backup output.

Fixes #277
Fixes #279
Fixes #280
Fixes #281