### PR TITLE
Spike .NET 10 migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "10.0.x"
 
       - name: Restore
         run: dotnet restore VaultSync.sln
@@ -48,13 +48,13 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "10.0.x"
 
       - name: Restore
         run: dotnet restore VaultSync.sln
 
       - name: Build UI generic target
-        run: dotnet build src/VaultSync.UI/VaultSync.UI.csproj --framework net8.0 --configuration Release --no-restore -warnaserror -p:UseSharedCompilation=false
+        run: dotnet build src/VaultSync.UI/VaultSync.UI.csproj --framework net10.0 --configuration Release --no-restore -warnaserror -p:UseSharedCompilation=false
 
       - name: Test
         run: dotnet test tests/VaultSync.Core.Tests/VaultSync.Core.Tests.csproj --configuration Release --no-restore -warnaserror -p:UseSharedCompilation=false

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -122,13 +122,13 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "10.0.x"
 
       - name: Publish (win-x64)
         run: >
           dotnet publish src/VaultSync.UI/VaultSync.UI.csproj
           -c Release
-          -f net8.0-windows10.0.19041.0
+          -f net10.0-windows10.0.19041.0
           -r win-x64
           --self-contained true
 
@@ -153,7 +153,7 @@ jobs:
           }
           $previousArgs = foreach ($baseVersion in $baseVersions) { "--previous"; $baseVersion }
           python scripts/build_patch.py `
-            --base-dir "src/VaultSync.UI/bin/Release/net8.0-windows10.0.19041.0/win-x64/publish" `
+            --base-dir "src/VaultSync.UI/bin/Release/net10.0-windows10.0.19041.0/win-x64/publish" `
             --out-zip "$patchDir/vaultsync-patch-windows.zip" `
             --out-manifest "$patchDir/vaultsync-patch-windows.json" `
             --platform windows `
@@ -179,13 +179,13 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "10.0.x"
 
       - name: Publish (osx-arm64)
         run: >
           dotnet publish src/VaultSync.UI/VaultSync.UI.csproj
           -c Release
-          -f net8.0
+          -f net10.0
           -r osx-arm64
           --self-contained true
 
@@ -193,14 +193,14 @@ jobs:
         run: >
           dotnet publish src/VaultSync.UI/VaultSync.UI.csproj
           -c Release
-          -f net8.0
+          -f net10.0
           -r osx-x64
           --self-contained true
 
       - name: Build DMGs
         run: |
-          bash scripts/build_macos_dmg.sh "${{ inputs.target_version }}" arm64 src/VaultSync.UI/bin/Release/net8.0/osx-arm64/publish
-          bash scripts/build_macos_dmg.sh "${{ inputs.target_version }}" x64 src/VaultSync.UI/bin/Release/net8.0/osx-x64/publish
+          bash scripts/build_macos_dmg.sh "${{ inputs.target_version }}" arm64 src/VaultSync.UI/bin/Release/net10.0/osx-arm64/publish
+          bash scripts/build_macos_dmg.sh "${{ inputs.target_version }}" x64 src/VaultSync.UI/bin/Release/net10.0/osx-x64/publish
 
       - name: Build patch assets
         env:
@@ -215,14 +215,14 @@ jobs:
           ${{ needs.validate.outputs.patch_base_versions }}
           EOF
           python3 scripts/build_patch.py \
-            --base-dir "src/VaultSync.UI/bin/Release/net8.0/osx-arm64/publish" \
+            --base-dir "src/VaultSync.UI/bin/Release/net10.0/osx-arm64/publish" \
             --out-zip "patches/v${{ inputs.target_version }}/vaultsync-patch-macos-apple-silicon.zip" \
             --out-manifest "patches/v${{ inputs.target_version }}/vaultsync-patch-macos-apple-silicon.json" \
             --platform macos \
             "${previous_args[@]}" \
             --target "${{ inputs.target_version }}"
           python3 scripts/build_patch.py \
-            --base-dir "src/VaultSync.UI/bin/Release/net8.0/osx-x64/publish" \
+            --base-dir "src/VaultSync.UI/bin/Release/net10.0/osx-x64/publish" \
             --out-zip "patches/v${{ inputs.target_version }}/vaultsync-patch-macos-intel.zip" \
             --out-manifest "patches/v${{ inputs.target_version }}/vaultsync-patch-macos-intel.json" \
             --platform macos \
