### PR TITLE
Prune missing backup entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,41 +2,38 @@
 ## [1.7.4] - Unreleased
 ### Added
 - [VS-1732] Release publish restore now declares Windows, Linux, and macOS RIDs.
-- [VS-1737] Added VS Code Linux debug launch/tasks for the UI, CLI, and full test suite.
-- [VS-1738] Linux tarball releases now include rootless install/uninstall scripts that create a user desktop launcher, icon, and `vaultsync` command across distro families.
-- [VS-1739] CLI JSON-producing commands now share a single indented serializer configuration so config, destination, snapshot, sync, restore, and prune output stays consistent.
-
+- [VS-1737] Added VS Code Linux debug configs for UI, CLI, and tests.
+- [VS-1738] Linux tarballs now include rootless install/uninstall scripts with launcher, icon, and `vaultsync` command setup.
+- [VS-1739] CLI JSON output now uses a shared indented serializer.
 ### Changed
-- [BUG-17119] Startup metadata import now also checks reachable backup destinations.
+- [BUG-17119] Startup metadata import now checks reachable backup destinations.
 - [BUG-17119] UI metadata imports now treat source stores as read-only.
 - [BUG-17120] Core tests now isolate config writes from real app settings.
-- [VS-1724] Patch manifest compatibility tests now cover empty allowlists, build metadata normalization, and prerelease mismatch edge cases.
-- [VS-1739] CLI command implementations were updated for the current Spectre.Console.Cli command override model.
-- [VS-1740] Refreshed the safe dependency set for 1.7.4, including Avalonia 11.3.14, LiveCharts 2.0.2, ReactiveUI 23.2.27, SQLite/ProtectedData/System.Text.Json 10.0.7, Spectre.Console 0.55.x, and the current DBus/test SDK packages.
-
+- [VS-1724] Patch manifest compatibility tests now cover key edge cases.
+- [VS-1739] CLI commands were updated for the current Spectre.Console.Cli override model.
+- [VS-1740] Refreshed the safe dependency set for 1.7.4.
 ### Fixed
-- [BUG-17116] Notification dismiss and auto-dismiss cleanup now avoid disposed-token races, preventing soft crash reports after toast-heavy UI flows.
+- [BUG-17116] Notification cleanup now avoids disposed-token races.
 - [BUG-17118] Log console rows now show readable time, source, and message fields.
 - [BUG-17108] In-app logs now capture runtime errors without verbose logging.
 - [BUG-17115] Windows/Linux tray menus now open the richer tray panel reliably.
 - [BUG-17117] Tray panel action labels now wrap in localized layouts.
 - [BUG-17119] Linux metadata imports now remap rooted backup paths to the active destination.
-- [BUG-17122] Linux debug builds now use an Avalonia/LiveCharts-compatible dependency set, preventing silent startup exits and dashboard chart crashes in local runs.
-- [BUG-17123] Destination metadata imports now recover SQLite sidecar journals through a temporary copy, preventing read-only source stores from importing as empty.
-- [BUG-17124] Destination imports now rebuild missing backup history from timestamped backup folders when metadata backup rows are absent or the store is missing, including Linux-mounted Windows backup roots.
-- [BUG-17125] Destination reachability probes now run during deferred startup instead of waiting for the periodic timer, and locked tombstone exports defer locally for a later retry instead of being dropped.
-- [BUG-17126] Crash dialog chrome now uses Avalonia 11's `SystemDecorations` API, restoring clean builds after the dependency refresh.
-- [BUG-17127] Onboarding's manual test hook now keeps the environment-variable override reachable without producing unreachable-code diagnostics.
-- [BUG-17128] System notification service creation now records fallback exceptions instead of swallowing an empty catch.
-- [BUG-17129] Drive health checks now prefer `smartctl` when available across platforms and avoid surfacing SMART health rows for network destinations where local drive data is unavailable.
-- [BUG-17130] Metadata tombstone exports now treat Linux mount roots as network-style SQLite stores, avoiding WAL locks on mounted backup destinations.
-- [BUG-18002] The log console now formats live diagnostics into readable time/source/message rows with fixed color-coded source chips while keeping raw lines available for copy and export.
-- [BUG-17108] The in-app log console now captures live output when opened and mirrors diagnostics-session errors, so runtime failures are visible without enabling verbose logging first.
-- [BUG-17115] Windows/Linux tray right-click now uses a compact native menu that opens the richer tray panel instead of fragile nested submenus, making tray actions selectable on Linux desktop environments.
-- [BUG-18001] Tray panel action buttons now wrap localized labels within the fixed popover width, preventing longer non-English text from clipping or overflowing.
-- [BUG-18003] Backup safety now blocks source/destination overlap, keeps offline staging outside project trees, and always excludes VaultSync-owned backup artifacts from scans to prevent recursive backup growth. Refs #281.
-- [BUG-18004] Backup delete cards now stay visible while overlapping deletes continue and show destination, target, current file, file counts, and removed bytes during deletion. Refs #279.
-- [BUG-18005] Manual metadata refresh now keeps import work off the UI thread and ignores VaultSync temporary root hints, preventing Refresh History hangs and temp-root project mappings. Refs #280.
+- [BUG-17122] Linux debug builds no longer silently exit or crash dashboard charts.
+- [BUG-17123] Destination metadata imports now recover SQLite sidecar journals through a temporary copy.
+- [BUG-17124] Destination imports now rebuild missing backup history from timestamped folders.
+- [BUG-17125] Destination reachability probes now run during deferred startup.
+- [BUG-17125] Locked tombstone exports now defer locally for retry instead of being dropped.
+- [BUG-17126] Crash dialog chrome now uses Avalonia 11 `SystemDecorations`.
+- [BUG-17127] Onboarding’s manual test hook no longer causes unreachable-code diagnostics.
+- [BUG-17128] System notification fallback exceptions are now logged.
+- [BUG-17129] Drive health checks now prefer `smartctl` and skip unavailable network-drive SMART data.
+- [BUG-17130] Metadata tombstone exports now avoid WAL locks on Linux-mounted backup destinations.
+- [BUG-18002] Log console diagnostics now display readable, color-coded rows while preserving raw lines.
+- [BUG-18003] Backup safety now blocks source/destination overlap and recursive backup growth. Refs #281.
+- [BUG-18004] Backup delete cards now stay visible and show deletion progress details. Refs #279.
+- [BUG-18005] Manual metadata refresh no longer hangs the UI or maps temporary roots. Refs #280.
+- [BUG-18006] Backups now prune stale database entries when recorded backup folders are missing from reachable destinations. Refs #283.
 
 ## [1.7.3] - 23.04.2026
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - [BUG-18004] Backup delete cards now stay visible and show deletion progress details. Refs #279.
 - [BUG-18005] Manual metadata refresh no longer hangs the UI or maps temporary roots. Refs #280.
 - [BUG-18006] Backups now prune stale database entries when recorded backup folders are missing from reachable destinations. Refs #284.
+- [BUG-18007] Backup probes now share in-flight buffer tuning and Avalonia presets skip nested build outputs. Refs #285.
 
 ## [1.7.3] - 23.04.2026
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 - [BUG-18004] Backup delete cards now stay visible and show deletion progress details. Refs #279.
 - [BUG-18005] Manual metadata refresh no longer hangs the UI or maps temporary roots. Refs #280.
 - [BUG-18006] Backups now prune stale database entries when recorded backup folders are missing from reachable destinations. Refs #284.
-- [BUG-18007] Backup probes now share in-flight buffer tuning and Avalonia presets skip nested build outputs. Refs #285.
+- [BUG-18007] Backup probes now share in-flight buffer tuning and dev presets skip nested generated outputs. Refs #285.
 
 ## [1.7.3] - 23.04.2026
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - [BUG-18005] Manual metadata refresh no longer hangs the UI or maps temporary roots. Refs #280.
 - [BUG-18006] Backups now prune stale database entries when recorded backup folders are missing from reachable destinations. Refs #284.
 - [BUG-18007] Backup probes now share in-flight buffer tuning and dev presets skip nested generated outputs. Refs #285.
