### PR TITLE
Fix beta metadata and localization polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@
 - [BUG-18009] The log console copy button now uses the console window clipboard instead of relying only on the main window.
 - [BUG-18010] Normal app runs no longer show caught first-chance SQLite/WinRT probes in diagnostics unless first-chance diagnostics are explicitly enabled.
 - [BUG-18011] The What's New parser now displays the current release notes slice instead of carrying older release sections into the dialog.
+- [BUG-18012] Imported destination history rebuilt from legacy backup folders now records and repairs real backup sizes instead of showing `0 B`. Refs #298.
+- [BUG-18013] Changing language no longer resets the selected theme or jumps Settings back to its initial scroll position. Refs #297.
 
 ## [1.7.3] - 23.04.2026
 ### Added

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -17,12 +17,14 @@ Current `1.7.4` highlights focus on the .NET 10 migration, safer destination cle
 - Passive Backups refreshes no longer wake destinations just to update reachability.
 - Backup probes now share in-flight archive buffer tuning work per destination.
 - Backup path-containment checks now share one hardened implementation across delete, restore, tray, and open-folder flows.
+- Imported destination history rebuilt from legacy backup folders now keeps real backup sizes instead of showing `0 B`, and existing imported `0 B` rows are repaired when their folders are still present.
 
 ### Diagnostics and app polish
 - The log console copy button now uses the active console window clipboard.
 - Normal diagnostics no longer show caught SQLite/WinRT first-chance probes unless first-chance diagnostics are explicitly enabled.
 - The in-app What's New dialog now reads only the current release slice and presents it as a cleaner release digest.
 - Repeated UI byte-size formatting and detached async-command wrappers now use shared helpers.
+- Changing language in Settings now preserves the active theme and keeps the page near the same scroll position through the relayout.
 
 ### Presets and generated output
 - Development and creative presets now exclude nested generated outputs such as build, cache, import, and render folders.

--- a/src/VaultSync.Core/Repositories/SqliteRepository.cs
+++ b/src/VaultSync.Core/Repositories/SqliteRepository.cs
@@ -690,6 +690,14 @@ DELETE FROM sqlite_sequence;";
                 new { externalId, id = snapshotId });
         }
 
+        public void UpdateSnapshotTotalBytes(int snapshotId, long totalBytes)
+        {
+            using SqliteConnection c = Open();
+            c.Execute(
+                "UPDATE snapshots SET total_bytes = @totalBytes WHERE id = @id;",
+                new { totalBytes = Math.Max(0, totalBytes), id = snapshotId });
+        }
+
         public Snapshot? GetLatestSnapshot(int projectId)
         {
             return GetLatestSnapshotForProject(projectId);
@@ -1122,6 +1130,14 @@ DELETE FROM sqlite_sequence;";
             c.Execute(
                 "UPDATE backups SET external_id = @externalId WHERE id = @id;",
                 new { externalId, id = backupId });
+        }
+
+        public void UpdateBackupTotalBytes(int backupId, long totalBytes)
+        {
+            using SqliteConnection c = Open();
+            c.Execute(
+                "UPDATE backups SET total_bytes = @totalBytes WHERE id = @id;",
+                new { totalBytes = Math.Max(0, totalBytes), id = backupId });
         }
 
         public void UpdateBackupProjectId(int backupId, int projectId)

--- a/src/VaultSync.Core/Services/MetadataSyncService.cs
+++ b/src/VaultSync.Core/Services/MetadataSyncService.cs
@@ -53,7 +53,8 @@ public sealed class MetadataSyncService(SqliteRepository repo)
                 if (legacyResult.Status == MetadataSyncStatus.Success &&
                     (legacyResult.ImportedProjects > 0 ||
                      legacyResult.ImportedSnapshots > 0 ||
-                     legacyResult.ImportedBackups > 0))
+                     legacyResult.ImportedBackups > 0 ||
+                     legacyResult.RepairedBackups > 0))
                 {
                     return legacyResult;
                 }