@@ -251,13 +251,13 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "10.0.x"
 
       - name: Publish (linux-x64)
         run: >
           dotnet publish src/VaultSync.UI/VaultSync.UI.csproj
           -c Release
-          -f net8.0
+          -f net10.0
           -r linux-x64
           --self-contained true
 
@@ -265,14 +265,14 @@ jobs:
         run: >
           dotnet publish src/VaultSync.UI/VaultSync.UI.csproj
           -c Release
-          -f net8.0
+          -f net10.0
           -r linux-arm64
           --self-contained true
 
       - name: Build Linux archives
         run: |
-          bash scripts/build_linux_release.sh "${{ inputs.target_version }}" x64 src/VaultSync.UI/bin/Release/net8.0/linux-x64/publish
-          bash scripts/build_linux_release.sh "${{ inputs.target_version }}" arm64 src/VaultSync.UI/bin/Release/net8.0/linux-arm64/publish
+          bash scripts/build_linux_release.sh "${{ inputs.target_version }}" x64 src/VaultSync.UI/bin/Release/net10.0/linux-x64/publish
+          bash scripts/build_linux_release.sh "${{ inputs.target_version }}" arm64 src/VaultSync.UI/bin/Release/net10.0/linux-arm64/publish
 
       - name: Build patch assets
         env:
@@ -287,14 +287,14 @@ jobs:
           ${{ needs.validate.outputs.patch_base_versions }}
           EOF
           python3 scripts/build_patch.py \
-            --base-dir "src/VaultSync.UI/bin/Release/net8.0/linux-x64/publish" \
+            --base-dir "src/VaultSync.UI/bin/Release/net10.0/linux-x64/publish" \
             --out-zip "patches/v${{ inputs.target_version }}/vaultsync-patch-linux-x64.zip" \
             --out-manifest "patches/v${{ inputs.target_version }}/vaultsync-patch-linux-x64.json" \
             --platform linux \
             "${previous_args[@]}" \
             --target "${{ inputs.target_version }}"
           python3 scripts/build_patch.py \
-            --base-dir "src/VaultSync.UI/bin/Release/net8.0/linux-arm64/publish" \
+            --base-dir "src/VaultSync.UI/bin/Release/net10.0/linux-arm64/publish" \
             --out-zip "patches/v${{ inputs.target_version }}/vaultsync-patch-linux-arm64.zip" \
             --out-manifest "patches/v${{ inputs.target_version }}/vaultsync-patch-linux-arm64.json" \
             --platform linux \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,11 +25,11 @@ Rules:
 - For risky or cross-cutting changes, align scope first.
 
 ## 3) Development Setup
-1. Install .NET 8 SDK.
+1. Install .NET 10 SDK.
 2. Restore:
    `dotnet restore`
 3. Run UI:
-   `dotnet run -f net8.0-windows10.0.19041.0 --project src/VaultSync.UI/VaultSync.UI.csproj`
+   `dotnet run -f net10.0-windows10.0.19041.0 --project src/VaultSync.UI/VaultSync.UI.csproj`
 
 ## 4) Implementation Rules
 - Keep changes focused.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" /></a>
   <img src="https://img.shields.io/badge/platform-macOS%20|%20Windows%20|%20Linux-green" />
-  <img src="https://img.shields.io/badge/.NET-8.0-blueviolet" />
+  <img src="https://img.shields.io/badge/.NET-10.0-blueviolet" />
 </p>
 
 <p align="center" style="margin-top:14px;display:flex;justify-content:center;gap:8px;flex-wrap:wrap;">

--- a/docs/HELP.md
+++ b/docs/HELP.md
@@ -12,8 +12,8 @@ Core actions:
 
 ## Install and Run
 - UI:
-  - macOS/Linux: `dotnet run -f net8.0 --project src/VaultSync.UI/VaultSync.UI.csproj`
-  - Windows target: `dotnet run -f net8.0-windows10.0.19041.0 --project src/VaultSync.UI/VaultSync.UI.csproj`
+  - macOS/Linux: `dotnet run -f net10.0 --project src/VaultSync.UI/VaultSync.UI.csproj`
+  - Windows target: `dotnet run -f net10.0-windows10.0.19041.0 --project src/VaultSync.UI/VaultSync.UI.csproj`
 - CLI tool build/install:
   - `dotnet pack src/VaultSync.CLI -c Release`
   - `dotnet tool install --global --add-source src/VaultSync.CLI/bin/ToolPackages vaultsync.cli`

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -3,7 +3,7 @@
 This document defines the current release packaging flow.
 
 ## Prerequisites
-- .NET 8 SDK
+- .NET 10 SDK
 - Inno Setup (Windows installer)
 - Repo version/changelog already updated for the target release
 - The current stable release target is `1.7.3`; prerelease builds for the active patch train use `1.7.4-Beta.N`.
@@ -11,7 +11,7 @@ This document defines the current release packaging flow.
 ## 1) Windows Installer
 1. Publish:
    ```bash
-   dotnet publish src/VaultSync.UI/VaultSync.UI.csproj -c Release -f net8.0-windows10.0.19041.0 -r win-x64 --self-contained true
+   dotnet publish src/VaultSync.UI/VaultSync.UI.csproj -c Release -f net10.0-windows10.0.19041.0 -r win-x64 --self-contained true
    ```
 2. Build installer using `installer/VaultSyncInstaller.iss`.
 3. Upload generated `VaultSyncInstaller.exe` to GitHub Release assets.
@@ -19,8 +19,8 @@ This document defines the current release packaging flow.
 ## 2) macOS DMG
 1. Publish both architectures:
    ```bash
-   dotnet publish src/VaultSync.UI/VaultSync.UI.csproj -c Release -f net8.0 -r osx-arm64 --self-contained true
-   dotnet publish src/VaultSync.UI/VaultSync.UI.csproj -c Release -f net8.0 -r osx-x64 --self-contained true
+   dotnet publish src/VaultSync.UI/VaultSync.UI.csproj -c Release -f net10.0 -r osx-arm64 --self-contained true
+   dotnet publish src/VaultSync.UI/VaultSync.UI.csproj -c Release -f net10.0 -r osx-x64 --self-contained true
    ```
 2. Build `.app` and `.dmg` using repository scripts.
 3. Upload both DMGs to release assets.
@@ -28,13 +28,13 @@ This document defines the current release packaging flow.
 ## 3) Linux Direct Assets
 1. Publish both Linux architectures:
    ```bash
-   dotnet publish src/VaultSync.UI/VaultSync.UI.csproj -c Release -f net8.0 -r linux-x64 --self-contained true
-   dotnet publish src/VaultSync.UI/VaultSync.UI.csproj -c Release -f net8.0 -r linux-arm64 --self-contained true
+   dotnet publish src/VaultSync.UI/VaultSync.UI.csproj -c Release -f net10.0 -r linux-x64 --self-contained true
+   dotnet publish src/VaultSync.UI/VaultSync.UI.csproj -c Release -f net10.0 -r linux-arm64 --self-contained true
    ```
 2. Build Linux archives:
    ```bash
-   bash scripts/build_linux_release.sh 1.7.3 x64 src/VaultSync.UI/bin/Release/net8.0/linux-x64/publish
-   bash scripts/build_linux_release.sh 1.7.3 arm64 src/VaultSync.UI/bin/Release/net8.0/linux-arm64/publish
+   bash scripts/build_linux_release.sh 1.7.3 x64 src/VaultSync.UI/bin/Release/net10.0/linux-x64/publish
+   bash scripts/build_linux_release.sh 1.7.3 arm64 src/VaultSync.UI/bin/Release/net10.0/linux-arm64/publish
    ```
 3. Upload the generated `.tar.gz` artifacts and the `linux-x64` `.AppImage`.
    The `.tar.gz` archives include `install.sh` and `uninstall.sh` for a

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,5 +1,25 @@
 # What's New
 