+- [BUG-18008] Passive Backups refreshes no longer wake destinations just to update reachability. Refs #286.
 
 ## [1.7.3] - 23.04.2026
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 - [BUG-18003] Backup safety now blocks source/destination overlap and recursive backup growth. Refs #281.
 - [BUG-18004] Backup delete cards now stay visible and show deletion progress details. Refs #279.
 - [BUG-18005] Manual metadata refresh no longer hangs the UI or maps temporary roots. Refs #280.
-- [BUG-18006] Backups now prune stale database entries when recorded backup folders are missing from reachable destinations. Refs #283.
+- [BUG-18006] Backups now prune stale database entries when recorded backup folders are missing from reachable destinations. Refs #284.
 
 ## [1.7.3] - 23.04.2026
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1032,6 +1032,19 @@
   - Acceptance:
     - Manually deleted backup folders disappear from the Backups page after the destination is reachable and the page refreshes.
     - Offline destinations do not lose history entries during refresh.
+- [x] `BUG-18007` `P2` Reduce duplicate destination probe work and nested Avalonia output scans. _(Done in PR #283, issue #285; completed 2026-05-13)_
+  - Scope: coalesce archive upload buffer auto-tune work per destination and tighten the Avalonia preset around nested generated output.
+  - What it takes:
+    - share an in-flight archive upload buffer probe when parallel backups target the same destination.
+    - cache the timeout fallback buffer so later backups do not repeat the same slow probe.
+    - exclude nested `bin`, `obj`, test-result, artifact, and package outputs from Avalonia project scans.
+  - Current status:
+    - Done: destination buffer tuning now uses a single lazy in-flight task per destination.
+    - Done: timed-out probes persist the fallback buffer.
+    - Done: Avalonia preset exclusions cover nested build/package outputs, with scanner regression coverage.
+  - Acceptance:
+    - parallel backup startup emits one archive buffer tune attempt per destination instead of duplicate timeout probes.
+    - nested Avalonia build outputs are not included in new snapshots.
 - [x] `VS-1713` `P1` Restore-readiness scorecard in Backups and Dashboard. _(Done)_
   - Scope: add an at-a-glance restore-readiness status using last backup recency, verification recency, destination reachability, and unresolved integrity warnings.
   - What it takes:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1020,6 +1020,18 @@
   - Acceptance:
     - Re-adding the same destination path/identity preserves project routing and history linkage where exact identity matches.
     - Mismatch cases are reported with explicit remediation guidance.
+- [x] `BUG-18006` `P1` Backups page stale-entry pruning for manually deleted destination backups. _(Done)_
+  - Scope: when the Backups page reloads, remove local database entries whose recorded backup path is missing from a reachable active destination.
+  - What it takes:
+    - resolve only active destinations that pass reachability checks, including configured credentials/mount behavior.
+    - validate recorded relative backup paths remain under the resolved destination root before trusting them for cleanup.
+    - leave offline, unresolved, or destination-mismatched histories untouched so disconnected drives are not mistaken for deleted backups.
+  - Current status:
+    - Done: Backups reload prunes missing backup rows before shaping the page cache and refreshes the history data afterward.
+    - Done: orphan snapshots are cleaned when the pruned backup was their last reference.
+  - Acceptance:
+    - Manually deleted backup folders disappear from the Backups page after the destination is reachable and the page refreshes.
+    - Offline destinations do not lose history entries during refresh.
 - [x] `VS-1713` `P1` Restore-readiness scorecard in Backups and Dashboard. _(Done)_
   - Scope: add an at-a-glance restore-readiness status using last backup recency, verification recency, destination reachability, and unresolved integrity warnings.
   - What it takes:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1046,16 +1046,17 @@
     - parallel backup startup emits one archive buffer tune attempt per destination instead of duplicate timeout probes.
     - nested generated outputs are not included in new snapshots for common development presets.
 - [x] `BUG-18008` `P1` Avoid waking destinations for passive status checks. _(Done in PR #283, issue #286; completed 2026-05-13)_
-  - Scope: make destination reachability updates opportunistic from backup execution and manual tests instead of startup/page-refresh probes.
+  - Scope: run one deferred startup reachability probe, then update destinations only from backup execution and manual tests.
   - What it takes:
-    - stop scheduling startup and periodic destination reachability tests from the Backups overview path.
+    - stop scheduling periodic destination reachability tests from the Backups overview path.
     - keep cached destination status updated when backup execution already prepares a destination.
     - run stale backup-entry cleanup only against a destination that backup execution has already prepared.
   - Current status:
     - Done: passive Backups refresh no longer resolves destinations or scans destination roots.
+    - Done: deferred startup runs a single destination probe and does not start a recurring probe timer.
     - Done: backup preparation updates cached destination status and runs safe stale-entry cleanup for that prepared root.
   - Acceptance:
-    - opening the Backups page or leaving the app idle does not wake sleeping backup destinations for reachability checks.
+    - after the startup probe, opening the Backups page or leaving the app idle does not wake sleeping backup destinations for reachability checks.
     - backup runs still fail fast and visibly when their destination cannot be prepared.
 - [x] `VS-1713` `P1` Restore-readiness scorecard in Backups and Dashboard. _(Done)_
   - Scope: add an at-a-glance restore-readiness status using last backup recency, verification recency, destination reachability, and unresolved integrity warnings.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -936,9 +936,9 @@
     - classify findings as `warning`, `repairable`, `critical`.
     - cache last scan summary so UI can show status without rescanning synchronously.
   - Current status:
-    - In progress: first pass now runs as a deferred startup task after metadata auto-import and before update checks.
-    - In progress: initial scan covers missing/duplicate external IDs plus snapshot/project/backup relationship mismatches, with runtime diagnostics summary state in `AppViewModel`.
-    - In progress: findings now emit deterministic samples and persist a lightweight last-scan summary for support-bundle reuse.
+    - Done: first pass now runs as a deferred startup task after metadata auto-import and before update checks.
+    - Done: initial scan covers missing/duplicate external IDs plus snapshot/project/backup relationship mismatches, with runtime diagnostics summary state in `AppViewModel`.
+    - Done: findings now emit deterministic samples and persist a lightweight last-scan summary for support-bundle reuse.
   - Acceptance:
     - Startup scan surfaces actionable warnings without blocking app launch.
     - Scan output is available in diagnostics/support bundle.
@@ -949,9 +949,9 @@
     - add operator-facing diagnostics surface and support-bundle export.
     - keep messages user-readable without exposing internal-only noise by default.
   - Current status:
-    - In progress: update checks now persist channel/decision/candidate diagnostics alongside the selected release result.
-    - In progress: Settings > Advanced now surfaces the persisted diagnostics summary next to the existing update status block.
-    - In progress: support bundles now export the same redacted update diagnostics so release-target decisions can be inspected off-box.
+    - Done: update checks now persist channel/decision/candidate diagnostics alongside the selected release result.
+    - Done: Settings > Advanced now surfaces the persisted diagnostics summary next to the existing update status block.
+    - Done: support bundles now export the same redacted update diagnostics so release-target decisions can be inspected off-box.
   - Acceptance:
     - Support diagnostics clearly show selected candidate release and why.
     - Channel mismatch scenarios are visible to operators without debug builds.
@@ -979,9 +979,9 @@
     - extend support-bundle schema with stable redacted sections for updater/repair outcomes.
     - version the schema so support tooling can rely on field names across minor releases.
   - Current status:
-    - In progress: support bundles now export persisted updater decision traces and patch-preflight eligibility results from advanced config.
-    - In progress: doctor repair dry-run/apply flows now persist lightweight repair telemetry (actions, blocked buckets, codes, last apply state) for support exports.
-    - In progress: metadata conflict tracking now persists conflict-resolution telemetry and exports pending conflict summaries for cross-machine triage.
+    - Done: support bundles now export persisted updater decision traces and patch-preflight eligibility results from advanced config.
+    - Done: doctor repair dry-run/apply flows now persist lightweight repair telemetry (actions, blocked buckets, codes, last apply state) for support exports.
+    - Done: metadata conflict tracking now persists conflict-resolution telemetry and exports pending conflict summaries for cross-machine triage.
   - Acceptance:
     - New telemetry sections are redacted and stable for support use.
 - [x] `VS-1710` `P2` Scheduled maintenance window jobs. _(Done)_
@@ -991,8 +991,8 @@
     - job history/logging so maintenance is explainable and non-silent.
     - opt-in defaults only; no surprise background mutation on upgrade.
   - Current status:
-    - In progress: Settings > Advanced now exposes an opt-in maintenance window with per-task toggles for consistency scan, repair dry-run, and metadata refresh.
-    - In progress: App startup/settings reload now wire a maintenance timer that runs only inside the configured window and records last-run status in advanced config.
+    - Done: Settings > Advanced now exposes an opt-in maintenance window with per-task toggles for consistency scan, repair dry-run, and metadata refresh.
+    - Done: App startup/settings reload now wire a maintenance timer that runs only inside the configured window and records last-run status in advanced config.
   - Acceptance:
     - Maintenance jobs run only within configured windows and emit clear run summaries.
 - [x] `VS-1711` `P0` Backup chain preflight before retention prune. _(Done)_
@@ -1002,7 +1002,7 @@
     - integrate with retention planner before delete execution, not after.
     - emit clear block reasons when prune would violate restore safety.
   - Current status:
-    - In progress: retention now simulates prune candidates and blocks when deletion would remove the last metadata-valid restore point for the project.
+    - Done: retention now simulates prune candidates and blocks when deletion would remove the last metadata-valid restore point for the project.
   - Depends on:
     - `VS-1706` consistency scan.
   - Acceptance:
@@ -1070,8 +1070,8 @@
     - Timeline is available in diagnostics and support bundle.
     - Normal startup path remains non-blocking.
   - Current status:
-    - In progress: startup now records stable constructor/deferred-startup phase checkpoints and persists the latest timeline summary in advanced config.
-    - In progress: Settings diagnostics and support bundles now surface the last startup timeline with total duration and per-phase elapsed milliseconds.
+    - Done: startup now records stable constructor/deferred-startup phase checkpoints and persists the latest timeline summary in advanced config.
+    - Done: Settings diagnostics and support bundles now surface the last startup timeline with total duration and per-phase elapsed milliseconds.
 - [x] `VS-1716` `P2` Retention simulation mode in settings. _(Done)_
     - Scope: preview retention outcomes per project/destination without deleting data.
     - What it takes:
@@ -1103,9 +1103,9 @@
     - one scripted gate command with machine-readable + human-readable output.
     - GitHub/project/release-asset queries wired into a deterministic checklist.
   - Current status:
-    - In progress: added `scripts/release_readiness_gate.ps1` to validate UI/installer version parity, unreleased changelog alignment, What's New version alignment, release asset presence, and project-board completion for the target release slice.
-    - In progress: release docs now point to the gate command as part of the release checklist.
-    - In progress: gate now distinguishes `PrePublish` vs `PostPublish` verification so asset-generation steps are emitted as warnings before upload and hard-fail only during final release verification.
+    - Done: added `scripts/release_readiness_gate.ps1` to validate UI/installer version parity, unreleased changelog alignment, What's New version alignment, release asset presence, and project-board completion for the target release slice.
+    - Done: release docs now point to the gate command as part of the release checklist.
+    - Done: gate now distinguishes `PrePublish` vs `PostPublish` verification so asset-generation steps are emitted as warnings before upload and hard-fail only during final release verification.
   - Acceptance:
     - One command emits pass/fail with actionable errors.
     - Gate output is attachable to release notes/support workflows.
@@ -1144,14 +1144,14 @@
 - [x] `BUG-17001` `P1` Doctor workflow command-state thread affinity fix. _(Done)_
   - Scope: ensure detached Doctor scan/apply/conflict actions marshal command-state and bound status updates onto the UI thread.
   - Current status:
-    - In progress: backup repair and metadata-conflict flows now dispatch busy-state, status, notification, and command refresh updates through Avalonia's UI thread.
+    - Done: backup repair and metadata-conflict flows now dispatch busy-state, status, notification, and command refresh updates through Avalonia's UI thread.
   - Acceptance:
     - Doctor workflows no longer emit `Call from invalid thread` traces during dry-run/apply operations.
 
 - [x] `BUG-17002` `P1` Restore corrupted bundled UI font assets. _(Done)_
   - Scope: replace invalid bundled `.ttf` placeholders with valid Noto Sans binaries so the shipped font pack is deterministic across machines.
   - Current status:
-    - In progress: corrupted `NotoSans*` and `NotoSansArabic*` placeholder assets have been replaced with valid binaries so Avalonia stops ingesting HTML masquerading as font files.
+    - Done: corrupted `NotoSans*` and `NotoSansArabic*` placeholder assets have been replaced with valid binaries so Avalonia stops ingesting HTML masquerading as font files.
   - Acceptance:
     - bundled font assets open as valid font binaries instead of text/HTML payloads.
     - UI text rendering no longer depends on unpredictable system fallback caused by broken embedded assets.
@@ -1159,8 +1159,8 @@
 - [x] `BUG-17003` `P1` Projects page discovery fallback when filesystem scan is empty. _(Done)_
   - Scope: keep the Projects page populated from registered database projects when directory discovery returns no items or misses known projects.
   - Current status:
-    - In progress: registered projects are now merged into the Projects page source list so tracked entries still render when folder discovery is unavailable or partial.
-    - In progress: Projects now render explicit empty-state and no-selection placeholders instead of leaving the list/detail panes visually broken when scan results or selection state are empty.
+    - Done: registered projects are now merged into the Projects page source list so tracked entries still render when folder discovery is unavailable or partial.
+    - Done: Projects now render explicit empty-state and no-selection placeholders instead of leaving the list/detail panes visually broken when scan results or selection state are empty.
   - Acceptance:
     - Projects page no longer appears blank just because discovery root scanning returned zero items.
     - Registered projects remain visible and selectable from stored metadata paths.
@@ -1168,8 +1168,8 @@
 - [x] `BUG-17004` `P1` Preserve Projects root across startup config read/write races. _(Done)_
   - Scope: stop `Projects root` from clearing itself across restarts when config reads race startup writes or transiently deserialize invalid/partial JSON.
   - Current status:
-    - In progress: config writes now use temp-file replace semantics with a backup file, and config loads fall back to backup/last-known-good snapshots before defaulting to empty values.
-    - In progress: safeguard is being verified against unreachable destination/startup stress scenarios so unrelated config saves cannot persist a blank projects root.
+    - Done: config writes now use temp-file replace semantics with a backup file, and config loads fall back to backup/last-known-good snapshots before defaulting to empty values.
+    - Done: safeguard was verified against unreachable destination/startup stress scenarios so unrelated config saves cannot persist a blank projects root.
   - Acceptance:
     - `Projects root` persists across restart even if startup writes happen while the destination is unreachable or config reads are transiently busy.
     - transient config read failures no longer downgrade the in-memory config to defaults and then overwrite the saved root path.
@@ -1527,18 +1527,18 @@
   - Acceptance:
     - enabling checkpointed retry no longer silently disables parallel archive uploads
     - interrupted parallel uploads can resume safely without re-sending already validated chunks
-- [ ] `BUG-17104` `P1` Keep Settings `Projects root` synchronized after config reloads in the cached Settings view.
+- [x] `BUG-17104` `P1` Keep Settings `Projects root` synchronized after config reloads in the cached Settings view. _(Done in PR #222, issue #227; completed 2026-04-18)_
   - Scope: ensure `LoadFromConfig()` refreshes visible Settings fields reliably, avoids reload-time autosave churn, and keeps the persisted `ProjectsRoot` value visible after navigation or startup reloads.
   - Current status:
-    - In progress: implemented on PR `#222`.
+    - Done: implemented on PR `#222`.
     - Issue `#227` tracks the regression report and expected behavior.
   - Acceptance:
     - Settings no longer shows `Projects root` as blank when the config file still contains a valid value
     - reload-time field refreshes do not trigger spurious saves
-- [ ] `BUG-17105` `P1` Repair blank project roots during startup when the project folder still exists under `ProjectsRoot`.
+- [x] `BUG-17105` `P1` Repair blank project roots during startup when the project folder still exists under `ProjectsRoot`. _(Done in PR #222, issue #228; completed 2026-04-18)_
   - Scope: reconcile blank `RootPath` values after startup initialization, repair from `ProjectsRoot\\ProjectName` when present, and prefer project-id-based updates where available.
   - Current status:
-    - In progress: implemented on PR `#222`.
+    - Done: implemented on PR `#222`.
     - Issue `#228` tracks the startup repair gap.
   - Acceptance:
     - projects with recoverable blank roots are repaired during startup without waiting for backup/restore flows
@@ -1551,10 +1551,11 @@
   - Acceptance:
     - the log console exposes an explicit auto-scroll toggle
     - users can copy the selected log line from the UI and with the platform shortcut
-- [ ] `BUG-17107` `P1` Preserve `Read-only` destination status for Linux paths that fail real write access.
+- [x] `BUG-17107` `P1` Preserve `Read-only` destination status for Linux paths that fail real write access. _(Done in PR #236, issue #230; completed 2026-04-21)_
   - Scope: replace the Linux-unreliable read-only heuristic in background destination probes with a real writability check, and preserve read-only warning state instead of collapsing it back to green reachable success on status refresh.
   - Current status:
-    - Reported via issue `#230`: `chmod 555` paths can flip from `Read-only` back to green `Reachable` during background/status refresh even though backups still fail with write denial.
+    - Done: implemented on PR `#236`.
+    - Issue `#230` tracked the `chmod 555` read-only refresh regression.
   - Acceptance:
     - Linux read-only destinations stay visibly `Read-only` during background and navigation refreshes
     - status refresh paths preserve warning/read-only state instead of repainting it as success
@@ -1566,18 +1567,18 @@
   - Acceptance:
     - reproducible runtime errors appear in the in-app log console without requiring an external terminal
     - log console coverage is consistent for handled and surfaced error paths on supported desktop targets
-- [ ] `BUG-17109` `P1` Fix destination status localization staying stale after navigation with cached views.
+- [x] `BUG-17109` `P1` Fix destination status localization staying stale after navigation with cached views. _(Done in PR #222, issue #223; completed 2026-04-18)_
   - Scope: keep destination status state in invariant internal keys, localize only at display time, and force destination-status refreshes when localization changes so cached navigation does not resurrect stale-language labels.
   - Current status:
-    - Reported via issue `#223`.
-    - Related work lives on PR `#222`.
+    - Done: implemented on PR `#222`.
+    - Issue `#223` tracked the cached-view localization regression.
   - Acceptance:
     - destination status cards always render in the active UI language after navigation and menu reopen flows
     - cached view reuse does not keep stale localized destination labels alive
-- [ ] `VS-1732` `P1` Add Linux release assets and architecture-aware patch packaging to the release workflow.
+- [x] `VS-1732` `P1` Add Linux release assets and architecture-aware patch packaging to the release workflow. _(Done in PR #233, issue #232; completed 2026-04-18)_
   - Scope: build Linux `tar.gz` assets for `x64` and `arm64`, produce a desktop-friendly `linux-x64` AppImage, generate Linux patch assets, and make updater asset selection architecture-aware.
   - Current status:
-    - In progress: workflow, updater, and docs changes are prepared locally on `Dev`.
+    - Done: implemented on PR `#233`.
     - Issue `#232` tracks the release-asset work item.
   - Acceptance:
     - release-assets workflow uploads Linux install artifacts and Linux patch assets
@@ -1628,16 +1629,18 @@
   - Acceptance:
     - test runs use a temporary config directory unless `VAULTSYNC_CONFIG_DIR` is explicitly provided.
     - running metadata/config tests no longer changes the visible Projects root in a developer app install.
-- [ ] `BUG-17121` `P2` Separate imported origin from manual/auto trigger counts.
+- [x] `BUG-17121` `P2` Separate imported origin from manual/auto trigger counts. _(Done in PR #263, issue #261; completed 2026-05-12)_
   - Scope: adjust Backups summaries and activity charts so imported restore points are not misleadingly double-counted as both imported and manual/auto totals.
   - Current status:
+    - Done: implemented on PR `#263`.
     - Issue `#261` tracks the follow-up from the import/history audit.
   - Acceptance:
     - Backups totals make origin (`Local`/`Imported`) distinct from trigger (`Manual`/`Auto`).
     - summary counts are internally consistent for mixed local/imported history.
-- [ ] `VS-1731` `P1` Versioned backup history with imported timestamps and file-change identity.
+- [x] `VS-1731` `P1` Versioned backup history with imported timestamps and file-change identity. _(Done in PR #263, issue #262; completed 2026-05-12)_
   - Scope: add explicit version/history identity fields so backup history can lead with restore-point version and file-change deltas instead of relying primarily on source timestamps.
   - Current status:
+    - Done: implemented on PR `#263`.
     - Issue `#262` tracks the design and implementation plan.
   - Acceptance:
     - history can show per-project restore-point versions alongside added/modified/deleted/net-size changes.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1032,19 +1032,19 @@
   - Acceptance:
     - Manually deleted backup folders disappear from the Backups page after the destination is reachable and the page refreshes.
     - Offline destinations do not lose history entries during refresh.
-- [x] `BUG-18007` `P2` Reduce duplicate destination probe work and nested Avalonia output scans. _(Done in PR #283, issue #285; completed 2026-05-13)_
-  - Scope: coalesce archive upload buffer auto-tune work per destination and tighten the Avalonia preset around nested generated output.
+- [x] `BUG-18007` `P2` Reduce duplicate destination probe work and nested generated-output scans. _(Done in PR #283, issue #285; completed 2026-05-13)_
+  - Scope: coalesce archive upload buffer auto-tune work per destination and tighten development presets around nested generated output.
   - What it takes:
     - share an in-flight archive upload buffer probe when parallel backups target the same destination.
     - cache the timeout fallback buffer so later backups do not repeat the same slow probe.
-    - exclude nested `bin`, `obj`, test-result, artifact, and package outputs from Avalonia project scans.
+    - exclude nested build, dependency, test-result, artifact, package, and cache outputs from development project scans.
   - Current status:
     - Done: destination buffer tuning now uses a single lazy in-flight task per destination.
     - Done: timed-out probes persist the fallback buffer.
-    - Done: Avalonia preset exclusions cover nested build/package outputs, with scanner regression coverage.
+    - Done: development preset exclusions cover nested generated outputs, with scanner regression coverage.
   - Acceptance:
     - parallel backup startup emits one archive buffer tune attempt per destination instead of duplicate timeout probes.
-    - nested Avalonia build outputs are not included in new snapshots.
+    - nested generated outputs are not included in new snapshots for common development presets.
 - [x] `VS-1713` `P1` Restore-readiness scorecard in Backups and Dashboard. _(Done)_
   - Scope: add an at-a-glance restore-readiness status using last backup recency, verification recency, destination reachability, and unresolved integrity warnings.
   - What it takes:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1045,6 +1045,18 @@
   - Acceptance:
     - parallel backup startup emits one archive buffer tune attempt per destination instead of duplicate timeout probes.
     - nested generated outputs are not included in new snapshots for common development presets.
+- [x] `BUG-18008` `P1` Avoid waking destinations for passive status checks. _(Done in PR #283, issue #286; completed 2026-05-13)_
+  - Scope: make destination reachability updates opportunistic from backup execution and manual tests instead of startup/page-refresh probes.
+  - What it takes:
+    - stop scheduling startup and periodic destination reachability tests from the Backups overview path.
+    - keep cached destination status updated when backup execution already prepares a destination.
+    - run stale backup-entry cleanup only against a destination that backup execution has already prepared.
+  - Current status:
+    - Done: passive Backups refresh no longer resolves destinations or scans destination roots.
+    - Done: backup preparation updates cached destination status and runs safe stale-entry cleanup for that prepared root.
+  - Acceptance:
+    - opening the Backups page or leaving the app idle does not wake sleeping backup destinations for reachability checks.
+    - backup runs still fail fast and visibly when their destination cannot be prepared.
 - [x] `VS-1713` `P1` Restore-readiness scorecard in Backups and Dashboard. _(Done)_
   - Scope: add an at-a-glance restore-readiness status using last backup recency, verification recency, destination reachability, and unresolved integrity warnings.
   - What it takes:

--- a/docs/wiki/Backups.md
+++ b/docs/wiki/Backups.md
@@ -36,6 +36,7 @@ Archive-mode retries can resume from validated checkpoints when the destination 
 ## Delete and permissions
 - If a delete fails due to permissions, VaultSync can prompt for credentials to retry.
 - Read-only destinations can be imported from, but writes and deletes require permission.
+- If backup folders are manually removed outside the app, the Backups page prunes the stale local history entries only after the matching active destination is reachable.
 
 ## Where backups are stored
 - Simple mode: under the single backup root path.
@@ -55,5 +56,6 @@ Notes:
 - This sync is metadata-only; files are restored only when you choose to restore.
 - Read-only destinations can be imported from, but VaultSync will not write updates.
 - Destination scans can import untracked backups into history when enabled.
+- Destination refreshes can also remove local history entries for recorded backup paths that no longer exist, but only for reachable active destinations.
 - If a destination has partial history, enable `Force full history export` on that destination and run a backup to backfill the store.
 - If imported settings conflict with local project settings, review them in Settings > Advanced > Doctor instead of silently overwriting one side.

--- a/docs/wiki/Troubleshooting.md
+++ b/docs/wiki/Troubleshooting.md
@@ -16,6 +16,11 @@
 - VaultSync can prompt for credentials if a delete fails; use a one-time admin or root user only when required.
 - On Windows SMB, disconnect existing connections using different credentials before retrying.
 
+## Deleted backup still appears in history
+- Open the Backups page while the destination is reachable.
+- VaultSync removes stale local history entries only after it can resolve the matching active destination and confirm the recorded backup path is gone.
+- If the destination is offline or no longer configured, the entry is preserved to avoid losing valid history for disconnected drives.
+
 ## Update banner stuck
 - Click Close on the banner.
 - Run `Check for updates now` in Settings > Advanced.

--- a/src/VaultSync.CLI/VaultSync.CLI.csproj
+++ b/src/VaultSync.CLI/VaultSync.CLI.csproj
@@ -43,7 +43,7 @@
 
   <ItemGroup>
     <!-- Ensure README is included in the package -->
-    <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VaultSync.UI/ViewModels/AppViewModel.BackupOrchestration.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.BackupOrchestration.cs
@@ -74,6 +74,15 @@ namespace VaultSync.UI.ViewModels
 
             DestinationResolution resolution = _networkMountService.PrepareDestination(dest, profile);
             RuntimeLog.WriteVerbose($"[Backup] Destination resolved: alias='{dest.Alias ?? dest.Path}', path='{dest.Path}', effective='{resolution.EffectivePath}', success={resolution.IsSuccess}, mountedByUs={resolution.MountedByUs}");
+            UpdateDestinationProbeSummary(dest, new DestinationTestResult(
+                resolution.IsSuccess,
+                resolution.IsSuccess,
+                resolution.EffectivePath,
+                resolution.Message));
+
+            if (resolution.IsSuccess && !string.IsNullOrWhiteSpace(resolution.EffectivePath))
+                PruneMissingBackupsFromPreparedDestination(dest, resolution.EffectivePath, cfg);
+
             return resolution;
         }
 

--- a/src/VaultSync.UI/ViewModels/AppViewModel.ConfigurationOps.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.ConfigurationOps.cs
@@ -286,16 +286,6 @@ namespace VaultSync.UI.ViewModels
                         ? [.. _repo.GetRecentBackupsByProject(limitPerProject: 5)]
                         : [.. _repo.GetBackupsInRange(DateTime.MinValue, DateTime.UtcNow)];
 
-                    if (onBackupsPage || force)
-                    {
-                        int pruned = PruneMissingBackupsFromReachableDestinations(backups);
-                        if (pruned > 0)
-                        {
-                            backups = [.. _repo.GetBackupsInRange(DateTime.MinValue, DateTime.UtcNow)];
-                            useLightweight = false;
-                        }
-                    }
-
                     HashSet<int> disabledAuto = _config.Backups.AutoBackupDisabledProjects?.ToHashSet() ?? [];
 
                     _backupsCacheProjects = projects;
@@ -313,30 +303,8 @@ namespace VaultSync.UI.ViewModels
                         }
                     });
 
-                    if (onBackupsPage || force)
-                    {
-                        if (backups.Count > 0)
-                        {
-                            int scanAdded = ScanDestinationsForUntrackedBackups(projects, backups);
-                            if (scanAdded > 0)
-                            {
-                                backups = [.. _repo.GetBackupsInRange(DateTime.MinValue, DateTime.UtcNow)];
-                                useLightweight = false;
-                                _backupsCacheBackups = backups;
-                                _backupsCachePartial = useLightweight;
-                                _backupsCacheUpdatedUtc = DateTime.UtcNow;
-
-                                Dispatcher.UIThread.Post(() =>
-                                {
-                                    if (onBackupsPage || force)
-                                    {
-                                        BackupsViewModel.LoadFromBackups(projects, backups, disabledAuto);
-                                        BackupsViewModel.RefreshBackupDriveHealth();
-                                    }
-                                });
-                            }
-                        }
-                    }
+                    // Destination reconciliation runs when a backup has already prepared the destination.
+                    // Backups-page refresh should not wake sleeping disks or network shares just to test status.
                 }
                 finally
                 {
@@ -359,61 +327,42 @@ namespace VaultSync.UI.ViewModels
             return new BackupProjectPreparation(cfg, selection.Destinations, project, selection.WarningMessage, selection.WarningCode);
         }
 
-        private int PruneMissingBackupsFromReachableDestinations(List<Backup> backups)
+        private int PruneMissingBackupsFromPreparedDestination(BackupDestination dest, string effectivePath, AppConfig cfg)
         {
+            if (string.IsNullOrWhiteSpace(effectivePath))
+                return 0;
+
+            List<Backup> backups = [.. _repo.GetBackupsInRange(DateTime.MinValue, DateTime.UtcNow)];
             if (backups.Count == 0)
                 return 0;
 
-            AppConfig cfg = _config;
             List<BackupDestination> destinations = AppViewModel.GetActiveDestinations(cfg);
             if (destinations.Count == 0)
                 return 0;
 
             int removed = 0;
-            foreach (BackupDestination dest in destinations)
+            foreach (Backup backup in backups)
             {
-                if (!ShouldScanDestination(dest))
+                if (string.IsNullOrWhiteSpace(backup.Path))
                     continue;
 
-                NetworkCredentialProfile? profile = string.IsNullOrWhiteSpace(dest.CredentialName)
-                    ? null
-                    : cfg.Network.Credentials.FirstOrDefault(c =>
-                        c.Name.Equals(dest.CredentialName, StringComparison.OrdinalIgnoreCase));
-
-                DestinationResolution resolution = _networkMountService.PrepareDestination(dest, profile);
-                if (!resolution.IsSuccess || string.IsNullOrWhiteSpace(resolution.EffectivePath))
+                if (!BackupBelongsToDestination(backup, dest, destinations.Count))
                     continue;
 
-                try
-                {
-                    foreach (Backup backup in backups)
-                    {
-                        if (string.IsNullOrWhiteSpace(backup.Path))
-                            continue;
+                if (!TryCombinePathUnderRoot(effectivePath, backup.Path, out string? fullPath))
+                    continue;
 
-                        if (!BackupBelongsToDestination(backup, dest, destinations.Count))
-                            continue;
+                if (Directory.Exists(fullPath) || File.Exists(fullPath))
+                    continue;
 
-                        if (!TryCombinePathUnderRoot(resolution.EffectivePath, backup.Path, out string? fullPath))
-                            continue;
-
-                        if (Directory.Exists(fullPath) || File.Exists(fullPath))
-                            continue;
-
-                        _repo.DeleteBackupById(backup.Id);
-                        TryDeleteSnapshotIfOrphan(backup.ProjectId, backup.SnapshotId);
-                        removed++;
-                    }
-                }
-                finally
-                {
-                    _networkMountService.Cleanup(resolution);
-                }
+                _repo.DeleteBackupById(backup.Id);
+                TryDeleteSnapshotIfOrphan(backup.ProjectId, backup.SnapshotId);
+                removed++;
             }
 
             if (removed > 0)
             {
-                RuntimeLog.WriteVerbose($"[Backups] Pruned {removed} missing backup database entr{(removed == 1 ? "y" : "ies")} from reachable destinations.");
+                RuntimeLog.WriteVerbose($"[Backups] Pruned {removed} missing backup database entr{(removed == 1 ? "y" : "ies")} from prepared destination '{dest.Alias ?? dest.Path}'.");
             }
 
             return removed;

--- a/src/VaultSync.UI/ViewModels/AppViewModel.ConfigurationOps.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.ConfigurationOps.cs
@@ -286,6 +286,16 @@ namespace VaultSync.UI.ViewModels
                         ? [.. _repo.GetRecentBackupsByProject(limitPerProject: 5)]
                         : [.. _repo.GetBackupsInRange(DateTime.MinValue, DateTime.UtcNow)];
 
+                    if (onBackupsPage || force)
+                    {
+                        int pruned = PruneMissingBackupsFromReachableDestinations(backups);
+                        if (pruned > 0)
+                        {
+                            backups = [.. _repo.GetBackupsInRange(DateTime.MinValue, DateTime.UtcNow)];
+                            useLightweight = false;
+                        }
+                    }
+
                     HashSet<int> disabledAuto = _config.Backups.AutoBackupDisabledProjects?.ToHashSet() ?? [];
 
                     _backupsCacheProjects = projects;
@@ -347,6 +357,86 @@ namespace VaultSync.UI.ViewModels
                 ? new ProjectDestinationSelection(AppViewModel.GetActiveDestinations(cfg), null, null)
                 : ResolveDestinationsForProject(project, cfg);
             return new BackupProjectPreparation(cfg, selection.Destinations, project, selection.WarningMessage, selection.WarningCode);
+        }
+
+        private int PruneMissingBackupsFromReachableDestinations(List<Backup> backups)
+        {
+            if (backups.Count == 0)
+                return 0;
+
+            AppConfig cfg = _config;
+            List<BackupDestination> destinations = AppViewModel.GetActiveDestinations(cfg);
+            if (destinations.Count == 0)
+                return 0;
+
+            int removed = 0;
+            foreach (BackupDestination dest in destinations)
+            {
+                if (!ShouldScanDestination(dest))
+                    continue;
+
+                NetworkCredentialProfile? profile = string.IsNullOrWhiteSpace(dest.CredentialName)
+                    ? null
+                    : cfg.Network.Credentials.FirstOrDefault(c =>
+                        c.Name.Equals(dest.CredentialName, StringComparison.OrdinalIgnoreCase));
+
+                DestinationResolution resolution = _networkMountService.PrepareDestination(dest, profile);
+                if (!resolution.IsSuccess || string.IsNullOrWhiteSpace(resolution.EffectivePath))
+                    continue;
+
+                try
+                {
+                    foreach (Backup backup in backups)
+                    {
+                        if (string.IsNullOrWhiteSpace(backup.Path))
+                            continue;
+
+                        if (!BackupBelongsToDestination(backup, dest, destinations.Count))
+                            continue;
+
+                        if (!TryCombinePathUnderRoot(resolution.EffectivePath, backup.Path, out string? fullPath))
+                            continue;
+
+                        if (Directory.Exists(fullPath) || File.Exists(fullPath))
+                            continue;
+
+                        _repo.DeleteBackupById(backup.Id);
+                        TryDeleteSnapshotIfOrphan(backup.ProjectId, backup.SnapshotId);
+                        removed++;
+                    }
+                }
+                finally
+                {
+                    _networkMountService.Cleanup(resolution);
+                }
+            }
+
+            if (removed > 0)
+            {
+                RuntimeLog.WriteVerbose($"[Backups] Pruned {removed} missing backup database entr{(removed == 1 ? "y" : "ies")} from reachable destinations.");
+            }
+
+            return removed;
+        }
+
+        private static bool BackupBelongsToDestination(Backup backup, BackupDestination dest, int activeDestinationCount)
+        {
+            if (!string.IsNullOrWhiteSpace(backup.DestinationPath) &&
+                string.Equals(backup.DestinationPath, dest.Path, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (!string.IsNullOrWhiteSpace(backup.DestinationPath))
+                return false;
+
+            if (!string.IsNullOrWhiteSpace(backup.DestinationAlias))
+            {
+                return string.Equals(backup.DestinationAlias, dest.Alias, StringComparison.OrdinalIgnoreCase) ||
+                       string.Equals(backup.DestinationAlias, dest.Path, StringComparison.OrdinalIgnoreCase);
+            }
+
+            return activeDestinationCount == 1;
         }
 
         private int ScanDestinationsForUntrackedBackups(List<Project> projects, List<Backup> backups)

--- a/src/VaultSync.UI/ViewModels/AppViewModel.ConfigurationOps.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.ConfigurationOps.cs
@@ -79,8 +79,6 @@ namespace VaultSync.UI.ViewModels
                     bool allowToggle = cfg.Backups.UseAdvancedDestinations && cfg.Backups.Destinations is { Count: > 0 };
                     vm.ResetDestinationStatuses(destinations, allowToggle);
 
-                    EnsureDestinationProbeStarted();
-
                     IReadOnlyList<DestinationProbeSummary> summaries = GetDestinationProbeSummaries(cfg);
                     foreach (DestinationProbeSummary summary in summaries)
                     {

--- a/src/VaultSync.UI/ViewModels/AppViewModel.RuntimeOps.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.RuntimeOps.cs
@@ -45,25 +45,8 @@ namespace VaultSync.UI.ViewModels
 
         private void EnsureDestinationProbeStarted()
         {
-            if (_destinationProbeTimer is not null)
-                return;
-
-            _destinationProbeTimer = new Timer(
-                _ => _ = ProbeDestinationsAsync(),
-                null,
-                TimeSpan.FromMinutes(10),
-                TimeSpan.FromMinutes(10));
-
-            TimeSpan initialDelay = DateTime.UtcNow - _appStartUtc < DestinationProbeStartupDelay
-                ? DestinationProbeStartupDelay
-                : TimeSpan.Zero;
-            _ = Task.Run(async () =>
-            {
-                if (initialDelay > TimeSpan.Zero)
-                    await Task.Delay(initialDelay).ConfigureAwait(false);
-                DiagnosticsLogger.Record("Destination startup probe running.");
-                await ProbeDestinationsAsync().ConfigureAwait(false);
-            });
+            _destinationProbeTimer?.Dispose();
+            _destinationProbeTimer = null;
         }
 
         public IReadOnlyList<DestinationProbeSummary> GetDestinationProbeSummaries()

--- a/src/VaultSync.UI/ViewModels/AppViewModel.RuntimeOps.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.RuntimeOps.cs
@@ -43,10 +43,13 @@ namespace VaultSync.UI.ViewModels
             _nasMonitorTimer = null;
         }
 
-        private void EnsureDestinationProbeStarted()
+        private async Task RunStartupDestinationProbeAsync()
         {
-            _destinationProbeTimer?.Dispose();
-            _destinationProbeTimer = null;
+            if (Interlocked.Exchange(ref _startupDestinationProbeQueued, 1) == 1)
+                return;
+
+            DiagnosticsLogger.Record("Destination startup probe running.");
+            await ProbeDestinationsAsync().ConfigureAwait(false);
         }
 
         public IReadOnlyList<DestinationProbeSummary> GetDestinationProbeSummaries()

--- a/src/VaultSync.UI/ViewModels/AppViewModel.RuntimeOps.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.RuntimeOps.cs
@@ -818,6 +818,30 @@ namespace VaultSync.UI.ViewModels
             if (existing.HasValue && existing.Value > 0)
                 return existing.Value;
 
+            string key = DestinationStatusItem.GetId(dest);
+            Lazy<Task<int?>> lazyTuneTask = _archiveUploadBufferTuneTasks.GetOrAdd(
+                key,
+                _ => new Lazy<Task<int?>>(
+                    () => TuneArchiveUploadBufferAsync(dest, cfg, effectivePath),
+                    LazyThreadSafetyMode.ExecutionAndPublication));
+            Task<int?> tuneTask = lazyTuneTask.Value;
+
+            try
+            {
+                return await tuneTask.WaitAsync(ct).ConfigureAwait(false);
+            }
+            finally
+            {
+                if (tuneTask.IsCompleted)
+                    _archiveUploadBufferTuneTasks.TryRemove(new KeyValuePair<string, Lazy<Task<int?>>>(key, lazyTuneTask));
+            }
+        }
+
+        private async Task<int?> TuneArchiveUploadBufferAsync(
+            BackupDestination dest,
+            AppConfig cfg,
+            string effectivePath)
+        {
             try
             {
                 string display = string.IsNullOrWhiteSpace(dest.Alias) ? dest.Path : dest.Alias ?? dest.Path;
@@ -826,13 +850,13 @@ namespace VaultSync.UI.ViewModels
                 int timeoutSeconds = IsSmbPath(dest.Path) || IsSmbPath(effectivePath) ? 8 : 3;
                 using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSeconds));
                 ArchiveProbeResult result = await Task.Run(
-                    () => ProbeArchiveUploadBufferBytes(effectivePath, ct, timeoutCts.Token),
-                    ct);
+                    () => ProbeArchiveUploadBufferBytes(effectivePath, CancellationToken.None, timeoutCts.Token));
 
                 if (result.TimedOut)
                 {
-                    Console.WriteLine($"[DestinationProbe] Auto-tune timed out for '{dest.Path}'. Falling back to default buffer.");
-                    return null;
+                    SaveArchiveUploadBufferBytes(cfg, dest, result.BufferBytes);
+                    Console.WriteLine($"[DestinationProbe] Auto-tune timed out for '{dest.Path}'. Cached fallback buffer.");
+                    return result.BufferBytes;
                 }
 
                 SaveArchiveUploadBufferBytes(cfg, dest, result.BufferBytes);
@@ -844,7 +868,7 @@ namespace VaultSync.UI.ViewModels
             }
             catch (OperationCanceledException)
             {
-                throw;
+                return null;
             }
             catch (Exception ex)
             {

--- a/src/VaultSync.UI/ViewModels/AppViewModel.UpdateOps.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.UpdateOps.cs
@@ -236,8 +236,8 @@ namespace VaultSync.UI.ViewModels
                     RecordStartupPhase("deferred-startup-begin");
 
                     AppConfig cfg = AppConfigStore.GetSnapshot();
-                    EnsureDestinationProbeStarted();
-                    RecordStartupPhase("destination-probe-deferred");
+                    await RunStartupDestinationProbeAsync().ConfigureAwait(false);
+                    RecordStartupPhase("destination-probe-complete");
 
                     if (cfg.Backups.EnableMetadataSync)
                     {

--- a/src/VaultSync.UI/ViewModels/AppViewModel.UpdateOps.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.UpdateOps.cs
@@ -237,7 +237,7 @@ namespace VaultSync.UI.ViewModels
 
                     AppConfig cfg = AppConfigStore.GetSnapshot();
                     EnsureDestinationProbeStarted();
-                    RecordStartupPhase("destination-probe-ready");
+                    RecordStartupPhase("destination-probe-deferred");
 
                     if (cfg.Backups.EnableMetadataSync)
                     {

--- a/src/VaultSync.UI/ViewModels/AppViewModel.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.cs
@@ -108,8 +108,8 @@ namespace VaultSync.UI.ViewModels
         private int _autoBackupInFlight;
         private Timer? _maintenanceTimer;
         private int _maintenanceInFlight;
-        private Timer? _destinationProbeTimer;
         private int _destinationProbeInFlight;
+        private int _startupDestinationProbeQueued;
 
         // Core services for live data
         private readonly SqliteRepository _repo;
@@ -129,7 +129,6 @@ namespace VaultSync.UI.ViewModels
         private readonly ConcurrentDictionary<string, Lazy<Task<int?>>> _archiveUploadBufferTuneTasks = new(StringComparer.OrdinalIgnoreCase);
         private static readonly TimeSpan DestinationProbeMinInterval = TimeSpan.FromMinutes(2);
         private static readonly TimeSpan DestinationProbeFailureBackoff = TimeSpan.FromMinutes(15);
-        private static readonly TimeSpan DestinationProbeStartupDelay = TimeSpan.Zero;
         private static readonly TimeSpan DestinationScanInterval = TimeSpan.FromMinutes(10);
         private const string BackupProtectionMarkerFileName = ".vaultsync_keep";
         private const int DefaultEncryptedOpenTimeoutMinutes = 10;

--- a/src/VaultSync.UI/ViewModels/AppViewModel.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.cs
@@ -126,6 +126,7 @@ namespace VaultSync.UI.ViewModels
         private readonly LogConsoleService _logConsoleService;
         private LogConsoleWindow? _logConsoleWindow;
         private readonly ConcurrentDictionary<string, DestinationProbeSummary> _destinationProbeSummaries = new();
+        private readonly ConcurrentDictionary<string, Lazy<Task<int?>>> _archiveUploadBufferTuneTasks = new(StringComparer.OrdinalIgnoreCase);
         private static readonly TimeSpan DestinationProbeMinInterval = TimeSpan.FromMinutes(2);
         private static readonly TimeSpan DestinationProbeFailureBackoff = TimeSpan.FromMinutes(15);
         private static readonly TimeSpan DestinationProbeStartupDelay = TimeSpan.Zero;

--- a/src/presets/avalonia.vaultsyncignore
+++ b/src/presets/avalonia.vaultsyncignore
@@ -1,10 +1,27 @@
 bin/**
 obj/**
+**/bin/**
+**/obj/**
+TestResults/**
+**/TestResults/**
+artifacts/**
+**/artifacts/**
+packages/**
+**/packages/**
 *.exe
+*.dll
 *.log
 *.pdb
 *.tmp
 *.db
+*.db-shm
+*.db-wal
+*.cache
+*.nupkg
+*.snupkg
+*.user
+*.csproj.user
+*.suo
 
 # IDE
 .vscode/

--- a/src/presets/blender.vaultsyncignore
+++ b/src/presets/blender.vaultsyncignore
@@ -6,6 +6,10 @@ __pycache__/**
 cache/**
 backup/**
 autosave/**
+**/__pycache__/**
+**/cache/**
+**/backup/**
+**/autosave/**
 *.swp
 *.tmp
 Thumbs.db

--- a/src/presets/c_cpp.vaultsyncignore
+++ b/src/presets/c_cpp.vaultsyncignore
@@ -1,6 +1,9 @@
 build/**
 bin/**
 obj/**
+**/build/**
+**/bin/**
+**/obj/**
 *.o
 *.obj
 *.pdb
@@ -13,6 +16,7 @@ obj/**
 
 # CMake
 CMakeFiles/**
+**/CMakeFiles/**
 CMakeCache.txt
 cmake_install.cmake
 Makefile

--- a/src/presets/davinci_resolve.vaultsyncignore
+++ b/src/presets/davinci_resolve.vaultsyncignore
@@ -3,6 +3,11 @@ Gallery/**
 Proxies/**
 Capture/**
 AudioCache/**
+**/CacheClip/**
+**/Gallery/**
+**/Proxies/**
+**/Capture/**
+**/AudioCache/**
 *.tmp
 *.log
 .DS_Store

--- a/src/presets/dotnet.vaultsyncignore
+++ b/src/presets/dotnet.vaultsyncignore
@@ -1,7 +1,10 @@
 bin/**
 obj/**
+**/bin/**
+**/obj/**
 *.exe
 TestResults/**
+**/TestResults/**
 *.user
 *.csproj.user
 *.suo

--- a/src/presets/fl_studio.vaultsyncignore
+++ b/src/presets/fl_studio.vaultsyncignore
@@ -1,5 +1,7 @@
 Backup/**
 Rendered/**
+**/Backup/**
+**/Rendered/**
 *.fst
 *.tmp
 *.bak

--- a/src/presets/flutter.vaultsyncignore
+++ b/src/presets/flutter.vaultsyncignore
@@ -1,9 +1,11 @@
 build/**
+**/build/**
 .ios/**
 .android/**
 .flutter-plugins
 .flutter-plugins-dependencies
 .dart_tool/**
+**/.dart_tool/**
 .packages
 *.exe
 

--- a/src/presets/gamemaker.vaultsyncignore
+++ b/src/presets/gamemaker.vaultsyncignore
@@ -6,6 +6,10 @@ backup/
 output/
 build/
 cache/
+**/backup/
+**/output/
+**/build/
+**/cache/
 *.exe
 
 # IDE

--- a/src/presets/go.vaultsyncignore
+++ b/src/presets/go.vaultsyncignore
@@ -1,5 +1,7 @@
 bin/**
 pkg/**
+**/bin/**
+**/pkg/**
 *.exe
 *.test
 *.tmp

--- a/src/presets/godot.vaultsyncignore
+++ b/src/presets/godot.vaultsyncignore
@@ -1,6 +1,8 @@
 # Godot generated
 .import/**
 mono/**
+**/.import/**
+**/mono/**
 export_presets.cfg
 *.exe
 

--- a/src/presets/java.vaultsyncignore
+++ b/src/presets/java.vaultsyncignore
@@ -2,6 +2,10 @@ target/**
 out/**
 build/**
 .gradle/**
+**/target/**
+**/out/**
+**/build/**
+**/.gradle/**
 *~ 
 *.iml
 *.class

--- a/src/presets/jetbrains.vaultsyncignore
+++ b/src/presets/jetbrains.vaultsyncignore
@@ -1,6 +1,7 @@
 .idea/**
 *.iml
 out/**
+**/out/**
 
 .DS_Store
 Thumbs.db

--- a/src/presets/node.vaultsyncignore
+++ b/src/presets/node.vaultsyncignore
@@ -2,11 +2,16 @@ node_modules/**
 dist/**
 build/**
 .cache/**
+**/node_modules/**
+**/dist/**
+**/build/**
+**/.cache/**
 *.log
 *.tmp
 
 # tooling
 coverage/**
+**/coverage/**
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/src/presets/python.vaultsyncignore
+++ b/src/presets/python.vaultsyncignore
@@ -1,18 +1,28 @@
 __pycache__/**
+**/__pycache__/**
 *.pyc
 *.pyo
 *.pyd
 *.egg-info/**
+**/*.egg-info/**
 build/**
 dist/**
+**/build/**
+**/dist/**
 pip-wheel-metadata/**
 pytest_cache/**
 htmlcov/**
+**/pip-wheel-metadata/**
+**/pytest_cache/**
+**/htmlcov/**
 
 # environments
 env/**
 .venv/**
 venv/**
+**/env/**
+**/.venv/**
+**/venv/**
 
 # IDE
 .vscode/

--- a/src/presets/react_native.vaultsyncignore
+++ b/src/presets/react_native.vaultsyncignore
@@ -1,12 +1,17 @@
 android/build/**
 ios/build/**
 node_modules/**
+**/android/build/**
+**/ios/build/**
+**/node_modules/**
 *.log
 *.tmp
 
 # Metro bundler
 .expo/**
 .expo-shared/**
+**/.expo/**
+**/.expo-shared/**
 
 # IDE
 .vscode/

--- a/src/presets/rust.vaultsyncignore
+++ b/src/presets/rust.vaultsyncignore
@@ -1,4 +1,5 @@
 target/**
+**/target/**
 *.exe
 Cargo.lock.bak
 *.rs.bk

--- a/src/presets/unreal.vaultsyncignore
+++ b/src/presets/unreal.vaultsyncignore
@@ -5,6 +5,12 @@ Intermediate/**
 Saved/**
 Build/**
 Builds/**
+**/Binaries/**
+**/DerivedDataCache/**
+**/Intermediate/**
+**/Saved/**
+**/Build/**
+**/Builds/**
 *.exe
 
 # IDE junk

--- a/src/presets/video.vaultsyncignore
+++ b/src/presets/video.vaultsyncignore
@@ -1,6 +1,9 @@
 Cache/**
 Proxies/**
 RenderCache/**
+**/Cache/**
+**/Proxies/**
+**/RenderCache/**
 *.tmp
 *.log
 *.sync

--- a/tests/VaultSync.Core.Tests/BackupSafetyServiceTests.cs
+++ b/tests/VaultSync.Core.Tests/BackupSafetyServiceTests.cs
@@ -98,6 +98,23 @@ public sealed class BackupSafetyServiceTests : IDisposable
         Assert.Single(entries);
     }
 
+    [Fact]
+    public void FilterService_DoubleStarDirectoryPatternExcludesNestedBuildOutput()
+    {
+        var projectRoot = Path.Combine(_tempDir, "project");
+        var nestedBin = Path.Combine(projectRoot, "src", "App", "bin", "Debug");
+        Directory.CreateDirectory(nestedBin);
+        File.WriteAllText(Path.Combine(projectRoot, "Program.cs"), "keep");
+        File.WriteAllText(Path.Combine(nestedBin, "App.dll"), "exclude");
+
+        var scanner = new ScannerService(new FilterService(["**/bin/**"]));
+        var entries = scanner.Scan(projectRoot).Select(entry => entry.RelPath).ToArray();
+
+        Assert.Contains("Program.cs", entries);
+        Assert.DoesNotContain(entries, path => path.Contains("App.dll", StringComparison.OrdinalIgnoreCase));
+        Assert.Single(entries);
+    }
+
     public void Dispose()
     {
         try

--- a/tests/VaultSync.Core.Tests/BackupSafetyServiceTests.cs
+++ b/tests/VaultSync.Core.Tests/BackupSafetyServiceTests.cs
@@ -115,6 +115,26 @@ public sealed class BackupSafetyServiceTests : IDisposable
         Assert.Single(entries);
     }
 
+    [Theory]
+    [InlineData("**/Intermediate/**", "Plugins/Module/Intermediate/cache.bin")]
+    [InlineData("**/.import/**", "addons/tool/.import/asset.import")]
+    [InlineData("**/RenderCache/**", "episodes/scene/RenderCache/frame.tmp")]
+    public void FilterService_NestedGeneratedOutputPatternsExcludeExpectedFiles(string pattern, string generatedPath)
+    {
+        var projectRoot = Path.Combine(_tempDir, Guid.NewGuid().ToString("N"));
+        string generatedFile = Path.Combine(projectRoot, generatedPath.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(generatedFile)!);
+        File.WriteAllText(Path.Combine(projectRoot, "source.txt"), "keep");
+        File.WriteAllText(generatedFile, "exclude");
+
+        var scanner = new ScannerService(new FilterService([pattern]));
+        var entries = scanner.Scan(projectRoot).Select(entry => entry.RelPath).ToArray();
+
+        Assert.Contains("source.txt", entries);
+        Assert.DoesNotContain(entries, path => path.Equals(generatedPath, StringComparison.OrdinalIgnoreCase));
+        Assert.Single(entries);
+    }
+
     public void Dispose()
     {
         try


### PR DESCRIPTION
﻿## Summary
- Prune backup database rows whose recorded backup folder/file is missing from a reachable active destination.
- Keep offline or unresolved destinations untouched so disconnected drives are not treated as deleted backups.
- Preserve path containment checks and remove orphan snapshots after metadata pruning.
- Coalesce archive upload buffer auto-tune work per destination and cache timeout fallback buffers.
- Tighten development and creative presets so nested generated outputs are excluded from snapshots.
- Run one deferred startup destination probe, then avoid passive Backups-page/idle probes so sleeping destinations are only touched for backup execution or manual tests.
- Document the fixes in the changelog and roadmap.

## Why
Manual deletion in a backup destination could leave stale history rows visible in the Backups page, including misleading 0 B entries. Cleanup now runs when a backup has already prepared the destination, which keeps it safe without waking storage just to inspect the page.

Runtime logs also showed parallel backups starting repeated buffer auto-tune probes for the same destination, and root-only preset rules could miss generated output when it lived below nested app or package folders.

Fixes #284.
Fixes #285.
Fixes #286.

## Validation
- dotnet test VaultSync.sln --no-restore