@@ -883,25 +884,37 @@ public sealed class MetadataSyncService(SqliteRepository repo)
         int importedProjects = 0;
         int importedSnapshots = 0;
         int importedBackups = 0;
+        int repairedBackups = 0;
         var affectedProjectIds = new HashSet<int>();
         var projectsByName = _repo
             .GetAllProjects()
             .ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
         IReadOnlyDictionary<string, int> snapshotExternalMap = _repo.GetSnapshotExternalIdMap();
         IReadOnlyDictionary<string, int> backupExternalMap = _repo.GetBackupExternalIdMap();
-        var existingBackupPaths = _repo
+        var existingBackupByPath = _repo
             .GetAllProjects()
             .SelectMany(project => _repo.GetBackupsForProject(project.Id))
-            .Select(backup => NormalizeStablePath(NormalizeBackupPathRel(backup.Path)))
-            .Where(path => !string.IsNullOrWhiteSpace(path))
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            .Select(backup => new
+            {
+                Backup = backup,
+                Path = NormalizeStablePath(NormalizeBackupPathRel(backup.Path))
+            })
+            .Where(entry => !string.IsNullOrWhiteSpace(entry.Path))
+            .GroupBy(entry => entry.Path, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.First().Backup, StringComparer.OrdinalIgnoreCase);
 
         foreach (IGrouping<string, LegacyBackupFolder> projectGroup in discovered.GroupBy(folder => folder.ProjectName, StringComparer.OrdinalIgnoreCase))
         {
             List<LegacyBackupFolder> importableFolders = [.. projectGroup
-                .Where(folder => !existingBackupPaths.Contains(NormalizeStablePath(folder.RelativePath)))
+                .Where(folder => !existingBackupByPath.ContainsKey(NormalizeStablePath(folder.RelativePath)))
                 .OrderBy(folder => folder.CreatedUtc)];
-            if (importableFolders.Count == 0)
+            List<LegacyBackupFolder> repairableFolders = [.. projectGroup
+                .Where(folder =>
+                    existingBackupByPath.TryGetValue(NormalizeStablePath(folder.RelativePath), out Backup? backup) &&
+                    backup.IsImported &&
+                    backup.TotalBytes <= 0)
+                .OrderBy(folder => folder.CreatedUtc)];
+            if (importableFolders.Count == 0 && repairableFolders.Count == 0)
                 continue;
 
             string projectName = projectGroup.Key;
@@ -937,11 +950,31 @@ public sealed class MetadataSyncService(SqliteRepository repo)
                 projectsByName[projectName] = project;
             }
 
+            foreach (LegacyBackupFolder folder in repairableFolders)
+            {
+                string normalizedRelativePath = NormalizeStablePath(folder.RelativePath);
+                if (!existingBackupByPath.TryGetValue(normalizedRelativePath, out Backup? existingBackup))
+                    continue;
+
+                long sizeBytes = GetLegacyBackupFolderSize(rootPath, folder.RelativePath);
+                if (sizeBytes <= 0)
+                    continue;
+
+                _repo.UpdateBackupTotalBytes(existingBackup.Id, sizeBytes);
+                Snapshot? existingSnapshot = _repo.GetSnapshotById(existingBackup.SnapshotId);
+                if (existingSnapshot is not null && existingSnapshot.TotalBytes <= 0)
+                    _repo.UpdateSnapshotTotalBytes(existingSnapshot.Id, sizeBytes);
+
+                repairedBackups++;
+                affectedProjectIds.Add(existingBackup.ProjectId);
+            }
+
             foreach (LegacyBackupFolder folder in importableFolders)
             {
                 string normalizedRelativePath = NormalizeStablePath(folder.RelativePath);
                 string snapshotExternalId = BuildStableExternalId("legacy-snapshot", rootPath, folder.RelativePath);
                 string backupExternalId = BuildStableExternalId("legacy-backup", rootPath, folder.RelativePath);
+                long sizeBytes = GetLegacyBackupFolderSize(rootPath, folder.RelativePath);
 
                 if (!snapshotExternalMap.TryGetValue(snapshotExternalId, out int snapshotId))
                 {
@@ -950,7 +983,7 @@ public sealed class MetadataSyncService(SqliteRepository repo)
                         project.Id,
                         folder.CreatedUtc,
                         fileCount: 0,
-                        totalBytes: 0);
+                        totalBytes: sizeBytes);
                     importedSnapshots++;
                 }
 