+## [1.7.4]
+
+Current `1.7.4` highlights focus on the .NET 10 migration, safer destination cleanup, quieter backup history refreshes, and the latest backup reliability fixes from the 1.7 release train.
+
+### Platform and release updates
+- Core, CLI, UI, and tests now target .NET 10.
+- Release workflows and documentation now use the .NET 10 SDK and publish paths.
+- The Windows installer metadata now points at the .NET 10 Windows publish output.
+- CLI packaging now includes the repository README from the correct path.
+
+### Backup and destination reliability
+- Backups now prune stale database entries when recorded backup folders are missing from reachable prepared destinations.
+- Offline or unresolved destinations are left untouched, so disconnected drives are not treated as deleted backups.
+- Passive Backups refreshes no longer wake destinations just to update reachability.
+- Backup probes now share in-flight archive buffer tuning work per destination.
+
+### Presets and generated output
+- Development and creative presets now exclude nested generated outputs such as build, cache, import, and render folders.
+- Filter coverage now includes nested `**/bin/**`, `**/Intermediate/**`, `.import`, and render-cache style folders.
+
 ## [1.7.3]
 
 Current `1.7.3` highlights focus on Linux reliability, release asset coverage, safer startup/config recovery, and the final backup and metadata fixes from the 1.7 stabilization cycle.

--- a/installer/VaultSyncInstaller.iss
+++ b/installer/VaultSyncInstaller.iss
@@ -1,8 +1,8 @@
 ﻿#define MyAppName "VaultSync"
-#define MyAppVersion "1.7.3"
+#define MyAppVersion "1.7.4"
 #define MyAppPublisher "Flavio Giacchetti"
 #define MyAppExeName "VaultSync.UI.exe"
-#define AppOutputDir "..\\src\\VaultSync.UI\\bin\\Release\\net8.0-windows10.0.19041.0\\win-x64\\publish"
+#define AppOutputDir "..\\src\\VaultSync.UI\\bin\\Release\\net10.0-windows10.0.19041.0\\win-x64\\publish"
 #define AppIconPath "..\\src\\VaultSync.UI\\Assets\\vaultsync.ico"
 
 [Setup]