@@ -963,7 +996,7 @@ public sealed class MetadataSyncService(SqliteRepository repo)
                     snapshotId,
                     folder.CreatedUtc,
                     "manual",
-                    0,
+                    sizeBytes,
                     folder.RelativePath,
                     rootPath,
                     string.Empty,
@@ -973,7 +1006,8 @@ public sealed class MetadataSyncService(SqliteRepository repo)
 
                 importedBackups++;
                 affectedProjectIds.Add(project.Id);
-                existingBackupPaths.Add(normalizedRelativePath);
+                existingBackupByPath[normalizedRelativePath] = _repo.GetBackupByExternalId(backupExternalId)
+                    ?? new Backup { Id = 0, ProjectId = project.Id, SnapshotId = snapshotId, Path = folder.RelativePath, TotalBytes = sizeBytes, IsImported = true };
             }
 
             if (opts.MarkNeedsRestoreOnImport && affectedProjectIds.Contains(project.Id))
@@ -990,7 +1024,8 @@ public sealed class MetadataSyncService(SqliteRepository repo)
             0,
             string.Empty)
         {
-            AffectedProjectIds = [.. affectedProjectIds]
+            AffectedProjectIds = [.. affectedProjectIds],
+            RepairedBackups = repairedBackups
         };
     }
 
@@ -1122,6 +1157,64 @@ public sealed class MetadataSyncService(SqliteRepository repo)
             CultureInfo.InvariantCulture,
             DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
             out createdUtc);
+    }
+
+    private static long GetLegacyBackupFolderSize(string rootPath, string relativePath)
+    {
+        if (string.IsNullOrWhiteSpace(rootPath) || string.IsNullOrWhiteSpace(relativePath))
+            return 0;
+
+        try
+        {
+            string backupFolder = Path.Combine(rootPath, relativePath);
+            long archiveSize = BackupArchiveCryptoService.GetStoredArchiveSize(backupFolder);
+            return archiveSize > 0 ? archiveSize : GetDirectorySize(backupFolder);
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+
+    private static long GetDirectorySize(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path))
+            return 0;
+
+        long total = 0;
+        var pending = new Stack<string>();
+        pending.Push(path);
+
+        while (pending.Count > 0)
+        {
+            string current = pending.Pop();
+
+            try
+            {
+                foreach (string file in Directory.EnumerateFiles(current))
+                {
+                    try
+                    {
+                        total += Math.Max(0, new FileInfo(file).Length);
+                    }
+                    catch
+                    {
+                        // Best-effort size recovery for legacy imports.
+                    }
+                }
+
+                foreach (string directory in Directory.EnumerateDirectories(current))
+                {
+                    pending.Push(directory);
+                }
+            }
+            catch
+            {
+                // Skip folders that disappear or cannot be read.
+            }
+        }
+
+        return total;
     }
 
     private static string BuildStableExternalId(string prefix, string rootPath, string relativePath)
@@ -2852,6 +2945,7 @@ public sealed record MetadataSyncResult(
     string Message)
 {
     public IReadOnlyCollection<int> AffectedProjectIds { get; init; } = [];
+    public int RepairedBackups { get; init; }
 
     public static MetadataSyncResult Failure(MetadataSyncStatus status, string message) =>
         new(status, 0, 0, 0, 0, message);

--- a/src/VaultSync.UI/Services/LocalizationService.cs
+++ b/src/VaultSync.UI/Services/LocalizationService.cs
@@ -44,6 +44,7 @@ namespace VaultSync.UI.Services
 
         public string CurrentLanguage { get; private set; }
 
+        public event Action? LanguageChanging;
         public event Action? LanguageChanged;
         public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -62,6 +63,7 @@ namespace VaultSync.UI.Services
             if (!LoadLanguage(normalized))
                 return false;
 
+            LanguageChanging?.Invoke();
             CurrentLanguage = normalized;
             _pendingLanguage = normalized;
             LanguageChanged?.Invoke();

--- a/src/VaultSync.UI/ViewModels/AppViewModel.RuntimeOps.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.RuntimeOps.cs
@@ -1143,7 +1143,8 @@ namespace VaultSync.UI.ViewModels
             if (result.ImportedProjects <= 0 &&
                 result.ImportedSnapshots <= 0 &&
                 result.ImportedBackups <= 0 &&
-                result.AppliedTombstones <= 0)
+                result.AppliedTombstones <= 0 &&
+                result.RepairedBackups <= 0)
             {
                 return;
             }

--- a/src/VaultSync.UI/ViewModels/SettingsViewModel.cs
+++ b/src/VaultSync.UI/ViewModels/SettingsViewModel.cs
@@ -156,6 +156,7 @@ namespace VaultSync.UI
         private bool _isSaving;
         private bool _savePending;
         private bool _isReloadingFromConfig;
+        private bool _isRefreshingLocalizedOptions;
         private bool? _lastLaunchOnLoginApplied;
 
         public event Action? OpenLogConsoleRequested;