--- a/src/VaultSync.CLI/VaultSync.CLI.csproj
+++ b/src/VaultSync.CLI/VaultSync.CLI.csproj
@@ -12,7 +12,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/src/VaultSync.Core/Services/BackupArchiveCryptoService.cs
+++ b/src/VaultSync.Core/Services/BackupArchiveCryptoService.cs
@@ -175,12 +175,12 @@ public sealed class BackupArchiveCryptoService
         string tempOutputPath = outputArchivePath + ".tmp";
         try
         {
-            using var pbkdf2 = new Rfc2898DeriveBytes(
+            byte[] derived = Rfc2898DeriveBytes.Pbkdf2(
                 password,
                 saltBytes,
                 iterations,
-                HashAlgorithmName.SHA256);
-            byte[] derived = pbkdf2.GetBytes(keyMaterial.Length);
+                HashAlgorithmName.SHA256,
+                keyMaterial.Length);
             Buffer.BlockCopy(derived, 0, keyMaterial, 0, keyMaterial.Length);
             Buffer.BlockCopy(keyMaterial, 0, encryptionKey, 0, encryptionKey.Length);
             Buffer.BlockCopy(keyMaterial, encryptionKey.Length, hmacKey, 0, hmacKey.Length);
@@ -307,12 +307,12 @@ public sealed class BackupArchiveCryptoService
 
         try
         {
-            using var pbkdf2 = new Rfc2898DeriveBytes(
+            byte[] derived = Rfc2898DeriveBytes.Pbkdf2(
                 password,
                 saltBytes,
                 iterations,
-                HashAlgorithmName.SHA256);
-            byte[] derived = pbkdf2.GetBytes(keyMaterial.Length);
+                HashAlgorithmName.SHA256,
+                keyMaterial.Length);
             Buffer.BlockCopy(derived, 0, keyMaterial, 0, keyMaterial.Length);
             Buffer.BlockCopy(keyMaterial, 0, encryptionKey, 0, encryptionKey.Length);
             Buffer.BlockCopy(keyMaterial, encryptionKey.Length, hmacKey, 0, hmacKey.Length);

--- a/src/VaultSync.Core/VaultSync.Core.csproj
+++ b/src/VaultSync.Core/VaultSync.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RuntimeIdentifiers>win-x64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/VaultSync.UI/VaultSync.UI.csproj
+++ b/src/VaultSync.UI/VaultSync.UI.csproj
@@ -6,8 +6,8 @@
     <Company>Flavio Giacchetti</Company>
     <ApplicationIcon>Assets\vaultsync.ico</ApplicationIcon>
 
-    <!-- Multi-target: generic .NET 8 + Windows-specific TFM -->
-    <TargetFrameworks>net8.0;net8.0-windows10.0.19041.0</TargetFrameworks>
+    <!-- Multi-target: generic .NET 10 + Windows-specific TFM -->
+    <TargetFrameworks>net10.0;net10.0-windows10.0.19041.0</TargetFrameworks>
     <RuntimeIdentifiers>win-x64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
 
     <Nullable>enable</Nullable>
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <!-- Enable WINDOWS constant for the Windows TFM so #if WINDOWS blocks compile -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0-windows10.0.19041.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0-windows10.0.19041.0'">
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
     <!-- Allow building the Windows TFM on non-Windows agents (e.g., macOS CI/local) -->
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
@@ -48,13 +48,12 @@
     <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="3.119.4-preview.1.1" />
     <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.2" />
     <PackageReference Include="ReactiveUI" Version="23.2.27" />
-    <PackageReference Include="System.Text.Json" Version="10.0.7" />
   </ItemGroup>
 
   <!-- Reference to core project -->
   <ItemGroup>
     <ProjectReference Include="..\VaultSync.Core\VaultSync.Core.csproj">
-      <SetTargetFramework>TargetFramework=net8.0</SetTargetFramework>
+      <SetTargetFramework>TargetFramework=net10.0</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
 
@@ -71,7 +70,7 @@
   </ItemGroup>
 
   <!-- Optional bundled rsync for Windows delta sync -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows10.0.19041.0' And (Exists('..\..\tools\rsync\bin\rsync.exe') Or Exists('..\..\tools\rsync\rsync.exe'))">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-windows10.0.19041.0' And (Exists('..\..\tools\rsync\bin\rsync.exe') Or Exists('..\..\tools\rsync\rsync.exe'))">
     <Content Include="..\..\tools\rsync\**\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>tools\rsync\%(RecursiveDir)%(Filename)%(Extension)</Link>
@@ -114,7 +113,7 @@
   </ItemGroup>
 
   <!-- Windows notifications -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows10.0.19041.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-windows10.0.19041.0'">
     <PackageReference Include="CommunityToolkit.WinUI.Notifications" Version="7.1.2" />
     <PackageReference Include="System.Drawing.Common" Version="10.0.7" />
   </ItemGroup>

--- a/tests/VaultSync.Core.Tests/VaultSync.Core.Tests.csproj
+++ b/tests/VaultSync.Core.Tests/VaultSync.Core.Tests.csproj
@@ -1,15 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="System.Text.Json" Version="10.0.7" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
﻿## Summary
- Retarget Core, CLI, UI, and test projects from .NET 8 to .NET 10.
- Update CI and release asset workflows to use the .NET 10 SDK and publish paths.
- Refresh developer/release docs for .NET 10 commands.
- Replace obsolete PBKDF2 constructor usage with the static `Rfc2898DeriveBytes.Pbkdf2` API.
- Remove redundant framework package references exposed by .NET 10 restore analysis.

## Validation
- dotnet restore VaultSync.sln
- dotnet build VaultSync.sln --configuration Release --no-restore -warnaserror -p:UseSharedCompilation=false -m:1
- dotnet test tests\VaultSync.Core.Tests\VaultSync.Core.Tests.csproj --configuration Release --no-build
- dotnet publish src/VaultSync.UI/VaultSync.UI.csproj -c Release -f net10.0-windows10.0.19041.0 -r win-x64 --self-contained true --no-restore -p:UseSharedCompilation=false
- dotnet build src/VaultSync.UI/VaultSync.UI.csproj --framework net10.0 --configuration Release --no-restore -warnaserror -p:UseSharedCompilation=false