@@ -457,10 +458,18 @@ namespace VaultSync.UI
             {
                 string normalizedTheme = NormalizeThemeOption(_selectedTheme);
                 string normalizedBaseTheme = NormalizeThemeBaseOption(_customThemeBase);
-                RefreshThemeOptions();
-                RefreshCustomThemeBaseOptions();
-                _selectedTheme = DisplayThemeOption(normalizedTheme);
-                _customThemeBase = DisplayThemeBaseOption(normalizedBaseTheme);
+                _isRefreshingLocalizedOptions = true;
+                try
+                {
+                    RefreshThemeOptions();
+                    RefreshCustomThemeBaseOptions();
+                    _selectedTheme = DisplayThemeOption(normalizedTheme);
+                    _customThemeBase = DisplayThemeBaseOption(normalizedBaseTheme);
+                }
+                finally
+                {
+                    _isRefreshingLocalizedOptions = false;
+                }
                 OnPropertyChanged(nameof(SelectedLanguage));
                 OnPropertyChanged(nameof(SelectedTheme));
                 OnPropertyChanged(nameof(CustomThemeBase));
@@ -1342,7 +1351,7 @@ namespace VaultSync.UI
 
         private void OnSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
-            if (_isReloadingFromConfig || e.PropertyName is null || !ShouldAutoSaveProperty(e.PropertyName))
+            if (_isReloadingFromConfig || _isRefreshingLocalizedOptions || e.PropertyName is null || !ShouldAutoSaveProperty(e.PropertyName))
                 return;
 
             TriggerAutoSave();
@@ -1460,6 +1469,18 @@ namespace VaultSync.UI
 
         private string NormalizeThemeOption(string theme)
         {
+            int existingIndex = ThemeOptions.IndexOf(theme);
+            if (existingIndex >= 0)
+            {
+                return existingIndex switch
+                {
+                    1 => "Dark",
+                    2 => "Light",
+                    3 => "Custom",
+                    _ => "System"
+                };
+            }
+
             return theme switch
             {
                 var value when string.Equals(value, ThemeOptionDarkLabel, StringComparison.OrdinalIgnoreCase) => "Dark",
@@ -1488,6 +1509,12 @@ namespace VaultSync.UI
 
         private string NormalizeThemeBaseOption(string value)
         {
+            int existingIndex = CustomThemeBaseOptions.IndexOf(value);
+            if (existingIndex >= 0)
+            {
+                return existingIndex == 1 ? "Light" : "Dark";
+            }
+
             return value switch
             {
                 var candidate when string.Equals(candidate, ThemeBaseLightLabel, StringComparison.OrdinalIgnoreCase) => "Light",
@@ -1822,6 +1849,9 @@ namespace VaultSync.UI
             get => _selectedTheme;
             set
             {
+                if (_isRefreshingLocalizedOptions)
+                    return;
+
                 if (SetField(ref _selectedTheme, value))
                 {
                     OnPropertyChanged(nameof(IsCustomThemeSelected));
@@ -1856,6 +1886,9 @@ namespace VaultSync.UI
             get => _customThemeBase;
             set
             {
+                if (_isRefreshingLocalizedOptions)
+                    return;
+
                 string normalized = DisplayThemeBaseOption(NormalizeThemeBaseOption(value));
                 if (!SetField(ref _customThemeBase, normalized))
                     return;
@@ -4584,5 +4617,3 @@ namespace VaultSync.UI
         public bool ShowPassword { get => _showPassword; set => SetField(ref _showPassword, value); }
     }
 }
-
-

--- a/src/VaultSync.UI/Views/SettingsView.axaml.cs
+++ b/src/VaultSync.UI/Views/SettingsView.axaml.cs
@@ -12,6 +12,8 @@ namespace VaultSync.UI
         private ScrollViewer? _scrollViewer;
         private double _pendingScrollOffset;
         private bool _restoreScrollPending;
+        private int _restoreScrollAttempts;
+        private DispatcherTimer? _restoreScrollTimer;
 
         public SettingsView()
         {
@@ -36,6 +38,7 @@ namespace VaultSync.UI
             LocalizationService? localization = LocalizationProvider.Service;
             if (localization != null)
             {
+                localization.LanguageChanging += CaptureScrollOffset;
                 localization.LanguageChanged += OnLanguageChanged;
             }
         }
@@ -45,6 +48,7 @@ namespace VaultSync.UI
             LocalizationService? localization = LocalizationProvider.Service;
             if (localization != null)
             {
+                localization.LanguageChanging -= CaptureScrollOffset;
                 localization.LanguageChanged -= OnLanguageChanged;
             }
 
@@ -53,6 +57,12 @@ namespace VaultSync.UI
                 _scrollViewer.LayoutUpdated -= OnScrollViewerLayoutUpdated;
                 _scrollViewer = null;
             }
+
+            if (_restoreScrollTimer != null)
+            {
+                _restoreScrollTimer.Stop();
+                _restoreScrollTimer = null;
+            }
         }
 
         private void OnLanguageChanged()
@@ -60,25 +70,60 @@ namespace VaultSync.UI
             if (_scrollViewer == null)
                 return;
 
+            _restoreScrollPending = true;
+            _restoreScrollAttempts = 12;
+            EnsureScrollRestoreTimer();
+            ApplyPendingScroll(countAttempt: false);
+        }
+
+        private void CaptureScrollOffset()
+        {
+            if (_scrollViewer == null)
+                return;
+
             _pendingScrollOffset = _scrollViewer.Offset.Y;
             _restoreScrollPending = true;
-
-            Dispatcher.UIThread.Post(ApplyPendingScroll, DispatcherPriority.Background);
         }
 
         private void OnScrollViewerLayoutUpdated(object? sender, EventArgs e)
         {
-            ApplyPendingScroll();
+            ApplyPendingScroll(countAttempt: false);
         }
 
-        private void ApplyPendingScroll()
+        private void ApplyPendingScroll(bool countAttempt = true)
         {
             if (!_restoreScrollPending || _scrollViewer == null)
                 return;
 
-            _restoreScrollPending = false;
             Vector current = _scrollViewer.Offset;
             _scrollViewer.Offset = new Vector(current.X, _pendingScrollOffset);
+
+            if (countAttempt && _restoreScrollAttempts > 0)
+                _restoreScrollAttempts--;
+
+            if (_restoreScrollAttempts > 0)
+                return;
+
+            _restoreScrollPending = false;
+            _restoreScrollTimer?.Stop();
+        }
+
+        private void EnsureScrollRestoreTimer()
+        {
+            if (_restoreScrollTimer is not null)
+            {
+                _restoreScrollTimer.Stop();
+            }
+            else
+            {
+                _restoreScrollTimer = new DispatcherTimer
+                {
+                    Interval = TimeSpan.FromMilliseconds(50)
+                };
+                _restoreScrollTimer.Tick += (_, _) => ApplyPendingScroll(countAttempt: true);
+            }
+
+            _restoreScrollTimer.Start();
         }
     }
 }

--- a/tests/VaultSync.Core.Tests/MetadataSyncTests.cs
+++ b/tests/VaultSync.Core.Tests/MetadataSyncTests.cs
@@ -86,8 +86,12 @@ public sealed class MetadataSyncTests : IDisposable
         string dbPath = Path.Combine(CreateTempDir(), "vaultsync.db");
         string projectsRoot = CreateTempDir();
         string projectFolder = Path.Combine(metaRoot, "blueprints");
-        Directory.CreateDirectory(Path.Combine(projectFolder, "2026-05-06_08-15-06"));
-        Directory.CreateDirectory(Path.Combine(projectFolder, "2026-05-07_12-42-10"));
+        string firstBackupFolder = Path.Combine(projectFolder, "2026-05-06_08-15-06");
+        string secondBackupFolder = Path.Combine(projectFolder, "2026-05-07_12-42-10");
+        Directory.CreateDirectory(firstBackupFolder);
+        Directory.CreateDirectory(secondBackupFolder);
+        File.WriteAllBytes(Path.Combine(firstBackupFolder, "data.bin"), new byte[123]);
+        File.WriteAllBytes(Path.Combine(secondBackupFolder, "data.bin"), new byte[456]);
         AppConfig originalConfig = CloneConfig(AppConfigStore.Load());
 
         try
@@ -125,6 +129,8 @@ public sealed class MetadataSyncTests : IDisposable
             List<Backup> backups = [.. repo.GetBackupsForProject(project.Id)];
             Assert.Equal(2, backups.Count);
             Assert.All(backups, backup => Assert.True(backup.IsImported));
+            Assert.Contains(backups, backup => backup.TotalBytes == 123);
+            Assert.Contains(backups, backup => backup.TotalBytes == 456);
             Assert.Contains(backups, backup => backup.Path == Path.Combine("blueprints", "2026-05-06_08-15-06"));
             Assert.Contains(backups, backup => backup.Path == Path.Combine("blueprints", "2026-05-07_12-42-10"));
         }
@@ -140,8 +146,12 @@ public sealed class MetadataSyncTests : IDisposable
         string backupRoot = CreateTempDir();
         string dbPath = Path.Combine(CreateTempDir(), "vaultsync.db");
         string projectsRoot = CreateTempDir();
-        Directory.CreateDirectory(Path.Combine(backupRoot, "risiko-3d", "2026-05-06_10-14-22"));
-        Directory.CreateDirectory(Path.Combine(backupRoot, "risiko-3d", "2026-05-07_09-00-00"));
+        string firstBackupFolder = Path.Combine(backupRoot, "risiko-3d", "2026-05-06_10-14-22");
+        string secondBackupFolder = Path.Combine(backupRoot, "risiko-3d", "2026-05-07_09-00-00");
+        Directory.CreateDirectory(firstBackupFolder);
+        Directory.CreateDirectory(secondBackupFolder);
+        File.WriteAllBytes(Path.Combine(firstBackupFolder, "data.bin"), new byte[321]);
+        File.WriteAllBytes(Path.Combine(secondBackupFolder, "data.bin"), new byte[654]);
         Directory.CreateDirectory(Path.Combine(backupRoot, ".vaultsync"));
         AppConfig originalConfig = CloneConfig(AppConfigStore.Load());
 
@@ -163,7 +173,58 @@ public sealed class MetadataSyncTests : IDisposable
             Project project = repo.GetProjectByName("risiko-3d");
             Assert.NotNull(project);
             Assert.Equal(Path.Combine(projectsRoot, "risiko-3d"), project!.RootPath);
-            Assert.Equal(2, repo.GetBackupsForProject(project.Id).Count());
+            List<Backup> backups = [.. repo.GetBackupsForProject(project.Id)];
+            Assert.Equal(2, backups.Count);
+            Assert.Contains(backups, backup => backup.TotalBytes == 321);
+            Assert.Contains(backups, backup => backup.TotalBytes == 654);
+        }
+        finally
+        {
+            AppConfigStore.Save(originalConfig);
+        }
+    }
+
+    [Fact]
+    public void ImportFromStore_RepairsZeroByteLegacyImportedBackups()
+    {
+        string backupRoot = CreateTempDir();
+        string dbPath = Path.Combine(CreateTempDir(), "vaultsync.db");
+        string projectsRoot = CreateTempDir();
+        string backupFolder = Path.Combine(backupRoot, "legacy-project", "2026-05-08_10-00-00");
+        Directory.CreateDirectory(backupFolder);
+        AppConfig originalConfig = CloneConfig(AppConfigStore.Load());
+
+        try
+        {
+            AppConfig cfg = CloneConfig(originalConfig);
+            cfg.ProjectsRoot = projectsRoot;
+            AppConfigStore.Save(cfg);
+
+            SqliteRepository repo = CreateRepository(dbPath);
+            var service = new MetadataSyncService(repo);
+            MetadataSyncResult firstImport = service.ImportFromStore(backupRoot, MetadataSyncOptions.Default);
+
+            Assert.Equal(MetadataSyncStatus.Success, firstImport.Status);
+            Assert.Equal(1, firstImport.ImportedBackups);
+
+            Project project = repo.GetProjectByName("legacy-project");
+            Assert.NotNull(project);
+            Backup originalBackup = Assert.Single(repo.GetBackupsForProject(project!.Id));
+            Assert.Equal(0, originalBackup.TotalBytes);
+
+            File.WriteAllBytes(Path.Combine(backupFolder, "restored-size.bin"), new byte[789]);
+
+            MetadataSyncResult repairImport = service.ImportFromStore(backupRoot, MetadataSyncOptions.Default);
+
+            Assert.Equal(MetadataSyncStatus.Success, repairImport.Status);
+            Assert.Equal(0, repairImport.ImportedBackups);
+            Assert.Equal(1, repairImport.RepairedBackups);
+
+            Backup repairedBackup = Assert.Single(repo.GetBackupsForProject(project.Id));
+            Assert.Equal(789, repairedBackup.TotalBytes);
+            Snapshot repairedSnapshot = repo.GetSnapshotById(repairedBackup.SnapshotId);
+            Assert.NotNull(repairedSnapshot);
+            Assert.Equal(789, repairedSnapshot!.TotalBytes);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- Fix imported legacy destination history showing 0 B by measuring folder/archive sizes and repairing existing imported 0 B rows when the folder still exists.
- Preserve Settings theme selection and scroll position when changing language.
- Update changelog and in-app What's New notes for the beta fixes.

## Issues
Closes #298
Closes #297

## Validation
- dotnet build VaultSync.sln
- dotnet test VaultSync.sln --no-build