### PR TITLE
Prepare VaultSync 1.7.5 cleanup and metadata performance pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,21 @@
 ﻿# Changelog
+## [1.7.5] - Unreleased
+### Changed
+- [VS-1745] Centralized NuGet package versions in `Directory.Packages.props` and removed unused package references.
+- [VS-1746] Routed app configuration access through a shared `IAppConfigStore` adapter so core, CLI, and UI code no longer depend directly on static config calls.
+- [VS-1747] Added shared runtime logging and hash-formatting helpers to reduce duplicated service plumbing.
+- [VS-1748] Standardized repeated view-model property updates on existing shared base helpers.
+- [VS-1749] Consolidated core test fixtures for temporary directories, config isolation, and repository/project setup.
+- [VS-1750] Reused destination path normalization across identity and quota planning code.
+- [VS-1751] Added a shared dependent-property notification helper for UI view models.
+- [VS-1752] Added verbose-only runtime timing scopes around startup background work, deferred metadata imports, update checks, and Dashboard refresh phases.
+- [VS-1753] Extracted Dashboard recent-activity projection so refreshes reuse a project lookup instead of scanning projects per activity row.
+- [VS-1754] Added reusable test builders for projects, backups, and backup destinations.
+- [VS-1755] Centralized byte and signed-byte formatting for UI and CLI callers.
+- [VS-1756] Consolidated repeated Dashboard, Backups, Projects, and Settings dependent-property notifications.
+- [VS-1757] Routed NetworkMount diagnostics through one local logging helper instead of repeating log prefixes inline.
+- [VS-1758] Added a durable unchanged-source cache for background metadata auto-imports and phase timings for metadata import internals.
+
 ## [1.7.4] - 20.05.2026
 ### Added
 - [VS-1732] Release publish restore now declares Windows, Linux, and macOS RIDs.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,47 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Core storage and platform APIs -->
+    <PackageVersion Include="Dapper" Version="2.1.79" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.8" />
+    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.8" />
+
+    <!-- CLI -->
+    <PackageVersion Include="Spectre.Console" Version="0.55.2" />
+    <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />
+
+    <!-- Avalonia UI -->
+    <PackageVersion Include="Avalonia" Version="11.3.15" />
+    <PackageVersion Include="Avalonia.Controls.ColorPicker" Version="11.3.15" />
+    <PackageVersion Include="Avalonia.Desktop" Version="11.3.15" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.15" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.15" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.15" />
+    <PackageVersion Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.4" />
+
+    <!-- Text and rendering native assets -->
+    <PackageVersion Include="SkiaSharp" Version="3.119.2" />
+    <PackageVersion Include="SkiaSharp.HarfBuzz" Version="3.119.2" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.2" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.macOS" Version="3.119.2" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="3.119.2" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Win32" Version="3.119.2" />
+    <PackageVersion Include="HarfBuzzSharp" Version="8.3.1.3" />
+    <PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.1.3" />
+    <PackageVersion Include="HarfBuzzSharp.NativeAssets.macOS" Version="8.3.1.3" />
+    <PackageVersion Include="HarfBuzzSharp.NativeAssets.WebAssembly" Version="8.3.1.3" />
+    <PackageVersion Include="HarfBuzzSharp.NativeAssets.Win32" Version="8.3.1.3" />
+
+    <!-- Windows-only UI integrations -->
+    <PackageVersion Include="CommunityToolkit.WinUI.Notifications" Version="7.1.2" />
+    <PackageVersion Include="System.Drawing.Common" Version="10.0.8" />
+
+    <!-- Tests -->
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+</Project>

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -6,7 +6,7 @@ This document defines the current release packaging flow.
 - .NET 10 SDK
 - Inno Setup (Windows installer)
 - Repo version/changelog already updated for the target release
-- The prepared stable release target is `1.7.4`; prerelease builds for the active patch train use `1.7.4-Beta.N` until the stable release is cut.
+- The prepared stable release target is `1.7.5`; prerelease builds for the active patch train use `1.7.5-Beta.N` until the stable release is cut.
 
 ## 1) Windows Installer
 1. Publish:
@@ -33,8 +33,8 @@ This document defines the current release packaging flow.
    ```
 2. Build Linux archives:
    ```bash
-   bash scripts/build_linux_release.sh 1.7.4 x64 src/VaultSync.UI/bin/Release/net10.0/linux-x64/publish
-   bash scripts/build_linux_release.sh 1.7.4 arm64 src/VaultSync.UI/bin/Release/net10.0/linux-arm64/publish
+   bash scripts/build_linux_release.sh 1.7.5 x64 src/VaultSync.UI/bin/Release/net10.0/linux-x64/publish
+   bash scripts/build_linux_release.sh 1.7.5 arm64 src/VaultSync.UI/bin/Release/net10.0/linux-arm64/publish
    ```
 3. Upload the generated `.tar.gz`, `.deb`, and `linux-x64` `.AppImage` artifacts.
    The `.tar.gz` archives include `install.sh` and `uninstall.sh` for a
@@ -57,13 +57,13 @@ Stable example:
 - branch: `Stable`
 - release channel: `stable`
 - `previous_version = 1.7.3`
-- `target_version = 1.7.4`
+- `target_version = 1.7.5`
 
 Current beta example:
 - branch: `Dev`
 - release channel: `beta`
-- `previous_version = 1.7.4-Beta.2`
-- `target_version = 1.7.4-Beta.3`
+- `previous_version = 1.7.5-Beta.1`
+- `target_version = 1.7.5-Beta.2`
 - `include_linux_patches = false` when the previous Linux build can be installed under `/opt/vaultsync`, so Linux users receive installer fallback instead of an unwritable patch apply.
 
 Example multi-base input:

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,43 +1,24 @@
 # What's New
 
-## [1.7.4]
+## [1.7.5]
 
-Current `1.7.4-Beta.3` highlights focus on the .NET 10 migration, safer destination cleanup, quieter diagnostics, and release-readiness polish across the 1.7 train.
+Current `1.7.5` highlights focus on making the codebase more reusable and maintainable while tightening metadata-import performance diagnostics.
 
-### Platform and release updates
-- Core, CLI, UI, and tests now target .NET 10.
-- Release workflows and documentation now use the .NET 10 SDK and publish paths.
-- The Windows installer metadata now points at the .NET 10 Windows publish output.
-- CLI packaging now includes the repository README from the correct path.
-- Release examples, issue templates, and release notes now target the prepared `1.7.4` release.
+### Architecture and maintainability
+- Package versions now live in one central props file instead of being repeated across projects.
+- Configuration access, runtime logging, hash formatting, byte-size formatting, and common test setup now use shared helpers.
+- View models reuse common property-notification helpers, reducing repeated UI plumbing.
+- Core tests use shared temporary directory, config, repository, and builder fixtures.
 
-### Backup and destination reliability
-- Backups now prune stale database entries when recorded backup folders are missing from reachable prepared destinations.
-- Offline or unresolved destinations are left untouched, so disconnected drives are not treated as deleted backups.
-- Passive Backups refreshes no longer wake destinations just to update reachability.
-- Backup probes now share in-flight archive buffer tuning work per destination.
-- Backup path-containment checks now share one hardened implementation across delete, restore, tray, and open-folder flows.
-- Imported destination history rebuilt from legacy backup folders now keeps real backup sizes instead of showing `0 B`, and existing imported `0 B` rows are repaired when their folders are still present.
-- Linux auto backups now ignore peripheral batteries when deciding whether to pause on battery power, and timer decisions are easier to diagnose from logs.
-- Auto backups now warm up active destinations before running and retry preparation after a short cooldown, helping sleeping drives wake before the backup attempt.
+### Performance and diagnostics
+- Dashboard refresh work now has verbose timing around data load, dispatcher wait, and individual rebuild phases.
+- Recent activity projection reuses a project lookup instead of scanning projects per activity row.
+- Background metadata auto-imports remember successful unchanged sources and can skip repeated imports when the remote store files have not changed.
+- Metadata import internals now report phase timings for temp-copy, row reads, backup apply, legacy folder scan, and restore flag updates.
 
-### Diagnostics and app polish
-- The log console copy button now uses the active console window clipboard.
-- Normal diagnostics no longer show caught SQLite/WinRT first-chance probes unless first-chance diagnostics are explicitly enabled.
-- The in-app What's New dialog now reads only the current release slice and presents it as a cleaner release digest.
-- Repeated UI byte-size formatting and detached async-command wrappers now use shared helpers.
-- Changing language in Settings now preserves the active theme and keeps the page near the same scroll position through the relayout.
-- Backup summary cards plus action and filter buttons now keep long localized labels inside their bounds in windowed layouts.
-- The log console keeps its readable styled rows, supports selecting and copying multiple log entries, and filters expected Linux DBus/IBus desktop noise.
-- The What's New dialog now opens centered over the main app window on multi-monitor desktops.
-- Linux SMART probe errors such as permission or unsupported-device output no longer look like failing disks or block backups.
-- Linux `.deb` packages now carry AppStream metadata, richer details, homepage data, and matching desktop/icon IDs for better software-center previews.
-- Linux windows now set the app icon explicitly and launcher metadata uses the executable WM class so taskbars can show the VaultSync icon.
-- Linux tray refreshes now reuse the existing native menu object to avoid duplicate tray indicators on AppIndicator hosts.
-- Linux packages now include hidden desktop identity fallbacks so taskbars can match the `VaultSync.UI` runtime window to the VaultSync icon.
-- Dependency-alert package versions were refreshed across core, UI, and tests while keeping the app on the Avalonia 11 release line.
-- Project roots imported from another OS now remap to matching local folders under the configured Projects root, including Windows-path leaf names and case-only folder differences on Linux.
-- Patched SkiaSharp and HarfBuzzSharp runtime packages are now pinned explicitly so dependency graph alerts do not resolve Avalonia's older transitive graphics stack.
+### Cleanup
+- Destination path normalization and NetworkMount diagnostics now reuse common helpers.
+- The 1.7.5 changelog records the cleanup work as versioned release notes.
 - Linux protected installs such as `/opt/vaultsync` now use the installer fallback instead of attempting a patch update that cannot write to root-owned files, and release asset builds can omit Linux patch assets when an installer-only Linux update is required.
 - Linux updater fallback now prefers `.deb` installers on Debian-family systems and marks downloaded AppImages executable before launch.
 - Linux startup now keeps Avalonia's compatible DBus protocol dependency instead of overriding it with an incompatible newer package.

--- a/installer/VaultSyncInstaller.iss
+++ b/installer/VaultSyncInstaller.iss
@@ -1,5 +1,5 @@
 ﻿#define MyAppName "VaultSync"
-#define MyAppVersion "1.7.4"
+#define MyAppVersion "1.7.5"
 #define MyAppPublisher "Flavio Giacchetti"
 #define MyAppExeName "VaultSync.UI.exe"
 #define AppOutputDir "..\\src\\VaultSync.UI\\bin\\Release\\net10.0-windows10.0.19041.0\\win-x64\\publish"

--- a/src/VaultSync.CLI/Commands/DestinationCommand.cs
+++ b/src/VaultSync.CLI/Commands/DestinationCommand.cs
@@ -22,7 +22,7 @@ namespace VaultSync.CLI.Commands
     {
         protected override Task<int> ExecuteAsync(CommandContext context, DestinationSettings settings, CancellationToken ct)
         {
-            AppConfig config = AppConfigStore.Load();
+            AppConfig config = ConfigHelper.Load();
             List<BackupDestination> destinations = BuildActiveDestinations(config);
             if (destinations.Count == 0)
             {

--- a/src/VaultSync.CLI/Commands/InitCommand.cs
+++ b/src/VaultSync.CLI/Commands/InitCommand.cs
@@ -21,10 +21,10 @@ namespace VaultSync.CLI.Commands
         {
             string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
             string targetDb = string.IsNullOrWhiteSpace(s.Db)
-                ? AppConfigStore.GetDefaultDbPath()
+                ? ConfigHelper.GetDefaultDbPath()
                 : s.Db.Replace("~", home);
 
-            AppConfig cfg = AppConfigStore.Load();
+            AppConfig cfg = ConfigHelper.Load();
             cfg.DbPath = targetDb;
             ConfigHelper.Save(cfg);
 

--- a/src/VaultSync.CLI/Commands/ProjectCommands.cs
+++ b/src/VaultSync.CLI/Commands/ProjectCommands.cs
@@ -156,7 +156,7 @@ namespace VaultSync.CLI.Commands
     {
         protected override async Task<int> ExecuteAsync(CommandContext context, DiscoverProjectsSettings s, CancellationToken ct)
         {
-            AppConfig config = AppConfigStore.Load();
+            AppConfig config = ConfigHelper.Load();
 
             if (!string.IsNullOrWhiteSpace(s.OverrideRoot))
             {
@@ -187,27 +187,14 @@ namespace VaultSync.CLI.Commands
             foreach (DiscoveredProject p in projects)
             {
                 string lastSnapshot = p.LastSnapshotTime?.ToString("u") ?? "-";
-                string size = p.LastSnapshotSizeBytes.HasValue ? FormatSize(p.LastSnapshotSizeBytes.Value) : "-";
+                string size = p.LastSnapshotSizeBytes.HasValue
+                    ? ByteSizeFormat.FormatBytes(p.LastSnapshotSizeBytes.Value, "0.#")
+                    : "-";
                 table.AddRow(p.Name, p.Path, lastSnapshot, size);
             }
 
             AnsiConsole.Write(table);
             return 0;
-        }
-
-        private static string FormatSize(long bytes)
-        {
-            string[] sizes = ["B", "KB", "MB", "GB", "TB"];
-            double len = bytes;
-            int order = 0;
-
-            while (len >= 1024 && order < sizes.Length - 1)
-            {
-                order++;
-                len /= 1024;
-            }
-
-            return $"{len:0.#} {sizes[order]}";
         }
     }
 }

--- a/src/VaultSync.CLI/Config/ConfigHelper.cs
+++ b/src/VaultSync.CLI/Config/ConfigHelper.cs
@@ -11,6 +11,8 @@ namespace VaultSync.CLI.Config
     /// </summary>
     static class ConfigHelper
     {
+        private static readonly IAppConfigStore ConfigStore = StaticAppConfigStore.Instance;
+
         private sealed class LegacyCliConfig
         {
             public string Database { get; set; } = string.Empty;
@@ -31,15 +33,15 @@ namespace VaultSync.CLI.Config
             Directory.CreateDirectory(Path.Combine(dir, "logs"));
 
             if (string.IsNullOrWhiteSpace(cfg.DbPath))
-                cfg.DbPath = AppConfigStore.GetDefaultDbPath();
+                cfg.DbPath = GetDefaultDbPath();
 
-            AppConfigStore.Save(cfg);
+            ConfigStore.Save(cfg);
         }
 
         public static AppConfig Load()
         {
             // Load the shared config first.
-            AppConfig cfg = AppConfigStore.Load();
+            AppConfig cfg = ConfigStore.Load();
 
             // If a legacy CLI config exists with a Database value, migrate it into DbPath.
             LegacyCliConfig? legacy = TryLoadLegacy();
@@ -49,7 +51,7 @@ namespace VaultSync.CLI.Config
                 if (string.IsNullOrWhiteSpace(cfg.DbPath))
                 {
                     cfg.DbPath = expanded;
-                    AppConfigStore.Save(cfg);
+                    ConfigStore.Save(cfg);
                 }
             }
 
@@ -63,7 +65,7 @@ namespace VaultSync.CLI.Config
                 return ExpandHome(overridePath);
 
             // 2. Shared AppConfig.DbPath (ensures a single DB location for CLI + UI).
-            AppConfig cfg = AppConfigStore.Load();
+            AppConfig cfg = ConfigStore.Load();
             if (!string.IsNullOrWhiteSpace(cfg.DbPath))
                 return ExpandHome(cfg.DbPath);
 
@@ -73,8 +75,10 @@ namespace VaultSync.CLI.Config
                 return ExpandHome(legacy.Database);
 
             // 4. Safe default from shared store.
-            return AppConfigStore.GetDefaultDbPath();
+            return GetDefaultDbPath();
         }
+
+        public static string GetDefaultDbPath() => ConfigStore.GetDefaultDbPath();
 
         private static string ExpandHome(string path)
         {

--- a/src/VaultSync.CLI/VaultSync.CLI.csproj
+++ b/src/VaultSync.CLI/VaultSync.CLI.csproj
@@ -5,9 +5,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Namotion.Reflection" Version="3.5.1" />
-    <PackageReference Include="Spectre.Console" Version="0.55.2" />
-    <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
+    <PackageReference Include="Spectre.Console" />
+    <PackageReference Include="Spectre.Console.Cli" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/VaultSync.Core/Config/AppConfig.cs
+++ b/src/VaultSync.Core/Config/AppConfig.cs
@@ -344,6 +344,7 @@ namespace VaultSync.Core.Config
         public MaintenanceConfig Maintenance { get; set; } = new();
         public StartupDiagnosticsSummary StartupDiagnostics { get; set; } = new();
         public CheckpointResumeTelemetry CheckpointResumeTelemetry { get; set; } = new();
+        public MetadataImportCacheConfig MetadataImportCache { get; set; } = new();
     }
 
     public sealed class MaintenanceConfig
@@ -465,6 +466,28 @@ namespace VaultSync.Core.Config
         public long LastArchiveSizeBytes { get; set; }
         public string LastSourceFingerprint { get; set; } = string.Empty;
         public string LastMessage { get; set; } = string.Empty;
+    }
+
+    public sealed class MetadataImportCacheConfig
+    {
+        public List<MetadataImportSourceStamp> Sources { get; set; } = [];
+    }
+
+    public sealed class MetadataImportSourceStamp
+    {
+        public string SourceKey { get; set; } = string.Empty;
+        public string SourcePath { get; set; } = string.Empty;
+        public string SourceMachineId { get; set; } = string.Empty;
+        public string StoreUpdatedUtc { get; set; } = string.Empty;
+        public int StoreSchemaVersion { get; set; }
+        public long StoreFileLengthBytes { get; set; }
+        public string StoreFileUpdatedUtc { get; set; } = string.Empty;
+        public string StoreSidecarStamp { get; set; } = string.Empty;
+        public string ImportedUtc { get; set; } = string.Empty;
+        public int ProjectCount { get; set; }
+        public int SnapshotCount { get; set; }
+        public int BackupCount { get; set; }
+        public int TombstoneCount { get; set; }
     }
 
     public sealed class StartupDiagnosticsPhase

--- a/src/VaultSync.Core/Config/AppConfigStore.cs
+++ b/src/VaultSync.Core/Config/AppConfigStore.cs
@@ -19,13 +19,25 @@ namespace VaultSync.Core.Config
 
         private static readonly SemaphoreSlim SaveGate = new(1, 1);
         private static readonly object LastKnownGoodGate = new();
-        private static readonly string ConfigDir = ResolveConfigDir();
+        private static readonly object ConfigPathGate = new();
+        private static string? TestConfigDirOverride;
         private static int _firstLoadState; // 0=unknown, 1=missing config, 2=existing config
 
-        private static readonly string ConfigFilePath =
+        private static string ConfigDir
+        {
+            get
+            {
+                lock (ConfigPathGate)
+                {
+                    return TestConfigDirOverride ?? ResolveConfigDir();
+                }
+            }
+        }
+
+        private static string ConfigFilePath =>
             Path.Combine(ConfigDir, "appsettings.json");
 
-        private static readonly string ConfigBackupFilePath =
+        private static string ConfigBackupFilePath =>
             Path.Combine(ConfigDir, "appsettings.bak.json");
 
         private static AppConfig? LastKnownGoodConfig;
@@ -36,6 +48,25 @@ namespace VaultSync.Core.Config
         };
 
         public static bool WasConfigMissingOnFirstLoad => Volatile.Read(ref _firstLoadState) == 1;
+
+        public static IDisposable UseDirectoryForTests(string directory)
+        {
+            if (string.IsNullOrWhiteSpace(directory))
+                throw new ArgumentException("Config directory is required.", nameof(directory));
+
+            string fullPath = Path.GetFullPath(directory);
+            Directory.CreateDirectory(fullPath);
+
+            string? previousOverride;
+            lock (ConfigPathGate)
+            {
+                previousOverride = TestConfigDirOverride;
+                TestConfigDirOverride = fullPath;
+            }
+
+            ResetRuntimeStateForTests();
+            return new TestConfigDirectoryScope(previousOverride);
+        }
 
         public static AppConfig GetSnapshot()
         {
@@ -323,6 +354,34 @@ namespace VaultSync.Core.Config
         {
             string json = JsonSerializer.Serialize(config, JsonOptions);
             return JsonSerializer.Deserialize<AppConfig>(json, JsonOptions) ?? new AppConfig();
+        }
+
+        private static void ResetRuntimeStateForTests()
+        {
+            Volatile.Write(ref _firstLoadState, 0);
+            lock (LastKnownGoodGate)
+            {
+                LastKnownGoodConfig = null;
+            }
+        }
+
+        private sealed class TestConfigDirectoryScope(string? previousOverride) : IDisposable
+        {
+            private bool _disposed;
+
+            public void Dispose()
+            {
+                if (_disposed)
+                    return;
+
+                lock (ConfigPathGate)
+                {
+                    TestConfigDirOverride = previousOverride;
+                }
+
+                ResetRuntimeStateForTests();
+                _disposed = true;
+            }
         }
 
         private static string ResolveConfigDir()

--- a/src/VaultSync.Core/Config/IAppConfigStore.cs
+++ b/src/VaultSync.Core/Config/IAppConfigStore.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace VaultSync.Core.Config;
+
+public interface IAppConfigStore
+{
+    bool WasConfigMissingOnFirstLoad { get; }
+
+    AppConfig GetSnapshot();
+
+    AppConfig Load();
+
+    void Save(AppConfig config);
+
+    Task SaveAsync(AppConfig config, CancellationToken ct = default);
+
+    string GetDefaultDbPath();
+}

--- a/src/VaultSync.Core/Config/StaticAppConfigStore.cs
+++ b/src/VaultSync.Core/Config/StaticAppConfigStore.cs
@@ -1,0 +1,26 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace VaultSync.Core.Config;
+
+public sealed class StaticAppConfigStore : IAppConfigStore
+{
+    public static StaticAppConfigStore Instance { get; } = new();
+
+    private StaticAppConfigStore()
+    {
+    }
+
+    public bool WasConfigMissingOnFirstLoad => AppConfigStore.WasConfigMissingOnFirstLoad;
+
+    public AppConfig GetSnapshot() => AppConfigStore.GetSnapshot();
+
+    public AppConfig Load() => AppConfigStore.Load();
+
+    public void Save(AppConfig config) => AppConfigStore.Save(config);
+
+    public Task SaveAsync(AppConfig config, CancellationToken ct = default) =>
+        AppConfigStore.SaveAsync(config, ct);
+
+    public string GetDefaultDbPath() => AppConfigStore.GetDefaultDbPath();
+}

--- a/src/VaultSync.Core/Services/BackupService.cs
+++ b/src/VaultSync.Core/Services/BackupService.cs
@@ -20,11 +20,13 @@ namespace VaultSync.Core.Services;
 
 public sealed class BackupService(
     SqliteRepository repo,
-    BackupEncryptionSecretService? backupEncryptionSecretService = null)
+    BackupEncryptionSecretService? backupEncryptionSecretService = null,
+    IAppConfigStore? configStore = null)
 {
     private readonly Dictionary<int, CancellationTokenSource> _cancelMap = [];
     private readonly SqliteRepository _repo = repo;
     private readonly BackupEncryptionSecretService _backupEncryptionSecretService = backupEncryptionSecretService ?? new BackupEncryptionSecretService();
+    private readonly IAppConfigStore _configStore = configStore ?? StaticAppConfigStore.Instance;
     private const string InProgressMarkerFileName = ".vaultsync_inprogress";
     private const string CompletedMarkerFileName = ".vaultsync_complete";
     private const string ArchiveResumeCheckpointFileName = ".vaultsync_resume.json";
@@ -86,11 +88,13 @@ public sealed class BackupService(
         long resumeOffsetBytes,
         long archiveSizeBytes,
         string sourceFingerprint,
-        string message)
+        string message,
+        IAppConfigStore? configStore = null)
     {
         try
         {
-            AppConfig cfg = AppConfigStore.Load();
+            IAppConfigStore store = configStore ?? StaticAppConfigStore.Instance;
+            AppConfig cfg = store.Load();
             UpdateCheckpointResumeTelemetry(
                 cfg,
                 status,
@@ -101,7 +105,7 @@ public sealed class BackupService(
                 archiveSizeBytes,
                 sourceFingerprint,
                 message);
-            AppConfigStore.Save(cfg);
+            store.Save(cfg);
         }
         catch (Exception ex)
         {
@@ -336,7 +340,7 @@ public sealed class BackupService(
         }
 
         sha.TransformFinalBlock([], 0, 0);
-        return Convert.ToHexString(sha.Hash ?? []);
+        return HashService.FormatHex(sha.Hash ?? []);
     }
 
     private static bool IsResumableArchiveBackup(string backupDir)
@@ -606,7 +610,10 @@ public sealed class BackupService(
         return isNetwork ? 25d : 80d;
     }
 
-    public static int CleanupIncompleteBackups(string backupRoot, IEnumerable<string>? projectFolderNames = null)
+    public static int CleanupIncompleteBackups(
+        string backupRoot,
+        IEnumerable<string>? projectFolderNames = null,
+        IAppConfigStore? configStore = null)
     {
         if (string.IsNullOrWhiteSpace(backupRoot) || !Directory.Exists(backupRoot))
             return 0;
@@ -624,7 +631,7 @@ public sealed class BackupService(
                 if (!Directory.Exists(projectDir))
                     continue;
 
-                removed += CleanupIncompleteBackupsUnderProject(projectDir);
+                removed += CleanupIncompleteBackupsUnderProject(projectDir, configStore);
             }
 
             return removed;
@@ -632,13 +639,13 @@ public sealed class BackupService(
 
         foreach (string projectDir in SafeEnumerateDirectories(backupRoot))
         {
-            removed += CleanupIncompleteBackupsUnderProject(projectDir);
+            removed += CleanupIncompleteBackupsUnderProject(projectDir, configStore);
         }
 
         return removed;
     }
 
-    private static int CleanupIncompleteBackupsUnderProject(string projectDir)
+    private static int CleanupIncompleteBackupsUnderProject(string projectDir, IAppConfigStore? configStore)
     {
         int removed = 0;
         {
@@ -664,7 +671,8 @@ public sealed class BackupService(
                                 : 0,
                             archiveSizeBytes: checkpoint?.ArchiveSizeBytes ?? 0,
                             sourceFingerprint: checkpoint?.SourceFingerprint ?? string.Empty,
-                            message: "Preserved interrupted archive backup because checkpoint resume metadata is valid.");
+                            message: "Preserved interrupted archive backup because checkpoint resume metadata is valid.",
+                            configStore: configStore);
                         continue;
                     }
 
@@ -762,7 +770,7 @@ public sealed class BackupService(
         if (string.IsNullOrWhiteSpace(backupRoot))
             throw new InvalidOperationException("Backup root is empty. Configure a backup location in Settings.");
 
-        AppConfig configSnapshot = AppConfigStore.Load();
+        AppConfig configSnapshot = _configStore.Load();
         BackupEncryptionConfig encryptionConfig = configSnapshot.Backups.Encryption ?? new BackupEncryptionConfig();
         BackupEncryptionPolicyResolver.ResolvedPolicy resolvedEncryption = BackupEncryptionPolicyResolver.Resolve(project, encryptionConfig);
         bool encryptionRequested = resolvedEncryption.EncryptionRequested;
@@ -955,6 +963,7 @@ public sealed class BackupService(
                     uploadBufferBytes,
                     preferParallelArchiveUpload,
                     enableCheckpointedRetry,
+                    _configStore,
                     linkedToken);
             }
             else
@@ -1622,6 +1631,7 @@ public sealed class BackupService(
         int uploadBufferBytes,
         bool preferParallelUpload,
         bool enableCheckpointedRetry,
+        IAppConfigStore configStore,
         CancellationToken ct)
     {
         string sourceDir = project.RootPath;
@@ -1667,7 +1677,8 @@ public sealed class BackupService(
                         : 0,
                     archiveSizeBytes: 0,
                     sourceFingerprint: fingerprint,
-                    message: "Found interrupted archive backup with matching fingerprint and will attempt resume.");
+                    message: "Found interrupted archive backup with matching fingerprint and will attempt resume.",
+                    configStore: configStore);
             }
         }
 
@@ -2037,7 +2048,8 @@ public sealed class BackupService(
                                 resumeOffsetBytes: existingLength,
                                 archiveSizeBytes: zipSize,
                                 sourceFingerprint: resumeCheckpoint?.SourceFingerprint ?? string.Empty,
-                                message: "Discarded partial archive because the existing destination prefix no longer matched the rebuilt local archive.");
+                                message: "Discarded partial archive because the existing destination prefix no longer matched the rebuilt local archive.",
+                                configStore: configStore);
                             using var truncate = new FileStream(finalArchivePath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None);
                             truncate.SetLength(0);
                             existingLength = 0;
@@ -2053,7 +2065,8 @@ public sealed class BackupService(
                                 resumeOffsetBytes: existingLength,
                                 archiveSizeBytes: zipSize,
                                 sourceFingerprint: resumeCheckpoint?.SourceFingerprint ?? string.Empty,
-                                message: "Resuming archive upload from a validated existing prefix.");
+                                message: "Resuming archive upload from a validated existing prefix.",
+                                configStore: configStore);
                         }
 
                         await UploadSingleAttemptAsync(existingLength);
@@ -2084,6 +2097,7 @@ public sealed class BackupService(
                         project.Name,
                         enableCheckpointedRetry,
                         resumeCheckpoint,
+                        configStore,
                         ct);
                 }
                 catch (TimeoutException ex)
@@ -2107,7 +2121,8 @@ public sealed class BackupService(
                 resumeOffsetBytes: zipSize,
                 archiveSizeBytes: zipSize,
                 sourceFingerprint: resumeCheckpoint?.SourceFingerprint ?? string.Empty,
-                message: "Archive upload completed and checkpoint metadata was cleared.");
+                message: "Archive upload completed and checkpoint metadata was cleared.",
+                configStore: configStore);
             RuntimeLog.WriteVerbose($"[BackupService] RunArchiveBackupAsync completed for '{project.Name}'. LocalZipSize={zipSize} bytes");
             return workingDestDir;
         }
@@ -2124,7 +2139,8 @@ public sealed class BackupService(
                     resumeOffsetBytes: new FileInfo(finalArchivePath).Length,
                     archiveSizeBytes: resumeCheckpoint?.ArchiveSizeBytes ?? 0,
                     sourceFingerprint: resumeCheckpoint?.SourceFingerprint ?? string.Empty,
-                    message: "Preserved interrupted archive upload for a future checkpointed retry.");
+                    message: "Preserved interrupted archive upload for a future checkpointed retry.",
+                    configStore: configStore);
             }
             else
             {
@@ -2137,7 +2153,8 @@ public sealed class BackupService(
                     resumeOffsetBytes: File.Exists(finalArchivePath) ? new FileInfo(finalArchivePath).Length : 0,
                     archiveSizeBytes: resumeCheckpoint?.ArchiveSizeBytes ?? 0,
                     sourceFingerprint: resumeCheckpoint?.SourceFingerprint ?? string.Empty,
-                    message: "Discarded incomplete archive upload because checkpointed retry was not active or no resumable archive was present.");
+                    message: "Discarded incomplete archive upload because checkpointed retry was not active or no resumable archive was present.",
+                    configStore: configStore);
                 DeletePartialBackup(workingDestDir);
             }
 
@@ -2183,6 +2200,7 @@ public sealed class BackupService(
         string projectName,
         bool enableCheckpointedRetry,
         ArchiveResumeCheckpoint? resumeCheckpoint,
+        IAppConfigStore configStore,
         CancellationToken ct)
     {
         if (zipSize <= 0)
@@ -2267,7 +2285,8 @@ public sealed class BackupService(
                 resumeOffsetBytes: uploaded,
                 archiveSizeBytes: zipSize,
                 sourceFingerprint: resumeCheckpoint?.SourceFingerprint ?? string.Empty,
-                message: $"Resuming parallel archive upload with {resumableChunkIndexes.Count} validated chunks already present.");
+                message: $"Resuming parallel archive upload with {resumableChunkIndexes.Count} validated chunks already present.",
+                configStore: configStore);
         }
 
         void PersistParallelCheckpoint(HashSet<int> completedIndexes)

--- a/src/VaultSync.Core/Services/ByteSizeFormat.cs
+++ b/src/VaultSync.Core/Services/ByteSizeFormat.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Globalization;
+
+namespace VaultSync.Core.Services;
+
+public static class ByteSizeFormat
+{
+    public static string FormatBytes(long bytes, string numberFormat = "0.##")
+    {
+        double size = bytes;
+        string unit = "B";
+
+        if (Math.Abs(size) >= 1024d)
+        {
+            size /= 1024d;
+            unit = "KB";
+        }
+
+        if (Math.Abs(size) >= 1024d)
+        {
+            size /= 1024d;
+            unit = "MB";
+        }
+
+        if (Math.Abs(size) >= 1024d)
+        {
+            size /= 1024d;
+            unit = "GB";
+        }
+
+        if (Math.Abs(size) >= 1024d)
+        {
+            size /= 1024d;
+            unit = "TB";
+        }
+
+        return $"{size.ToString(numberFormat, CultureInfo.CurrentCulture)} {unit}";
+    }
+
+    public static string FormatSignedBytes(long bytes, string numberFormat = "0.##")
+    {
+        string absolute = FormatBytes(Math.Abs(bytes), numberFormat);
+        if (bytes > 0)
+            return $"+{absolute}";
+        if (bytes < 0)
+            return $"-{absolute}";
+        return absolute;
+    }
+}

--- a/src/VaultSync.Core/Services/DestinationIdentityService.cs
+++ b/src/VaultSync.Core/Services/DestinationIdentityService.cs
@@ -15,12 +15,12 @@ public static class DestinationIdentityService
     {
         ArgumentNullException.ThrowIfNull(destination);
 
-        string normalizedPath = NormalizePath(destination.Path);
+        string normalizedPath = NormalizeDestinationPath(destination.Path);
         string normalizedCredential = (destination.CredentialName ?? string.Empty).Trim().ToLowerInvariant();
         string mountMode = destination.PreMounted ? "premounted" : "managed";
         string payload = $"{normalizedPath}|{normalizedCredential}|{mountMode}";
         byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(payload));
-        return $"dest-{Convert.ToHexString(hash).ToLowerInvariant()[..24]}";
+        return $"dest-{HashService.FormatHexLower(hash)[..24]}";
     }
 
     public static string NormalizePreferredDestinationId(string? preferredDestinationId, IEnumerable<BackupDestination>? destinations)
@@ -63,7 +63,7 @@ public static class DestinationIdentityService
             string.Equals(GetId(dest), normalized, StringComparison.OrdinalIgnoreCase));
     }
 
-    private static string NormalizePath(string? path)
+    public static string NormalizeDestinationPath(string? path)
     {
         string raw = (path ?? string.Empty).Trim();
         if (string.IsNullOrWhiteSpace(raw))

--- a/src/VaultSync.Core/Services/DestinationQuotaPlanner.cs
+++ b/src/VaultSync.Core/Services/DestinationQuotaPlanner.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using VaultSync.Core.Config;
 using VaultSync.Core.Models;
@@ -22,9 +21,12 @@ public sealed class DestinationQuotaPlanner
         foreach (BackupDestination destination in destinations)
         {
             string destinationId = DestinationIdentityService.GetId(destination);
-            string normalizedPath = NormalizePath(destination.Path);
+            string normalizedPath = DestinationIdentityService.NormalizeDestinationPath(destination.Path);
             var matchingBackups = backupList
-                .Where(backup => string.Equals(NormalizePath(backup.DestinationPath), normalizedPath, StringComparison.OrdinalIgnoreCase))
+                .Where(backup => string.Equals(
+                    DestinationIdentityService.NormalizeDestinationPath(backup.DestinationPath),
+                    normalizedPath,
+                    StringComparison.OrdinalIgnoreCase))
                 .OrderBy(backup => backup.CreatedUtc)
                 .ThenByDescending(backup => backup.TotalBytes)
                 .ThenBy(backup => backup.Id)
@@ -93,26 +95,6 @@ public sealed class DestinationQuotaPlanner
 
     private static long? NormalizeQuotaBytes(long? value) =>
         value.HasValue && value.Value > 0 ? value.Value : null;
-
-    private static string NormalizePath(string? path)
-    {
-        string raw = (path ?? string.Empty).Trim();
-        if (string.IsNullOrWhiteSpace(raw))
-            return string.Empty;
-
-        string slashNormalized = raw.Replace('/', '\\');
-        try
-        {
-            if (slashNormalized.StartsWith(@"\\", StringComparison.Ordinal))
-                return slashNormalized.TrimEnd('\\').ToLowerInvariant();
-
-            return Path.GetFullPath(slashNormalized).TrimEnd('\\').ToLowerInvariant();
-        }
-        catch
-        {
-            return slashNormalized.TrimEnd('\\').ToLowerInvariant();
-        }
-    }
 }
 
 public sealed record DestinationQuotaPlan(

--- a/src/VaultSync.Core/Services/FilterService.cs
+++ b/src/VaultSync.Core/Services/FilterService.cs
@@ -35,30 +35,35 @@ public class FilterService
         _compiledPatterns = _patterns.Select(CompilePattern).ToList();
     }
 
-    public static FilterService FromPresetAndLocal(string projectRoot, string presetName, string? presetsDir = null)
+    public static FilterService FromPresetAndLocal(
+        string projectRoot,
+        string presetName,
+        string? presetsDir = null,
+        IVaultLogger? logger = null)
     {
+        logger ??= RuntimeVaultLogger.Instance;
         var patterns = new List<string>();
 
         // Resolve presets directory by priority
         presetsDir = ResolvePresetsDir(presetsDir);
 
-        Console.WriteLine($"[FilterService] Using presetsDir='{presetsDir}', preset='{presetName}'");
+        logger.Info($"[FilterService] Using presetsDir='{presetsDir}', preset='{presetName}'");
 
         // Load preset file if present
         if (!string.IsNullOrWhiteSpace(presetName))
         {
             string? presetFile = ResolvePresetFile(presetsDir, presetName);
-            Console.WriteLine($"[FilterService] Looking for preset file '{presetFile ?? "(not found)"}'");
+            logger.Info($"[FilterService] Looking for preset file '{presetFile ?? "(not found)"}'");
 
             if (!string.IsNullOrWhiteSpace(presetFile) && File.Exists(presetFile))
             {
                 IReadOnlyList<string> presetLines = ReadLinesCached(presetFile);
-                Console.WriteLine($"[FilterService] Loaded {presetLines.Count} rules from preset file.");
+                logger.Info($"[FilterService] Loaded {presetLines.Count} rules from preset file.");
                 patterns.AddRange(presetLines);
             }
             else
             {
-                Console.WriteLine("[FilterService] Preset file NOT FOUND.");
+                logger.Info("[FilterService] Preset file NOT FOUND.");
             }
         }
 
@@ -67,11 +72,11 @@ public class FilterService
         if (File.Exists(localIgnore))
         {
             IReadOnlyList<string> localLines = ReadLinesCached(localIgnore);
-            Console.WriteLine($"[FilterService] Loaded {localLines.Count} rules from local .vaultsyncignore.");
+            logger.Info($"[FilterService] Loaded {localLines.Count} rules from local .vaultsyncignore.");
             patterns.AddRange(localLines);
         }
 
-        Console.WriteLine($"[FilterService] Total rules in combined filter: {patterns.Count} user/preset + {BackupSafetyService.ReservedIgnorePatterns.Count} reserved safety rules");
+        logger.Info($"[FilterService] Total rules in combined filter: {patterns.Count} user/preset + {BackupSafetyService.ReservedIgnorePatterns.Count} reserved safety rules");
 
         return new FilterService(patterns);
     }

--- a/src/VaultSync.Core/Services/HashService.cs
+++ b/src/VaultSync.Core/Services/HashService.cs
@@ -4,12 +4,20 @@ namespace VaultSync.Core.Services;
 
 public class HashService
 {
+    public static string FormatHex(byte[] bytes) => Convert.ToHexString(bytes);
+
+    public static string FormatHexLower(byte[] bytes) => Convert.ToHexString(bytes).ToLowerInvariant();
+
+    public static string FormatSha256(byte[] hash) => FormatHex(hash);
+
+    public static string FormatSha256Lower(byte[] hash) => FormatHexLower(hash);
+
     public async Task<string> Sha256Async(string file, CancellationToken ct = default)
     {
         const int Buf = 1024 * 1024;
         await using var fs = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read, Buf, useAsync: true);
         using var sha = SHA256.Create();
         byte[] hash = await sha.ComputeHashAsync(fs, ct);
-        return Convert.ToHexString(hash);
+        return FormatSha256(hash);
     }
 }

--- a/src/VaultSync.Core/Services/IVaultLogger.cs
+++ b/src/VaultSync.Core/Services/IVaultLogger.cs
@@ -1,0 +1,12 @@
+namespace VaultSync.Core.Services;
+
+public interface IVaultLogger
+{
+    void Verbose(string message);
+
+    void Info(string message);
+
+    void Warning(string message);
+
+    void Error(string message);
+}

--- a/src/VaultSync.Core/Services/MetadataSyncService.cs
+++ b/src/VaultSync.Core/Services/MetadataSyncService.cs
@@ -16,9 +16,10 @@ using Microsoft.Data.Sqlite;
 
 namespace VaultSync.Core.Services;
 
-public sealed class MetadataSyncService(SqliteRepository repo)
+public sealed class MetadataSyncService(SqliteRepository repo, IAppConfigStore? configStore = null)
 {
     private readonly SqliteRepository _repo = repo;
+    private readonly IAppConfigStore _configStore = configStore ?? StaticAppConfigStore.Instance;
     private readonly ConcurrentDictionary<string, (DateTime LastWriteUtc, MetadataSyncPreview Preview)> _previewCache =
         new(StringComparer.OrdinalIgnoreCase);
     private static readonly SemaphoreSlim MetadataIoGate = new(1, 1);
@@ -33,10 +34,14 @@ public sealed class MetadataSyncService(SqliteRepository repo)
 
     public async Task<MetadataSyncResult> ImportFromStoreAsync(string rootPath, MetadataSyncOptions? options = null, CancellationToken ct = default)
     {
+        using var totalTiming = RuntimeTiming.Measure("Metadata import total");
         await MetadataIoGate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
-            await WaitForNetworkReadyAsync(rootPath, ct).ConfigureAwait(false);
+            using (RuntimeTiming.Measure("Metadata import network wait"))
+            {
+                await WaitForNetworkReadyAsync(rootPath, ct).ConfigureAwait(false);
+            }
             MetadataSyncOptions opts = options ?? MetadataSyncOptions.Default;
 
             if (string.IsNullOrWhiteSpace(rootPath))
@@ -49,7 +54,7 @@ public sealed class MetadataSyncService(SqliteRepository repo)
             if (!File.Exists(store.DatabasePath))
             {
                 Console.WriteLine($"[MetadataSync] Import skipped: store not found at '{store.DatabasePath}'.");
-                MetadataSyncResult legacyResult = ImportBackupFoldersFromDestination(rootPath, opts, AppConfigStore.Load());
+                MetadataSyncResult legacyResult = ImportBackupFoldersFromDestination(rootPath, opts, _configStore.Load());
                 if (legacyResult.Status == MetadataSyncStatus.Success &&
                     (legacyResult.ImportedProjects > 0 ||
                      legacyResult.ImportedSnapshots > 0 ||
@@ -62,12 +67,23 @@ public sealed class MetadataSyncService(SqliteRepository repo)
                 return MetadataSyncResult.Failure(MetadataSyncStatus.NoStore, "Metadata store not found.");
             }
 
-            if (ShouldUseTempCopy(store.DatabasePath) && TryCopyStoreForRead(store.DatabasePath, out string? walTempRoot))
+            if (TrySkipUnchangedSourceFromFileStamp(rootPath, store.DatabasePath, opts, out MetadataSyncResult? unchangedResult))
+                return unchangedResult!;
+
+            string? walTempRoot = null;
+            bool copiedWalStore = false;
+            if (ShouldUseTempCopy(store.DatabasePath))
+            {
+                using var copyTiming = RuntimeTiming.Measure("Metadata import temp copy");
+                copiedWalStore = TryCopyStoreForRead(store.DatabasePath, out walTempRoot);
+            }
+
+            if (copiedWalStore && !string.IsNullOrWhiteSpace(walTempRoot))
             {
                 Console.WriteLine($"[MetadataSync] Import using temp copy (SQLite sidecar detected): '{walTempRoot}'.");
                 try
                 {
-                    return ImportFromStoreInternal(rootPath, new MetadataStore(walTempRoot, allowReadRecovery: true), opts);
+                    return ImportFromStoreInternal(rootPath, new MetadataStore(walTempRoot, allowReadRecovery: true), opts, store.DatabasePath);
                 }
                 finally
                 {
@@ -77,7 +93,7 @@ public sealed class MetadataSyncService(SqliteRepository repo)
 
             try
             {
-                return ImportFromStoreInternal(rootPath, store, opts);
+                return ImportFromStoreInternal(rootPath, store, opts, store.DatabasePath);
             }
             catch (SqliteException ex) when (IsCannotOpenOrLocked(ex))
             {
@@ -88,7 +104,7 @@ public sealed class MetadataSyncService(SqliteRepository repo)
                 Console.WriteLine($"[MetadataSync] Import retrying from temp copy: '{tempRoot}'.");
                 try
                 {
-                    return ImportFromStoreInternal(rootPath, new MetadataStore(tempRoot, allowReadRecovery: true), opts);
+                    return ImportFromStoreInternal(rootPath, new MetadataStore(tempRoot, allowReadRecovery: true), opts, store.DatabasePath);
                 }
                 finally
                 {
@@ -177,11 +193,17 @@ public sealed class MetadataSyncService(SqliteRepository repo)
         }
     }
 
-    private MetadataSyncResult ImportFromStoreInternal(string rootPath, MetadataStore store, MetadataSyncOptions opts)
+    private MetadataSyncResult ImportFromStoreInternal(
+        string rootPath,
+        MetadataStore store,
+        MetadataSyncOptions opts,
+        string sourceDatabasePath)
     {
+        using var totalTiming = RuntimeTiming.Measure("Metadata import apply");
         MetaInfo? metaInfo;
         try
         {
+            using var timing = RuntimeTiming.Measure("Metadata import read meta info");
             metaInfo = store.GetMetaInfo();
         }
         catch (Exception ex) when (ex is not SqliteException sqliteEx || !IsCannotOpenOrLocked(sqliteEx))
@@ -198,6 +220,15 @@ public sealed class MetadataSyncService(SqliteRepository repo)
                 $"Metadata schema {metaInfo.SchemaVersion} is newer than supported {MetadataStore.CurrentSchemaVersion}.");
         }
 
+        if (opts.SkipUnchangedReadOnlySource &&
+            !opts.ExportMissingTombstonesOnImport &&
+            TryGetMetadataSourceStamp(rootPath, sourceDatabasePath, metaInfo, out MetadataImportSourceStamp sourceStamp) &&
+            HasSuccessfulUnchangedImport(sourceStamp))
+        {
+            Console.WriteLine($"[MetadataSync] Auto import skipped for unchanged store '{rootPath}'.");
+            return new MetadataSyncResult(MetadataSyncStatus.Success, 0, 0, 0, 0, "Metadata source unchanged.");
+        }
+
         int importedProjects = 0;
         int importedSnapshots = 0;
         int importedBackups = 0;
@@ -206,8 +237,13 @@ public sealed class MetadataSyncService(SqliteRepository repo)
         var projectMap = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         var snapshotMap = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
-        AppConfig config = AppConfigStore.Load();
-        var localProjects = _repo.GetAllProjects().ToList();
+        AppConfig config;
+        List<Project> localProjects;
+        using (RuntimeTiming.Measure("Metadata import load local state"))
+        {
+            config = _configStore.Load();
+            localProjects = _repo.GetAllProjects().ToList();
+        }
         List<ProjectMetadataConflictRecord> pendingConflicts = config.Advanced.ProjectMetadataConflicts ??= [];
         bool metadataConflictChanged = false;
 
@@ -224,6 +260,7 @@ public sealed class MetadataSyncService(SqliteRepository repo)
 
         try
         {
+            using var timing = RuntimeTiming.Measure("Metadata import read store rows");
             metaProjects = [.. store.ListProjects()];
             metaSnapshots = [.. store.ListSnapshots()];
             metaBackups = [.. store.ListBackups()];
@@ -422,50 +459,53 @@ public sealed class MetadataSyncService(SqliteRepository repo)
         var missingBackupExternalIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         IReadOnlyDictionary<int, DateTime> localLatestByProjectBeforeBackupImport = _repo.GetLatestBackupUtcByProject();
 
-        foreach (MetaBackup metaBackup in metaBackups)
+        using (RuntimeTiming.Measure("Metadata import apply backups"))
         {
-            if (string.IsNullOrWhiteSpace(metaBackup.ExternalId))
-                continue;
-
-            if (tombstonedBackupIds.Contains(metaBackup.ExternalId))
-                continue;
-
-            if (!TryResolveBackupPath(rootPath, metaBackup.PathRel, out string? normalizedPathRel))
+            foreach (MetaBackup metaBackup in metaBackups)
             {
-                missingBackupExternalIds.Add(metaBackup.ExternalId);
-                tombstonedBackupIds.Add(metaBackup.ExternalId);
-                continue;
+                if (string.IsNullOrWhiteSpace(metaBackup.ExternalId))
+                    continue;
+
+                if (tombstonedBackupIds.Contains(metaBackup.ExternalId))
+                    continue;
+
+                if (!TryResolveBackupPath(rootPath, metaBackup.PathRel, out string? normalizedPathRel))
+                {
+                    missingBackupExternalIds.Add(metaBackup.ExternalId);
+                    tombstonedBackupIds.Add(metaBackup.ExternalId);
+                    continue;
+                }
+
+                if (!projectMap.TryGetValue(metaBackup.ProjectExternalId, out int projectId))
+                    continue;
+
+                if (!snapshotMap.TryGetValue(metaBackup.SnapshotExternalId, out int snapshotId))
+                {
+                    continue;
+                }
+
+                if (backupExternalMap.ContainsKey(metaBackup.ExternalId))
+                    continue;
+
+                _repo.CreateBackupFromMetadata(
+                    metaBackup.ExternalId,
+                    projectId,
+                    snapshotId,
+                    metaBackup.CreatedUtc,
+                    metaBackup.Type,
+                    metaBackup.TotalBytes,
+                    normalizedPathRel,
+                    rootPath,
+                    metaBackup.DestinationAlias,
+                    metaBackup.IsProtected,
+                    isImported: true,
+                    backupMode: metaBackup.BackupMode,
+                    originMachineName: metaBackup.OriginMachineName,
+                    isEncrypted: metaBackup.IsEncrypted,
+                    cryptoDescriptorJson: metaBackup.KdfParamsJson);
+                importedBackups++;
+                affectedProjectIds.Add(projectId);
             }
-
-            if (!projectMap.TryGetValue(metaBackup.ProjectExternalId, out int projectId))
-                continue;
-
-            if (!snapshotMap.TryGetValue(metaBackup.SnapshotExternalId, out int snapshotId))
-            {
-                continue;
-            }
-
-            if (backupExternalMap.ContainsKey(metaBackup.ExternalId))
-                continue;
-
-            _repo.CreateBackupFromMetadata(
-                metaBackup.ExternalId,
-                projectId,
-                snapshotId,
-                metaBackup.CreatedUtc,
-                metaBackup.Type,
-                metaBackup.TotalBytes,
-                normalizedPathRel,
-                rootPath,
-                metaBackup.DestinationAlias,
-                metaBackup.IsProtected,
-                isImported: true,
-                backupMode: metaBackup.BackupMode,
-                originMachineName: metaBackup.OriginMachineName,
-                isEncrypted: metaBackup.IsEncrypted,
-                cryptoDescriptorJson: metaBackup.KdfParamsJson);
-            importedBackups++;
-            affectedProjectIds.Add(projectId);
         }
 
         foreach (MetaTombstone tombstone in metaTombstones)
@@ -529,7 +569,11 @@ public sealed class MetadataSyncService(SqliteRepository repo)
             }
         }
 
-        MetadataSyncResult filesystemResult = ImportBackupFoldersFromDestination(rootPath, opts, config);
+        MetadataSyncResult filesystemResult;
+        using (RuntimeTiming.Measure("Metadata import legacy folder scan"))
+        {
+            filesystemResult = ImportBackupFoldersFromDestination(rootPath, opts, config);
+        }
         importedProjects += filesystemResult.ImportedProjects;
         importedSnapshots += filesystemResult.ImportedSnapshots;
         importedBackups += filesystemResult.ImportedBackups;
@@ -540,7 +584,7 @@ public sealed class MetadataSyncService(SqliteRepository repo)
 
         if (metadataConflictChanged)
         {
-            AppConfigStore.Save(config);
+            _configStore.Save(config);
         }
 
         var result = new MetadataSyncResult(
@@ -557,10 +601,186 @@ public sealed class MetadataSyncService(SqliteRepository repo)
         {
             IEnumerable<MetaBackup> liveBackups = metaBackups
                 .Where(b => !string.IsNullOrWhiteSpace(b.ExternalId) && !tombstonedBackupIds.Contains(b.ExternalId));
-            UpdateNeedsRestoreFlags(projectMap, liveBackups, localLatestByProjectBeforeBackupImport);
+            using (RuntimeTiming.Measure("Metadata import restore flags"))
+            {
+                UpdateNeedsRestoreFlags(projectMap, liveBackups, localLatestByProjectBeforeBackupImport);
+            }
+        }
+        if (opts.SkipUnchangedReadOnlySource &&
+            !opts.ExportMissingTombstonesOnImport &&
+            TryGetMetadataSourceStamp(rootPath, sourceDatabasePath, metaInfo, out MetadataImportSourceStamp completedStamp))
+        {
+            SaveSuccessfulImportStamp(
+                completedStamp,
+                metaProjects.Count(),
+                metaSnapshots.Count(),
+                metaBackups.Count(),
+                metaTombstones.Count());
         }
         Console.WriteLine($"[MetadataSync] Import complete from '{rootPath}': projects={importedProjects}, snapshots={importedSnapshots}, backups={importedBackups}, tombstones={appliedTombstones}.");
         return result;
+    }
+
+    private bool HasSuccessfulUnchangedImport(MetadataImportSourceStamp current)
+    {
+        try
+        {
+            MetadataImportSourceStamp? cached = _configStore.Load()
+                .Advanced
+                .MetadataImportCache
+                .Sources
+                .FirstOrDefault(source => string.Equals(source.SourceKey, current.SourceKey, StringComparison.OrdinalIgnoreCase));
+
+            return cached != null &&
+                   !string.IsNullOrWhiteSpace(cached.ImportedUtc) &&
+                   string.Equals(cached.SourceMachineId, current.SourceMachineId, StringComparison.Ordinal) &&
+                   string.Equals(cached.StoreUpdatedUtc, current.StoreUpdatedUtc, StringComparison.Ordinal) &&
+                   cached.StoreSchemaVersion == current.StoreSchemaVersion &&
+                   cached.StoreFileLengthBytes == current.StoreFileLengthBytes &&
+                   string.Equals(cached.StoreFileUpdatedUtc, current.StoreFileUpdatedUtc, StringComparison.Ordinal) &&
+                   string.Equals(cached.StoreSidecarStamp, current.StoreSidecarStamp, StringComparison.Ordinal);
+        }
+        catch (Exception ex)
+        {
+            RuntimeLog.WriteVerbose($"[MetadataSync] Import cache check failed: {ex.Message}");
+            return false;
+        }
+    }
+
+    private void SaveSuccessfulImportStamp(
+        MetadataImportSourceStamp stamp,
+        int projectCount,
+        int snapshotCount,
+        int backupCount,
+        int tombstoneCount)
+    {
+        try
+        {
+            AppConfig config = _configStore.Load();
+            List<MetadataImportSourceStamp> sources = config.Advanced.MetadataImportCache.Sources;
+            sources.RemoveAll(source => string.Equals(source.SourceKey, stamp.SourceKey, StringComparison.OrdinalIgnoreCase));
+            stamp.ImportedUtc = DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture);
+            stamp.ProjectCount = projectCount;
+            stamp.SnapshotCount = snapshotCount;
+            stamp.BackupCount = backupCount;
+            stamp.TombstoneCount = tombstoneCount;
+            sources.Insert(0, stamp);
+            if (sources.Count > 32)
+            {
+                sources.RemoveRange(32, sources.Count - 32);
+            }
+
+            _configStore.Save(config);
+        }
+        catch (Exception ex)
+        {
+            RuntimeLog.WriteVerbose($"[MetadataSync] Import cache save failed: {ex.Message}");
+        }
+    }
+
+    private static bool TryGetMetadataSourceStamp(
+        string rootPath,
+        string sourceDatabasePath,
+        MetaInfo? metaInfo,
+        out MetadataImportSourceStamp stamp)
+    {
+        stamp = new MetadataImportSourceStamp();
+        if (metaInfo == null || string.IsNullOrWhiteSpace(sourceDatabasePath))
+            return false;
+
+        try
+        {
+            var db = new FileInfo(sourceDatabasePath);
+            if (!db.Exists)
+                return false;
+
+            string normalizedRoot = Path.GetFullPath(rootPath).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            string sourceKey = BuildMetadataSourceKey(normalizedRoot);
+            stamp = new MetadataImportSourceStamp
+            {
+                SourceKey = sourceKey,
+                SourcePath = normalizedRoot,
+                SourceMachineId = metaInfo.WriterMachineId ?? string.Empty,
+                StoreUpdatedUtc = metaInfo.LastWriteUtc.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture),
+                StoreSchemaVersion = metaInfo.SchemaVersion,
+                StoreFileLengthBytes = db.Length,
+                StoreFileUpdatedUtc = db.LastWriteTimeUtc.ToString("O", CultureInfo.InvariantCulture),
+                StoreSidecarStamp = BuildStoreSidecarStamp(sourceDatabasePath)
+            };
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static string BuildMetadataSourceKey(string normalizedRoot)
+    {
+        byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(normalizedRoot.Replace('\\', '/')));
+        return "metadata:" + HashService.FormatHexLower(hash);
+    }
+
+    private bool TrySkipUnchangedSourceFromFileStamp(
+        string rootPath,
+        string sourceDatabasePath,
+        MetadataSyncOptions opts,
+        out MetadataSyncResult? result)
+    {
+        result = null;
+        if (!opts.SkipUnchangedReadOnlySource || opts.ExportMissingTombstonesOnImport)
+            return false;
+
+        try
+        {
+            var db = new FileInfo(sourceDatabasePath);
+            if (!db.Exists)
+                return false;
+
+            string normalizedRoot = Path.GetFullPath(rootPath).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            string sourceKey = BuildMetadataSourceKey(normalizedRoot);
+            MetadataImportSourceStamp? cached = _configStore.Load()
+                .Advanced
+                .MetadataImportCache
+                .Sources
+                .FirstOrDefault(source => string.Equals(source.SourceKey, sourceKey, StringComparison.OrdinalIgnoreCase));
+
+            if (cached == null || string.IsNullOrWhiteSpace(cached.ImportedUtc))
+                return false;
+
+            bool unchanged =
+                cached.StoreFileLengthBytes == db.Length &&
+                string.Equals(cached.StoreFileUpdatedUtc, db.LastWriteTimeUtc.ToString("O", CultureInfo.InvariantCulture), StringComparison.Ordinal) &&
+                string.Equals(cached.StoreSidecarStamp, BuildStoreSidecarStamp(sourceDatabasePath), StringComparison.Ordinal);
+            if (!unchanged)
+                return false;
+
+            Console.WriteLine($"[MetadataSync] Auto import skipped for unchanged store files '{rootPath}'.");
+            result = new MetadataSyncResult(MetadataSyncStatus.Success, 0, 0, 0, 0, "Metadata source unchanged.");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            RuntimeLog.WriteVerbose($"[MetadataSync] Import file-stamp cache check failed: {ex.Message}");
+            return false;
+        }
+    }
+
+    private static string BuildStoreSidecarStamp(string sourceDatabasePath)
+    {
+        var parts = new List<string>();
+        foreach (string suffix in new[] { "-wal", "-shm", "-journal" })
+        {
+            var file = new FileInfo(sourceDatabasePath + suffix);
+            if (!file.Exists)
+                continue;
+
+            parts.Add(string.Create(
+                CultureInfo.InvariantCulture,
+                $"{suffix}:{file.Length}:{file.LastWriteTimeUtc.Ticks}"));
+        }
+
+        return parts.Count == 0 ? "none" : string.Join("|", parts);
     }
 
     private void UpdateNeedsRestoreFlags(
@@ -1222,7 +1442,7 @@ public sealed class MetadataSyncService(SqliteRepository repo)
         _ = rootPath;
         string normalized = $"{prefix}|{NormalizeStablePath(relativePath)}";
         byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(normalized));
-        return $"{prefix}-{Convert.ToHexString(hash)[..32].ToLowerInvariant()}";
+        return $"{prefix}-{HashService.FormatHexLower(hash)[..32]}";
     }
 
     private static string NormalizeStablePath(string value)
@@ -2271,9 +2491,8 @@ public sealed class MetadataSyncService(SqliteRepository repo)
 
     private static string GetDeferredExportRoot(string rootPath)
     {
-        string hash = Convert.ToHexString(
-            System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(rootPath)));
-        return Path.Combine(Path.GetTempPath(), "vaultsync-meta-export", hash.ToLowerInvariant());
+        byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(rootPath));
+        return Path.Combine(Path.GetTempPath(), "vaultsync-meta-export", HashService.FormatHexLower(hash));
     }
 
     private static async Task WaitForNetworkReadyAsync(string rootPath, CancellationToken ct)
@@ -2527,7 +2746,7 @@ public sealed class MetadataSyncService(SqliteRepository repo)
 
     private static string NewExternalId() => Guid.NewGuid().ToString("N");
 
-    private static string BuildProjectSettingsJson(Project project)
+    private string BuildProjectSettingsJson(Project project)
     {
         try
         {
@@ -2547,7 +2766,7 @@ public sealed class MetadataSyncService(SqliteRepository repo)
                 : project.PreferredDestinationId;
             settings["restoreMode"] = ProjectRestoreMode.Normalize(project.RestoreMode);
             settings["verificationPolicy"] = ProjectVerificationPolicy.Normalize(project.VerificationPolicy);
-            List<int> disabledProjects = AppConfigStore.GetSnapshot().Backups.AutoBackupDisabledProjects ?? [];
+            List<int> disabledProjects = _configStore.GetSnapshot().Backups.AutoBackupDisabledProjects ?? [];
             settings["autoBackupEnabled"] = !disabledProjects.Contains(project.Id);
             settings["tags"] = string.IsNullOrWhiteSpace(project.Tags)
                 ? string.Empty
@@ -2577,7 +2796,7 @@ public sealed class MetadataSyncService(SqliteRepository repo)
         bool HasAutoBackupEnabled,
         bool HasTags);
 
-    private static ParsedProjectSettings ParseProjectSettings(string? settingsJson)
+    private ParsedProjectSettings ParseProjectSettings(string? settingsJson)
     {
         if (string.IsNullOrWhiteSpace(settingsJson))
         {
@@ -2639,7 +2858,7 @@ public sealed class MetadataSyncService(SqliteRepository repo)
             {
                 preferredDestinationId = NormalizePreferredDestinationId(
                     destinationProp.GetString(),
-                    AppConfigStore.Load().Backups.Destinations);
+                    _configStore.Load().Backups.Destinations);
                 hasPreferredDestinationId = true;
             }
 
@@ -2745,7 +2964,7 @@ public sealed class MetadataSyncService(SqliteRepository repo)
         string nextVerificationPolicy = parsedSettings.HasVerificationPolicy
             ? ProjectVerificationPolicy.Normalize(parsedSettings.VerificationPolicy)
             : currentVerificationPolicy;
-        List<BackupDestination> destinations = AppConfigStore.Load().Backups.Destinations;
+        List<BackupDestination> destinations = _configStore.Load().Backups.Destinations;
         string currentPreferredDestinationId = NormalizePreferredDestinationId(current.PreferredDestinationId, destinations);
         string nextPreferredDestinationId = parsedSettings.HasPreferredDestinationId
             ? NormalizePreferredDestinationId(parsedSettings.PreferredDestinationId, destinations)
@@ -2956,10 +3175,12 @@ public sealed class MetadataSyncService(SqliteRepository repo)
 public sealed record MetadataSyncOptions(
     bool AllowCreateProjects,
     bool MarkNeedsRestoreOnImport,
-    bool ExportMissingTombstonesOnImport = true)
+    bool ExportMissingTombstonesOnImport = true,
+    bool SkipUnchangedReadOnlySource = false)
 {
     public static MetadataSyncOptions Default => new(true, true);
     public MetadataSyncOptions AsReadOnlySource() => this with { ExportMissingTombstonesOnImport = false };
+    public MetadataSyncOptions WithUnchangedSourceSkip() => this with { SkipUnchangedReadOnlySource = true };
 }
 
 public sealed record MetadataSyncResult(

--- a/src/VaultSync.Core/Services/NetworkMountService.cs
+++ b/src/VaultSync.Core/Services/NetworkMountService.cs
@@ -15,7 +15,7 @@ public sealed class NetworkMountService
     public DestinationResolution PrepareDestination(BackupDestination dest, NetworkCredentialProfile? profile)
     {
         string alias = DisplayName(dest);
-        Console.WriteLine($"[NetworkMount] PrepareDestination: alias='{alias}', path='{dest.Path}', preMounted={dest.PreMounted}, autoMount={dest.AutoMount}, autoUnmount={dest.AutoUnmount}");
+        Log($"PrepareDestination: alias='{alias}', path='{dest.Path}', preMounted={dest.PreMounted}, autoMount={dest.AutoMount}, autoUnmount={dest.AutoUnmount}");
 
         string normalizedPath = NormalizePath(dest.Path, out string? normalizeError);
         if (!string.IsNullOrWhiteSpace(normalizeError))
@@ -25,7 +25,7 @@ public sealed class NetworkMountService
 
         if (dest.PreMounted)
         {
-            Console.WriteLine($"[NetworkMount] Using pre-mounted path for '{alias}'.");
+            Log($"Using pre-mounted path for '{alias}'.");
             return Directory.Exists(normalizedPath)
                 ? CreateSuccessWithKeepAlive(dest, normalizedPath, mounted: false, $"Using pre-mounted path '{normalizedPath}'")
                 : DestinationResolution.CreateFailure(dest, $"Destination '{alias}' is marked pre-mounted but is not accessible.");
@@ -37,19 +37,19 @@ public sealed class NetworkMountService
             try
             {
                 Directory.CreateDirectory(normalizedPath);
-                Console.WriteLine($"[NetworkMount] Using local path '{normalizedPath}'.");
+                Log($"Using local path '{normalizedPath}'.");
                 return CreateSuccessWithKeepAlive(dest, normalizedPath, mounted: false, $"Using local path '{normalizedPath}'");
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[NetworkMount] Local path '{normalizedPath}' failed: {ex.Message}");
+                Log($"Local path '{normalizedPath}' failed: {ex.Message}");
                 return DestinationResolution.CreateFailure(dest, $"Cannot use destination '{alias}': {ex.Message}");
             }
         }
 
         if (!dest.AutoMount)
         {
-            Console.WriteLine($"[NetworkMount] Auto-mount disabled for '{alias}'.");
+            Log($"Auto-mount disabled for '{alias}'.");
             if (OperatingSystem.IsMacOS() &&
                 normalizedPath.StartsWith("nfs://", StringComparison.OrdinalIgnoreCase))
             {
@@ -62,7 +62,7 @@ public sealed class NetworkMountService
                 : DestinationResolution.CreateFailure(dest, $"Destination '{alias}' is unreachable and auto-mount is disabled.");
         }
 
-        Console.WriteLine($"[NetworkMount] Attempting auto-mount for '{alias}' using profile '{profile?.Name ?? "none"}'.");
+        Log($"Attempting auto-mount for '{alias}' using profile '{profile?.Name ?? "none"}'.");
         string? password = profile is null
             ? null
             : _vault.GetSecret(profile.KeyRef, profile.Username, profile.UseKeychain, profile.Password);
@@ -92,7 +92,7 @@ public sealed class NetworkMountService
         if (!resolution.MountedByUs || !resolution.Destination.AutoUnmount)
             return;
 
-        Console.WriteLine($"[NetworkMount] Auto-unmounting '{DisplayName(resolution.Destination)}' ({resolution.EffectivePath}).");
+        Log($"Auto-unmounting '{DisplayName(resolution.Destination)}' ({resolution.EffectivePath}).");
         if (OperatingSystem.IsWindows())
         {
             DisconnectWindows(resolution);
@@ -129,7 +129,7 @@ public sealed class NetworkMountService
         try
         {
             NetUseResult firstAttempt = TryNetUseConnect(normalizedPath, username, password);
-            Console.WriteLine($"[NetworkMount] net use connect attempt exit={firstAttempt.ExitCode}.");
+            Log($"net use connect attempt exit={firstAttempt.ExitCode}.");
             if (firstAttempt.ExitCode == 0)
                 return CreateSuccessWithKeepAlive(dest, normalizedPath, mounted: true, $"Mounted {DisplayName(dest)}");
 
@@ -145,7 +145,7 @@ public sealed class NetworkMountService
                 }
 
                 NetUseResult secondAttempt = TryNetUseConnect(normalizedPath, username, password);
-                Console.WriteLine($"[NetworkMount] net use retry exit={secondAttempt.ExitCode}.");
+                Log($"net use retry exit={secondAttempt.ExitCode}.");
                 if (secondAttempt.ExitCode == 0)
                     return CreateSuccessWithKeepAlive(dest, normalizedPath, mounted: true, $"Mounted {DisplayName(dest)}");
 
@@ -307,14 +307,14 @@ public sealed class NetworkMountService
         if (TryGetMountedSharePath(shareHost, shareName, mountPoint, out string? existingMount))
         {
             mountPoint = existingMount;
-            Console.WriteLine($"[NetworkMount] Share already mounted for '{DisplayName(dest)}' at '{mountPoint}'.");
+            Log($"Share already mounted for '{DisplayName(dest)}' at '{mountPoint}'.");
             if (!IsSmbfsMountPoint(mountPoint, out string? mountLine))
             {
                 return DestinationResolution.CreateFailure(dest, $"Mount point '{mountPoint}' is not an SMB mount.");
             }
             if (!string.IsNullOrWhiteSpace(mountLine))
             {
-                Console.WriteLine($"[NetworkMount] SMB mount detected: {mountLine}");
+                Log($"SMB mount detected: {mountLine}");
             }
             string effectivePath = AppendShareSubPath(mountPoint, shareSubPath);
             return CreateSuccessWithKeepAlive(dest, effectivePath, mounted: false, $"Mounted {DisplayName(dest)}");
@@ -360,18 +360,18 @@ public sealed class NetworkMountService
             {
                 string stderr = proc.StandardError.ReadToEnd();
                 string sanitized = SanitizeMountError(stderr, password, share, shareDisplay);
-                Console.WriteLine($"[NetworkMount] mount_smbfs failed for '{DisplayName(dest)}': {sanitized.Trim()}");
+                Log($"mount_smbfs failed for '{DisplayName(dest)}': {sanitized.Trim()}");
                 if (TryGetMountedSharePath(shareHost, shareName, mountPoint, out string? existingMountAfterFail))
                 {
                     mountPoint = existingMountAfterFail;
-                    Console.WriteLine($"[NetworkMount] Share already mounted for '{DisplayName(dest)}' at '{mountPoint}'.");
+                    Log($"Share already mounted for '{DisplayName(dest)}' at '{mountPoint}'.");
                     if (!IsSmbfsMountPoint(mountPoint, out string? mountLine))
                     {
                         return DestinationResolution.CreateFailure(dest, $"Mount point '{mountPoint}' is not an SMB mount.");
                     }
                     if (!string.IsNullOrWhiteSpace(mountLine))
                     {
-                        Console.WriteLine($"[NetworkMount] SMB mount detected: {mountLine}");
+                        Log($"SMB mount detected: {mountLine}");
                     }
                     string effectivePath = AppendShareSubPath(mountPoint, shareSubPath);
                     return CreateSuccessWithKeepAlive(dest, effectivePath, mounted: false, $"Mounted {DisplayName(dest)}");
@@ -380,14 +380,14 @@ public sealed class NetworkMountService
                 return DestinationResolution.CreateFailure(dest, $"Mount failed for {DisplayName(dest)}: {sanitized}".Trim());
             }
 
-            Console.WriteLine($"[NetworkMount] Mounted '{DisplayName(dest)}' at '{mountPoint}'.");
+            Log($"Mounted '{DisplayName(dest)}' at '{mountPoint}'.");
             if (!IsSmbfsMountPoint(mountPoint, out string? mountInfo))
             {
                 return DestinationResolution.CreateFailure(dest, $"Mount point '{mountPoint}' is not an SMB mount.");
             }
             if (!string.IsNullOrWhiteSpace(mountInfo))
             {
-                Console.WriteLine($"[NetworkMount] SMB mount detected: {mountInfo}");
+                Log($"SMB mount detected: {mountInfo}");
             }
             string finalPath = AppendShareSubPath(mountPoint, shareSubPath);
             return CreateSuccessWithKeepAlive(dest, finalPath, mounted: true, $"Mounted {DisplayName(dest)}");
@@ -446,7 +446,7 @@ public sealed class NetworkMountService
         {
             if (!string.IsNullOrWhiteSpace(mountLine))
             {
-                Console.WriteLine($"[NetworkMount] NFS mount detected: {mountLine}");
+                Log($"NFS mount detected: {mountLine}");
             }
             string effectivePath = mountPoint;
             if (TryGetNfsMountSource(mountLine, out string? mountedSource))
@@ -493,18 +493,18 @@ public sealed class NetworkMountService
                 if (proc.ExitCode != 0)
                 {
                     string stderr = proc.StandardError.ReadToEnd();
-                    Console.WriteLine($"[NetworkMount] mount_nfs failed for '{DisplayName(dest)}': {stderr.Trim()}");
+                    Log($"mount_nfs failed for '{DisplayName(dest)}': {stderr.Trim()}");
                     continue;
                 }
 
-                Console.WriteLine($"[NetworkMount] Mounted '{DisplayName(dest)}' at '{mountPoint}'.");
+                Log($"Mounted '{DisplayName(dest)}' at '{mountPoint}'.");
                 if (!IsNfsMountPoint(mountPoint, out string? mountInfo))
                 {
                     return DestinationResolution.CreateFailure(dest, $"Mount point '{mountPoint}' is not an NFS mount.");
                 }
                 if (!string.IsNullOrWhiteSpace(mountInfo))
                 {
-                    Console.WriteLine($"[NetworkMount] NFS mount detected: {mountInfo}");
+                    Log($"NFS mount detected: {mountInfo}");
                 }
 
                 string effectivePath = mountPoint;
@@ -993,6 +993,11 @@ public sealed class NetworkMountService
         return "Destination";
     }
 
+    private static void Log(string message)
+    {
+        RuntimeVaultLogger.Instance.Info($"[NetworkMount] {message}");
+    }
+
     private static string Slugify(string input)
     {
         var sb = new StringBuilder();
@@ -1104,7 +1109,7 @@ public sealed class NetworkMountService
             Timers.GetOrAdd(path, key =>
             {
                 var timer = new Timer(_ => KeepAliveTick(key), null, TimeSpan.FromMinutes(2), TimeSpan.FromMinutes(2));
-                Console.WriteLine($"[NetworkMount] SMB keep-alive enabled for '{key}'.");
+                Log($"SMB keep-alive enabled for '{key}'.");
                 return timer;
             });
         }
@@ -1131,7 +1136,7 @@ public sealed class NetworkMountService
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[NetworkMount] SMB keep-alive failed for '{path}': {ex.Message}");
+                Log($"SMB keep-alive failed for '{path}': {ex.Message}");
             }
         }
     }

--- a/src/VaultSync.Core/Services/RuntimeTiming.cs
+++ b/src/VaultSync.Core/Services/RuntimeTiming.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace VaultSync.Core.Services;
+
+public static class RuntimeTiming
+{
+    public static RuntimeTimingScope Measure(string label) => new(label);
+}
+
+public readonly struct RuntimeTimingScope : IDisposable
+{
+    private readonly string _label;
+    private readonly long _startTimestamp;
+    private readonly bool _enabled;
+
+    internal RuntimeTimingScope(string label)
+    {
+        _enabled = RuntimeLog.ShouldEmitVerbose && !string.IsNullOrWhiteSpace(label);
+        _label = _enabled ? label : string.Empty;
+        _startTimestamp = _enabled ? Stopwatch.GetTimestamp() : 0L;
+    }
+
+    public void Dispose()
+    {
+        if (!_enabled)
+        {
+            return;
+        }
+
+        long elapsedTicks = Stopwatch.GetTimestamp() - _startTimestamp;
+        double elapsedMs = elapsedTicks * 1000d / Stopwatch.Frequency;
+        RuntimeLog.WriteVerbose(string.Create(
+            CultureInfo.InvariantCulture,
+            $"[Timing] {_label} finished in {elapsedMs:0.0} ms."));
+    }
+}

--- a/src/VaultSync.Core/Services/RuntimeVaultLogger.cs
+++ b/src/VaultSync.Core/Services/RuntimeVaultLogger.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace VaultSync.Core.Services;
+
+public sealed class RuntimeVaultLogger : IVaultLogger
+{
+    public static RuntimeVaultLogger Instance { get; } = new();
+
+    private RuntimeVaultLogger()
+    {
+    }
+
+    public void Verbose(string message) => RuntimeLog.WriteVerbose(message);
+
+    public void Info(string message) => Console.WriteLine(message);
+
+    public void Warning(string message) => Console.WriteLine(message);
+
+    public void Error(string message) => Console.WriteLine(message);
+}

--- a/src/VaultSync.Core/Services/ScannerService.cs
+++ b/src/VaultSync.Core/Services/ScannerService.cs
@@ -10,8 +10,13 @@ namespace VaultSync.Core.Services;
 public class ScannerService
 {
     private readonly FilterService _filter;
+    private readonly IVaultLogger _logger;
 
-    public ScannerService(FilterService filter) => _filter = filter;
+    public ScannerService(FilterService filter, IVaultLogger? logger = null)
+    {
+        _filter = filter;
+        _logger = logger ?? RuntimeVaultLogger.Instance;
+    }
 
     /// <summary>
     /// Synchronous scan. Use this only from background threads (e.g. CLI, services).
@@ -61,12 +66,12 @@ public class ScannerService
                 catch (IOException ex)
                 {
                     // Skip unreadable files but log for diagnostics.
-                    Console.WriteLine($"[ScannerService] IO error while scanning '{path}': {ex.Message}");
+                    _logger.Warning($"[ScannerService] IO error while scanning '{path}': {ex.Message}");
                 }
                 catch (UnauthorizedAccessException ex)
                 {
                     // Skip restricted files but log for diagnostics.
-                    Console.WriteLine($"[ScannerService] Access denied while scanning '{path}': {ex.Message}");
+                    _logger.Warning($"[ScannerService] Access denied while scanning '{path}': {ex.Message}");
                 }
             }
 
@@ -97,7 +102,7 @@ public class ScannerService
             }
             catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is DirectoryNotFoundException)
             {
-                Console.WriteLine($"[ScannerService] Skipping directory '{current}': {ex.Message}");
+                _logger.Warning($"[ScannerService] Skipping directory '{current}': {ex.Message}");
                 continue;
             }
 
@@ -114,7 +119,7 @@ public class ScannerService
             }
             catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is DirectoryNotFoundException)
             {
-                Console.WriteLine($"[ScannerService] Skipping subdirectory scan for '{current}': {ex.Message}");
+                _logger.Warning($"[ScannerService] Skipping subdirectory scan for '{current}': {ex.Message}");
                 continue;
             }
 

--- a/src/VaultSync.Core/Services/SnapshotService.cs
+++ b/src/VaultSync.Core/Services/SnapshotService.cs
@@ -9,14 +9,16 @@ public class SnapshotService
 {
     private readonly SqliteRepository _repo;
     private readonly HashService _hash;
+    private readonly IVaultLogger _logger;
 
     private readonly record struct SnapshotFileMetadata(string Full, string Rel, FileEntry Entry);
     public SnapshotOutcome? LastCreatedOutcome { get; private set; }
 
-    public SnapshotService(SqliteRepository repo, HashService hash)
+    public SnapshotService(SqliteRepository repo, HashService hash, IVaultLogger? logger = null)
     {
         _repo = repo;
         _hash = hash;
+        _logger = logger ?? RuntimeVaultLogger.Instance;
     }
 
     public Task<int> CreateSnapshotAsync(Project project, bool fullHash, int? maxSnapshotsToKeep = null, CancellationToken ct = default)
@@ -39,9 +41,9 @@ public class SnapshotService
         if (string.IsNullOrWhiteSpace(project.RootPath))
             throw new InvalidOperationException("Project.RootPath is not set.");
 
-        Console.WriteLine($"[SnapshotService] Starting snapshot for project '{project.Name}'");
-        Console.WriteLine($"[SnapshotService]   RootPath = '{project.RootPath}'");
-        Console.WriteLine($"[SnapshotService]   Preset   = '{project.Preset}'");
+        _logger.Info($"[SnapshotService] Starting snapshot for project '{project.Name}'");
+        _logger.Info($"[SnapshotService]   RootPath = '{project.RootPath}'");
+        _logger.Info($"[SnapshotService]   Preset   = '{project.Preset}'");
 
         // IMPORTANT:
         // Run the entire snapshot pipeline on a background thread so that
@@ -66,7 +68,7 @@ public class SnapshotService
             ct.ThrowIfCancellationRequested();
 
             // Build filter from preset + local overrides
-            var filter = FilterService.FromPresetAndLocal(project.RootPath, project.Preset);
+            var filter = FilterService.FromPresetAndLocal(project.RootPath, project.Preset, logger: _logger);
 
             // Build current file list (with optional scan cache)
             string filterHash = ComputeFilterHash(filter);
@@ -84,7 +86,7 @@ public class SnapshotService
                 out int skippedDirs,
                 ct);
 
-            Console.WriteLine($"[SnapshotService] Scan cache used={useScanCache && cache is not null}, skippedDirs={skippedDirs}, files={currentEntries.Count}.");
+            _logger.Info($"[SnapshotService] Scan cache used={useScanCache && cache is not null}, skippedDirs={skippedDirs}, files={currentEntries.Count}.");
 
             ct.ThrowIfCancellationRequested();
 
@@ -181,7 +183,7 @@ public class SnapshotService
                     }
                     catch (Exception ex)
                     {
-                        Console.WriteLine($"[SnapshotService] Retention step failed for project '{project.Name}': {ex}");
+                        _logger.Error($"[SnapshotService] Retention step failed for project '{project.Name}': {ex}");
                     }
                 }
 
@@ -196,8 +198,8 @@ public class SnapshotService
                 );
                 LastOutcome = LastCreatedOutcome;
 
-                Console.WriteLine($"[SnapshotService] Finished snapshot for '{project.Name}': " +
-                                  $"added={added.Count}, modified={modified.Count}, deleted={deleted.Count}, unchanged={unchanged.Count}, totalFiles={snapshotEntries.Count}, totalBytes={snapshotTotalBytes}");
+                _logger.Info($"[SnapshotService] Finished snapshot for '{project.Name}': " +
+                             $"added={added.Count}, modified={modified.Count}, deleted={deleted.Count}, unchanged={unchanged.Count}, totalFiles={snapshotEntries.Count}, totalBytes={snapshotTotalBytes}");
 
                 return snapshotId;
             }
@@ -237,7 +239,7 @@ public class SnapshotService
                 ? currMeta
                 : [.. currMeta.Where(m => changedRel.Contains(m.Rel))];
 
-            Console.WriteLine($"[SnapshotService] toHash = {toHash.Count}, fullHash={fullHash}, added={added.Count}, modified={modified.Count}, unchanged={unchanged.Count}, deleted={deleted.Count}");
+            _logger.Info($"[SnapshotService] toHash = {toHash.Count}, fullHash={fullHash}, added={added.Count}, modified={modified.Count}, unchanged={unchanged.Count}, deleted={deleted.Count}");
 
             int totalToHash = toHash.Count;
             long totalHashBytes = toHash.Sum(m => m.Entry.Size);
@@ -342,7 +344,7 @@ public class SnapshotService
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[SnapshotService] Retention step failed for project '{project.Name}': {ex}");
+                    _logger.Error($"[SnapshotService] Retention step failed for project '{project.Name}': {ex}");
                 }
             }
 
@@ -358,8 +360,8 @@ public class SnapshotService
             );
             LastOutcome = LastCreatedOutcome;
 
-            Console.WriteLine($"[SnapshotService] Finished snapshot for '{project.Name}': " +
-                              $"added={added.Count}, modified={modified.Count}, deleted={deleted.Count}, unchanged={unchanged.Count}, totalFiles={entries.Count}, totalBytes={totalBytes}");
+            _logger.Info($"[SnapshotService] Finished snapshot for '{project.Name}': " +
+                         $"added={added.Count}, modified={modified.Count}, deleted={deleted.Count}, unchanged={unchanged.Count}, totalFiles={entries.Count}, totalBytes={totalBytes}");
 
             return snapId;
         }, ct);
@@ -370,7 +372,7 @@ public class SnapshotService
         string joined = string.Join('\n', filter.RawPatterns ?? Array.Empty<string>());
         byte[] bytes = System.Text.Encoding.UTF8.GetBytes(joined);
         byte[] hash = SHA256.HashData(bytes);
-        return Convert.ToHexString(hash);
+        return HashService.FormatHex(hash);
     }
 
     private static List<FileEntry> BuildCurrentEntries(
@@ -735,7 +737,7 @@ public class SnapshotService
                 }
                 catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
                 {
-                    Console.WriteLine($"[SnapshotService] Failed to hash '{fullPath}': {ex.Message}");
+                    _logger.Warning($"[SnapshotService] Failed to hash '{fullPath}': {ex.Message}");
                 }
             });
 
@@ -776,7 +778,7 @@ public class SnapshotService
 
         if (toDelete.Count > 0)
         {
-            Console.WriteLine($"[SnapshotService] Retention deleting {toDelete.Count} old snapshots for project '{project.Name}'.");
+            _logger.Info($"[SnapshotService] Retention deleting {toDelete.Count} old snapshots for project '{project.Name}'.");
             _repo.DeleteSnapshotsById(project.Name, toDelete);
         }
     }

--- a/src/VaultSync.Core/Services/Telemetry.cs
+++ b/src/VaultSync.Core/Services/Telemetry.cs
@@ -250,7 +250,7 @@ public static class Telemetry
 
                 byte[] bytes = new byte[32];
                 RandomNumberGenerator.Fill(bytes);
-                string salt = Convert.ToHexString(bytes).ToLowerInvariant();
+                string salt = HashService.FormatHexLower(bytes);
                 File.WriteAllText(path, salt);
                 return salt;
             }
@@ -259,7 +259,7 @@ public static class Telemetry
                 // Fall back to a volatile salt if persistence fails.
                 byte[] bytes = new byte[32];
                 RandomNumberGenerator.Fill(bytes);
-                return Convert.ToHexString(bytes).ToLowerInvariant();
+                return HashService.FormatHexLower(bytes);
             }
         }
     }
@@ -354,6 +354,6 @@ public sealed class TelemetryEventBuilder
     {
         using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(_salt));
         byte[] bytes = hmac.ComputeHash(Encoding.UTF8.GetBytes(raw));
-        return Convert.ToHexString(bytes).ToLowerInvariant();
+        return HashService.FormatHexLower(bytes);
     }
 }

--- a/src/VaultSync.Core/VaultSync.Core.csproj
+++ b/src/VaultSync.Core/VaultSync.Core.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.1.79" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.8" />
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.8" />
+    <PackageReference Include="Dapper" />
+    <PackageReference Include="Microsoft.Data.Sqlite" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VaultSync.UI/App.axaml.cs
+++ b/src/VaultSync.UI/App.axaml.cs
@@ -32,6 +32,8 @@ namespace VaultSync.UI;
 
 public partial class App : Application
 {
+    private static readonly IAppConfigStore ConfigStore = StaticAppConfigStore.Instance;
+
     // Test hook: enabled while onboarding UX is being validated every startup.
     private static readonly bool ForceOnboardingAtStartupForTesting = false;
     private static readonly string OnboardingSentinelPath =
@@ -200,7 +202,7 @@ public partial class App : Application
                 CreateSystemNotificationService() ?? new StubSystemNotificationService();
             GlobalNotificationCenter.Instance.ShouldShowSystemNotification = _ =>
             {
-                AppConfig cfg = AppConfigStore.GetSnapshot();
+                AppConfig cfg = ConfigStore.GetSnapshot();
                 if (!cfg.Notifications.UseOsNotifications)
                     return false;
                 if (!cfg.Notifications.OnBackupSuccess &&
@@ -219,7 +221,7 @@ public partial class App : Application
             };
 
             // Read behavior config and, if enabled, create a tray/menu-bar icon.
-            AppConfig config = AppConfigStore.GetSnapshot();
+            AppConfig config = ConfigStore.GetSnapshot();
             if (config.Behavior?.ShowTrayIcon is true)
             {
                 CreateTrayIcon(desktop);
@@ -257,7 +259,7 @@ public partial class App : Application
         try
         {
             var localizationService = new LocalizationService();
-            AppConfig cfg = AppConfigStore.GetSnapshot();
+            AppConfig cfg = ConfigStore.GetSnapshot();
             if (!string.IsNullOrWhiteSpace(cfg.Advanced.Language))
             {
                 localizationService.SetLanguage(cfg.Advanced.Language);
@@ -424,7 +426,7 @@ public partial class App : Application
         if (AppViewModelInstance is null)
             return;
 
-        AppConfig cfg = AppConfigStore.GetSnapshot();
+        AppConfig cfg = ConfigStore.GetSnapshot();
         string currentVersion = AppViewModelInstance.CurrentVersionDisplay.TrimStart('v');
         if (string.IsNullOrWhiteSpace(currentVersion))
             return;
@@ -456,7 +458,7 @@ public partial class App : Application
         vm.CloseRequested += () =>
         {
             cfg.Advanced.LastWhatsNewVersion = currentVersion;
-            AppConfigStore.Save(cfg);
+            ConfigStore.Save(cfg);
             window.Close();
         };
 
@@ -517,11 +519,11 @@ public partial class App : Application
         if (AppViewModelInstance is null)
             return false;
 
-        AppConfig cfg = AppConfigStore.GetSnapshot();
+        AppConfig cfg = ConfigStore.GetSnapshot();
         bool showForTesting = IsOnboardingAlwaysEnabledForTesting();
         if (!showForTesting)
         {
-            bool isFreshInstall = AppConfigStore.WasConfigMissingOnFirstLoad;
+            bool isFreshInstall = ConfigStore.WasConfigMissingOnFirstLoad;
             bool sentinelExists = File.Exists(OnboardingSentinelPath);
 
             if (!isFreshInstall || sentinelExists || cfg.Advanced.HasSeenOnboarding)
@@ -572,7 +574,7 @@ public partial class App : Application
         if (!cfg.Advanced.HasSeenOnboarding)
         {
             cfg.Advanced.HasSeenOnboarding = true;
-            AppConfigStore.Save(cfg);
+            ConfigStore.Save(cfg);
         }
     }
 
@@ -675,7 +677,7 @@ public partial class App : Application
 
     private void UpdateTrayIconVisibility(IClassicDesktopStyleApplicationLifetime desktop)
     {
-        AppConfig cfg = AppConfigStore.GetSnapshot();
+        AppConfig cfg = ConfigStore.GetSnapshot();
         if (cfg.Behavior?.ShowTrayIcon == true)
         {
             if (_trayIcon is null)
@@ -714,7 +716,7 @@ public partial class App : Application
         IReadOnlyList<AppViewModel.DestinationProbeSummary> destinationSummaries = AppViewModelInstance?.GetDestinationProbeSummaries()
                                    ?? [];
 
-        AppConfig cfg = AppConfigStore.GetSnapshot();
+        AppConfig cfg = ConfigStore.GetSnapshot();
         List<BackupDestination> configuredDestinations = GetConfiguredDestinations(cfg);
 
         (string destinationsTitle, string destinationsStatus) =
@@ -776,7 +778,7 @@ public partial class App : Application
 
         IReadOnlyList<AppViewModel.DestinationProbeSummary> destinationSummaries = AppViewModelInstance?.GetDestinationProbeSummaries()
                                    ?? [];
-        AppConfig cfg = AppConfigStore.GetSnapshot();
+        AppConfig cfg = ConfigStore.GetSnapshot();
         List<BackupDestination> configuredDestinations = GetConfiguredDestinations(cfg);
         (string destinationsTitle, string destinationsStatus) =
             GetDestinationStatus(destinationSummaries, configuredDestinations);
@@ -1254,7 +1256,7 @@ public partial class App : Application
     {
         try
         {
-            AppConfig cfg        = AppViewModelInstance?.GetConfigSnapshot() ?? AppConfigStore.GetSnapshot();
+            AppConfig cfg        = AppViewModelInstance?.GetConfigSnapshot() ?? ConfigStore.GetSnapshot();
             string backupRoot = cfg.Backups.BackupLocation ?? string.Empty;
             string driveLabel = FormatDriveLabel(backupRoot);
             if (_cachedDriveHealthIsNetwork)
@@ -1446,7 +1448,7 @@ public partial class App : Application
         if (window is null)
             return;
 
-        AppConfig config = AppConfigStore.GetSnapshot();
+        AppConfig config = ConfigStore.GetSnapshot();
         if (config.Behavior?.ShowWindowOnTrayActions != true)
             return;
 
@@ -1912,7 +1914,7 @@ public partial class App : Application
     {
         try
         {
-            AppConfig cfg = AppConfigStore.GetSnapshot();
+            AppConfig cfg = ConfigStore.GetSnapshot();
             int minutes = Math.Clamp(
                 cfg?.Backups?.Encryption?.OpenUnlockTimeoutMinutes ?? DefaultEncryptedOpenTimeoutMinutes,
                 1,
@@ -1985,17 +1987,17 @@ public partial class App : Application
 
     private static void ApplyThemeFromConfig()
     {
-        AppConfig config = AppConfigStore.GetSnapshot();
+        AppConfig config = ConfigStore.GetSnapshot();
         ThemeManager.ApplyAppearance(config.Appearance);
         ThemeManager.ApplyCompactLayout(config.Appearance.CompactLayout);
     }
 
     public static void ApplyTheme(string themeOption)
     {
-        AppConfig config = AppConfigStore.Load();
+        AppConfig config = ConfigStore.Load();
         config.Appearance.Theme = themeOption;
         ThemeManager.ApplyAppearance(config.Appearance);
-        AppConfigStore.Save(config);
+        ConfigStore.Save(config);
     }
 
     private static string FormatDriveLabel(string? path)
@@ -2044,7 +2046,7 @@ public partial class App : Application
         {
             try
             {
-                AppConfig cfg        = AppViewModelInstance?.GetConfigSnapshot() ?? AppConfigStore.GetSnapshot();
+                AppConfig cfg        = AppViewModelInstance?.GetConfigSnapshot() ?? ConfigStore.GetSnapshot();
                 string backupRoot = cfg.Backups.BackupRoot ?? string.Empty;
                 string driveLabel = FormatDriveLabel(backupRoot);
 

--- a/src/VaultSync.UI/Infrastructure/ProjectTagAppearance.cs
+++ b/src/VaultSync.UI/Infrastructure/ProjectTagAppearance.cs
@@ -18,10 +18,10 @@ public sealed class ProjectTagChip
         ("#2E414D", "#D8F0FF", "#4B7083"),
     };
 
-    public static ProjectTagChip Create(string value, AppConfig? config = null)
+    public static ProjectTagChip Create(string value, AppConfig? config = null, IAppConfigStore? configStore = null)
     {
         string safe = (value ?? string.Empty).Trim();
-        config ??= ProjectTagAppearance.TryLoadConfig();
+        config ??= ProjectTagAppearance.TryLoadConfig(configStore);
         (string Background, string Foreground, string Border) colors = ProjectTagAppearance.Resolve(safe, config?.Appearance?.TagColors);
         return new ProjectTagChip(safe, colors.Background, colors.Foreground, colors.Border);
     }
@@ -49,11 +49,11 @@ public sealed class ProjectTagChip
 
 public static class ProjectTagAppearance
 {
-    public static AppConfig? TryLoadConfig()
+    public static AppConfig? TryLoadConfig(IAppConfigStore? configStore = null)
     {
         try
         {
-            return AppConfigStore.GetSnapshot();
+            return (configStore ?? StaticAppConfigStore.Instance).GetSnapshot();
         }
         catch
         {
@@ -61,9 +61,13 @@ public static class ProjectTagAppearance
         }
     }
 
-    public static IReadOnlyList<ProjectTagChip> CreateChips(string? csv, int? max = null, AppConfig? config = null)
+    public static IReadOnlyList<ProjectTagChip> CreateChips(
+        string? csv,
+        int? max = null,
+        AppConfig? config = null,
+        IAppConfigStore? configStore = null)
     {
-        config ??= TryLoadConfig();
+        config ??= TryLoadConfig(configStore);
         IEnumerable<string> tags = (csv ?? string.Empty)
             .Split(new[] { ',', ';', '|', '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries)
             .Select(tag => tag.Trim())
@@ -73,7 +77,7 @@ public static class ProjectTagAppearance
         if (max.HasValue)
             tags = tags.Take(max.Value);
 
-        return tags.Select(tag => ProjectTagChip.Create(tag, config)).ToArray();
+        return tags.Select(tag => ProjectTagChip.Create(tag, config, configStore)).ToArray();
     }
 
     public static (string Background, string Foreground, string Border) Resolve(

--- a/src/VaultSync.UI/Infrastructure/UiFormat.cs
+++ b/src/VaultSync.UI/Infrastructure/UiFormat.cs
@@ -1,49 +1,12 @@
-using System;
-using System.Globalization;
+using VaultSync.Core.Services;
 
 namespace VaultSync.UI.Infrastructure;
 
 public static class UiFormat
 {
-    public static string FormatBytes(long bytes, string numberFormat = "0.##")
-    {
-        double size = bytes;
-        string unit = "B";
+    public static string FormatBytes(long bytes, string numberFormat = "0.##") =>
+        ByteSizeFormat.FormatBytes(bytes, numberFormat);
 
-        if (Math.Abs(size) >= 1024d)
-        {
-            size /= 1024d;
-            unit = "KB";
-        }
-
-        if (Math.Abs(size) >= 1024d)
-        {
-            size /= 1024d;
-            unit = "MB";
-        }
-
-        if (Math.Abs(size) >= 1024d)
-        {
-            size /= 1024d;
-            unit = "GB";
-        }
-
-        if (Math.Abs(size) >= 1024d)
-        {
-            size /= 1024d;
-            unit = "TB";
-        }
-
-        return $"{size.ToString(numberFormat, CultureInfo.CurrentCulture)} {unit}";
-    }
-
-    public static string FormatSignedBytes(long bytes, string numberFormat = "0.##")
-    {
-        string absolute = FormatBytes(Math.Abs(bytes), numberFormat);
-        if (bytes > 0)
-            return $"+{absolute}";
-        if (bytes < 0)
-            return $"-{absolute}";
-        return absolute;
-    }
+    public static string FormatSignedBytes(long bytes, string numberFormat = "0.##") =>
+        ByteSizeFormat.FormatSignedBytes(bytes, numberFormat);
 }

--- a/src/VaultSync.UI/MainWindow.axaml.cs
+++ b/src/VaultSync.UI/MainWindow.axaml.cs
@@ -20,6 +20,7 @@ namespace VaultSync.UI;
 public partial class MainWindow : Window
 {
     private readonly AppViewModel _appVm;
+    private readonly IAppConfigStore _configStore;
     private bool _fullscreenSuppressed;
     private bool _macFullscreenDisabled;
     private bool _ignoreNextPointerPress;
@@ -34,7 +35,13 @@ public partial class MainWindow : Window
     public static bool IsForeground { get; private set; }
 
     public MainWindow()
+        : this(StaticAppConfigStore.Instance)
     {
+    }
+
+    internal MainWindow(IAppConfigStore configStore)
+    {
+        _configStore = configStore;
         InitializeComponent();
         if (OperatingSystem.IsLinux())
         {
@@ -222,7 +229,7 @@ public partial class MainWindow : Window
         // and keep VaultSync running in the background.
         try
         {
-            AppConfig config = AppConfigStore.GetSnapshot();
+            AppConfig config = _configStore.GetSnapshot();
             if (config.Behavior?.RunInBackground == true)
             {
                 e.Cancel = true;

--- a/src/VaultSync.UI/Services/PatchInstallService.cs
+++ b/src/VaultSync.UI/Services/PatchInstallService.cs
@@ -10,6 +10,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Reflection;
+using VaultSync.Core.Services;
 
 namespace VaultSync.UI.Services
 {
@@ -437,14 +438,14 @@ namespace VaultSync.UI.Services
             using FileStream stream = File.OpenRead(path);
             using var sha = SHA256.Create();
             byte[] bytes = sha.ComputeHash(stream);
-            return BitConverter.ToString(bytes).Replace("-", string.Empty).ToLowerInvariant();
+            return HashService.FormatSha256Lower(bytes);
         }
 
         private static string ComputeSha256(byte[] payload)
         {
             using var sha = SHA256.Create();
             byte[] bytes = sha.ComputeHash(payload);
-            return BitConverter.ToString(bytes).Replace("-", string.Empty).ToLowerInvariant();
+            return HashService.FormatSha256Lower(bytes);
         }
 
         private static void VerifyArchivePreflight(string archivePath, PatchManifest manifest)

--- a/src/VaultSync.UI/Services/PatchUpdateService.cs
+++ b/src/VaultSync.UI/Services/PatchUpdateService.cs
@@ -10,6 +10,7 @@ using System.Security.Cryptography;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using VaultSync.Core.Services;
 
 namespace VaultSync.UI.Services
 {
@@ -313,7 +314,7 @@ namespace VaultSync.UI.Services
             using FileStream stream = File.OpenRead(filePath);
             using var sha = SHA256.Create();
             byte[] hash = await sha.ComputeHashAsync(stream, cancellationToken);
-            string actual = BitConverter.ToString(hash).Replace("-", string.Empty).ToLowerInvariant();
+            string actual = HashService.FormatSha256Lower(hash);
             return string.Equals(actual, expectedSha256.Trim().ToLowerInvariant(), StringComparison.OrdinalIgnoreCase);
         }
 

--- a/src/VaultSync.UI/Services/SupportBundleService.cs
+++ b/src/VaultSync.UI/Services/SupportBundleService.cs
@@ -15,8 +15,9 @@ public sealed record SupportBundleExportResult(bool Success, string? ZipPath, st
 
 public sealed class SupportBundleService
 {
-    public static SupportBundleExportResult Export()
+    public static SupportBundleExportResult Export(IAppConfigStore? configStore = null)
     {
+        configStore ??= StaticAppConfigStore.Instance;
         DateTimeOffset timestamp = DateTimeOffset.UtcNow;
         string bundleName = $"vaultsync-support-{timestamp:yyyyMMdd-HHmmss}.zip";
         string exportRoot = Path.Combine(
@@ -35,7 +36,7 @@ public sealed class SupportBundleService
             Directory.CreateDirectory(exportRoot);
             Directory.CreateDirectory(stagingRoot);
 
-            AppConfig config = AppConfigStore.GetSnapshot();
+            AppConfig config = configStore.GetSnapshot();
             object report = BuildBundleReport(config, timestamp);
 
             string reportJson = JsonSerializer.Serialize(report, new JsonSerializerOptions

--- a/src/VaultSync.UI/UpdaterApp.axaml.cs
+++ b/src/VaultSync.UI/UpdaterApp.axaml.cs
@@ -10,6 +10,8 @@ namespace VaultSync.UI;
 
 public sealed partial class UpdaterApp : Application
 {
+    private static readonly IAppConfigStore ConfigStore = StaticAppConfigStore.Instance;
+
     public static PatchApplyRequest? PendingRequest { get; private set; }
 
     public static void SetPendingRequest(PatchApplyRequest request)
@@ -57,7 +59,7 @@ public sealed partial class UpdaterApp : Application
 
         try
         {
-            AppConfig config = AppConfigStore.GetSnapshot();
+            AppConfig config = ConfigStore.GetSnapshot();
             if (!string.IsNullOrWhiteSpace(config.Advanced.Language))
             {
                 localizationService.SetLanguage(config.Advanced.Language);
@@ -71,7 +73,7 @@ public sealed partial class UpdaterApp : Application
 
     private static void ApplyThemeFromConfig()
     {
-        AppConfig config = AppConfigStore.GetSnapshot();
+        AppConfig config = ConfigStore.GetSnapshot();
         ThemeManager.ApplyAppearance(config.Appearance);
     }
 }

--- a/src/VaultSync.UI/VaultSync.UI.csproj
+++ b/src/VaultSync.UI/VaultSync.UI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <Version>1.7.4</Version>
+    <Version>1.7.5</Version>
     <Product>VaultSync</Product>
     <Company>Flavio Giacchetti</Company>
     <ApplicationIcon>Assets\vaultsync.ico</ApplicationIcon>
@@ -34,29 +34,28 @@
 
   <!-- Base Avalonia + dependencies -->
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.15" />
-    <PackageReference Include="Avalonia.Controls.ColorPicker" Version="11.3.15" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.15" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.15" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.15" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.15">
+    <PackageReference Include="Avalonia" />
+    <PackageReference Include="Avalonia.Controls.ColorPicker" />
+    <PackageReference Include="Avalonia.Desktop" />
+    <PackageReference Include="Avalonia.Themes.Fluent" />
+    <PackageReference Include="Avalonia.Fonts.Inter" />
+    <PackageReference Include="Avalonia.Diagnostics">
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>
 
-    <PackageReference Include="SkiaSharp" Version="3.119.2" />
-    <PackageReference Include="SkiaSharp.HarfBuzz" Version="3.119.2" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.2" />
-    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="3.119.2" />
-    <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" Version="3.119.2" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="3.119.2" />
-    <PackageReference Include="HarfBuzzSharp" Version="8.3.1.3" />
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.1.3" />
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="8.3.1.3" />
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.WebAssembly" Version="8.3.1.3" />
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.Win32" Version="8.3.1.3" />
-    <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.4" />
-    <PackageReference Include="ReactiveUI" Version="23.2.27" />
+    <PackageReference Include="SkiaSharp" />
+    <PackageReference Include="SkiaSharp.HarfBuzz" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
+    <PackageReference Include="SkiaSharp.NativeAssets.macOS" />
+    <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Win32" />
+    <PackageReference Include="HarfBuzzSharp" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.WebAssembly" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Win32" />
+    <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" />
   </ItemGroup>
 
   <!-- Reference to core project -->
@@ -124,8 +123,8 @@
 
   <!-- Windows notifications -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-windows10.0.19041.0'">
-    <PackageReference Include="CommunityToolkit.WinUI.Notifications" Version="7.1.2" />
-    <PackageReference Include="System.Drawing.Common" Version="10.0.8" />
+    <PackageReference Include="CommunityToolkit.WinUI.Notifications" />
+    <PackageReference Include="System.Drawing.Common" />
   </ItemGroup>
 
     <ItemGroup>

--- a/src/VaultSync.UI/ViewModels/AppViewModel.BackupHandlers.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.BackupHandlers.cs
@@ -498,7 +498,7 @@ namespace VaultSync.UI.ViewModels
                 }
 
                 // --- After backup: optional verification / post-hash ---
-                AppConfig cfgAfter = await Task.Run(AppConfigStore.Load);
+                AppConfig cfgAfter = await Task.Run(_configStore.Load);
                 if (metadataRoot is not null)
                 {
                     Backup? latest = metadataBackupId.HasValue
@@ -1117,7 +1117,7 @@ namespace VaultSync.UI.ViewModels
                 await DashboardViewModel.RefreshAsync();
 
                 // --- After all backups: optional verification / post-hash ---
-                AppConfig cfgAfterAll = await Task.Run(AppConfigStore.Load);
+                AppConfig cfgAfterAll = await Task.Run(_configStore.Load);
                 List<BackupDestination> allDestinations = AppViewModel.GetAllDestinations(cfgAfterAll);
                 List<Backup> allLatest = _repo.GetLatestBackupsPerProject();
                 var projectsById = _repo.GetAllProjects()

--- a/src/VaultSync.UI/ViewModels/AppViewModel.BackupHistoryHandlers.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.BackupHistoryHandlers.cs
@@ -50,7 +50,7 @@ namespace VaultSync.UI.ViewModels
 
             var deleteContext = await Task.Run(() =>
             {
-                AppConfig cfg = AppConfigStore.GetSnapshot();
+                AppConfig cfg = _configStore.GetSnapshot();
                 List<BackupDestination> destinations = AppViewModel.GetAllDestinations(cfg);
                 BackupDestination? matchedDestination = FindDestinationForBackup(backup, destinations, backupRoot);
                 bool hasCredentialProfile = HasCredentialProfile(cfg, matchedDestination);
@@ -349,7 +349,7 @@ namespace VaultSync.UI.ViewModels
 
         private async Task<bool> ConfirmDeleteBackupAsync(string projectName, DateTime timestamp)
         {
-            AppConfig cfg = await Task.Run(AppConfigStore.Load);
+            AppConfig cfg = await Task.Run(_configStore.Load);
             if (!cfg.Behavior.ConfirmDeleteBackup)
                 return true;
 
@@ -465,7 +465,7 @@ namespace VaultSync.UI.ViewModels
                 if (confirmed && dontShowAgain.IsChecked == true)
                 {
                     cfg.Behavior.ConfirmDeleteBackup = false;
-                    AppConfigStore.Save(cfg);
+                    _configStore.Save(cfg);
                     if (_settingsViewModel is not null)
                     {
                         _settingsViewModel.ConfirmDeleteBackups = false;
@@ -1187,7 +1187,7 @@ namespace VaultSync.UI.ViewModels
             if (backup is null)
                 return DeleteBackupPreparation.Failure;
 
-            AppConfig cfg = AppConfigStore.GetSnapshot();
+            AppConfig cfg = _configStore.GetSnapshot();
             List<BackupDestination> destinations = AppViewModel.GetAllDestinations(cfg);
             string? backupRoot = ResolveDestinationRootForBackup(backup, destinations, cfg.Backups.BackupRoot);
             if (string.IsNullOrWhiteSpace(backupRoot))
@@ -1265,7 +1265,7 @@ namespace VaultSync.UI.ViewModels
                 return RestoreBackupPreparation.Failure;
             }
 
-            AppConfig cfg = AppConfigStore.GetSnapshot();
+            AppConfig cfg = _configStore.GetSnapshot();
             List<BackupDestination> destinations = AppViewModel.GetAllDestinations(cfg);
             string? backupRoot = ResolveDestinationRootForBackup(backup, destinations, cfg.Backups.BackupRoot);
             if (string.IsNullOrWhiteSpace(backupRoot))
@@ -1347,7 +1347,7 @@ namespace VaultSync.UI.ViewModels
             if (project is null)
                 return [];
 
-            AppConfig cfg = AppConfigStore.GetSnapshot();
+            AppConfig cfg = _configStore.GetSnapshot();
             IReadOnlyList<string> keyRefs = BackupEncryptionPolicyResolver.ResolveRestoreKeyRefs(project, cfg.Backups.Encryption);
             if (keyRefs.Count == 0)
                 return [];
@@ -1393,7 +1393,7 @@ namespace VaultSync.UI.ViewModels
             if (!string.IsNullOrWhiteSpace(project.RootPath) && Directory.Exists(project.RootPath))
                 return project.RootPath;
 
-            AppConfig cfg = AppConfigStore.GetSnapshot();
+            AppConfig cfg = _configStore.GetSnapshot();
             if (!string.IsNullOrWhiteSpace(cfg.ProjectsRoot))
             {
                 string projectsRoot = Path.Combine(cfg.ProjectsRoot, project.Name);
@@ -1417,7 +1417,7 @@ namespace VaultSync.UI.ViewModels
 
         private AutoBackupPreparation PrepareAutoBackupRun()
         {
-            AppConfig cfg = AppConfigStore.GetSnapshot();
+            AppConfig cfg = _configStore.GetSnapshot();
             if (!cfg.Backups.EnableAutoBackups)
                 return AutoBackupPreparation.Failure("disabled");
 

--- a/src/VaultSync.UI/ViewModels/AppViewModel.BackupOrchestration.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.BackupOrchestration.cs
@@ -150,7 +150,7 @@ namespace VaultSync.UI.ViewModels
 
         private BackupAllPreparationResult PrepareBackupAll()
         {
-            AppConfig cfg = AppConfigStore.GetSnapshot();
+            AppConfig cfg = _configStore.GetSnapshot();
             System.Collections.Generic.List<BackupDestination> destinations = AppViewModel.GetAllDestinations(cfg);
             if (destinations.Count == 0)
             {

--- a/src/VaultSync.UI/ViewModels/AppViewModel.BackupSupport.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.BackupSupport.cs
@@ -75,7 +75,7 @@ namespace VaultSync.UI.ViewModels
                 {
                     try
                     {
-                        AppConfig cfg = AppConfigStore.Load();
+                        AppConfig cfg = _configStore.Load();
                         double existing = useArchiveMode
                             ? cfg.Backups.LastBackupThroughputArchiveMbSec
                             : cfg.Backups.LastBackupThroughputCopyMbSec;
@@ -90,7 +90,7 @@ namespace VaultSync.UI.ViewModels
                             cfg.Backups.LastBackupThroughputCopyMbSec = rounded;
                         }
                         cfg.Backups.LastBackupThroughputMbSec = rounded;
-                        AppConfigStore.Save(cfg);
+                        _configStore.Save(cfg);
 
                         Dispatcher.UIThread.Post(() =>
                         {

--- a/src/VaultSync.UI/ViewModels/AppViewModel.ConfigurationOps.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.ConfigurationOps.cs
@@ -46,7 +46,7 @@ namespace VaultSync.UI.ViewModels
             {
                 try
                 {
-                    AppConfig cfg = AppConfigStore.Load();
+                    AppConfig cfg = _configStore.Load();
                     Dispatcher.UIThread.Post(() => apply(cfg));
                 }
                 catch (Exception ex)
@@ -76,7 +76,7 @@ namespace VaultSync.UI.ViewModels
             {
                 try
                 {
-                    AppConfig cfg = AppConfigStore.Load();
+                    AppConfig cfg = _configStore.Load();
                     List<BackupDestination> destinations = AppViewModel.GetAllDestinations(cfg);
                     bool allowToggle = cfg.Backups.UseAdvancedDestinations && cfg.Backups.Destinations is { Count: > 0 };
                     vm.ResetDestinationStatuses(destinations, allowToggle);
@@ -185,7 +185,7 @@ namespace VaultSync.UI.ViewModels
             {
                 try
                 {
-                    AppConfig cfg = AppConfigStore.Load();
+                    AppConfig cfg = _configStore.Load();
                     if (!cfg.Backups.EnableMetadataSync)
                         return;
 
@@ -319,7 +319,7 @@ namespace VaultSync.UI.ViewModels
 
         private BackupProjectPreparation CreateManualBackupPreparation(int projectId)
         {
-            AppConfig cfg = AppConfigStore.GetSnapshot();
+            AppConfig cfg = _configStore.GetSnapshot();
             Project? project = _repo.GetProjectById(projectId);
             ProjectDestinationSelection selection = project is null
                 ? new ProjectDestinationSelection(AppViewModel.GetActiveDestinations(cfg), null, null)
@@ -1068,7 +1068,7 @@ namespace VaultSync.UI.ViewModels
             {
                 try
                 {
-                    AppConfig cfg = AppConfigStore.Load();
+                    AppConfig cfg = _configStore.Load();
                     List<int> list = cfg.Backups.AutoBackupDisabledProjects ?? [];
                     if (!enabled)
                     {
@@ -1081,7 +1081,7 @@ namespace VaultSync.UI.ViewModels
                     }
 
                     cfg.Backups.AutoBackupDisabledProjects = list;
-                    AppConfigStore.Save(cfg);
+                    _configStore.Save(cfg);
                     DiagnosticsLogger.Record(
                         $"[AutoBackup] Preference changed. ProjectId={projectId}; Enabled={enabled}; DisabledCount={list.Count}.");
 
@@ -1117,7 +1117,7 @@ namespace VaultSync.UI.ViewModels
             {
                 try
                 {
-                    AppConfig cfg = AppConfigStore.Load();
+                    AppConfig cfg = _configStore.Load();
                     List<int> list = cfg.Backups.AutoBackupDisabledProjects ?? [];
                     foreach (int projectId in ids)
                     {
@@ -1132,7 +1132,7 @@ namespace VaultSync.UI.ViewModels
                     }
 
                     cfg.Backups.AutoBackupDisabledProjects = list;
-                    AppConfigStore.Save(cfg);
+                    _configStore.Save(cfg);
                     DiagnosticsLogger.Record(
                         $"[AutoBackup] Group preference changed. ProjectIds={string.Join(',', ids)}; Enabled={enabled}; DisabledCount={list.Count}.");
 
@@ -1173,10 +1173,10 @@ namespace VaultSync.UI.ViewModels
                     if (string.IsNullOrWhiteSpace(externalId))
                         return;
 
-                    AppConfig cfg = AppConfigStore.Load();
+                    AppConfig cfg = _configStore.Load();
                     if (cfg.Backups.AutoBackupDisabledProjects?.Remove(projectId) is true)
                     {
-                        AppConfigStore.Save(cfg);
+                        _configStore.Save(cfg);
                     }
 
                     foreach (BackupDestination dest in AppViewModel.GetAllDestinations(cfg))
@@ -1325,7 +1325,7 @@ namespace VaultSync.UI.ViewModels
             {
                 try
                 {
-                    AppConfig cfg = AppConfigStore.Load();
+                    AppConfig cfg = _configStore.Load();
                     if (!cfg.Backups.UseAdvancedDestinations ||
                         cfg.Backups.Destinations is null ||
                         cfg.Backups.Destinations.Count == 0)
@@ -1344,7 +1344,7 @@ namespace VaultSync.UI.ViewModels
                         return;
 
                     destEntry.Active = isActive;
-                    AppConfigStore.Save(cfg);
+                    _configStore.Save(cfg);
 
                     Dispatcher.UIThread.Post(() =>
                     {

--- a/src/VaultSync.UI/ViewModels/AppViewModel.MaintenanceOps.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.MaintenanceOps.cs
@@ -49,7 +49,7 @@ namespace VaultSync.UI.ViewModels
 
             try
             {
-                AppConfig cfg = AppConfigStore.Load();
+                AppConfig cfg = _configStore.Load();
                 MaintenanceConfig maintenance = cfg.Advanced.Maintenance ?? new MaintenanceConfig();
                 if (!maintenance.Enabled)
                     return;
@@ -65,7 +65,7 @@ namespace VaultSync.UI.ViewModels
                 MaintenanceRunOutcome outcome = await ExecuteMaintenanceRunAsync(cfg).ConfigureAwait(false);
                 cfg.Advanced.Maintenance.LastRunUtc = DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture);
                 cfg.Advanced.Maintenance.LastStatus = outcome.Status;
-                AppConfigStore.Save(cfg);
+                _configStore.Save(cfg);
 
                 await Dispatcher.UIThread.InvokeAsync(() =>
                 {
@@ -90,7 +90,7 @@ namespace VaultSync.UI.ViewModels
             {
                 BackupIndexConsistencyReport report = await Task.Run(() => _backupIndexConsistencyService.Scan()).ConfigureAwait(false);
                 BackupIndexConsistencySummary summarySnapshot = BackupIndexConsistencyService.BuildSummary(report);
-                await Task.Run(() => AppViewModel.PersistBackupIndexConsistencySummary(summarySnapshot)).ConfigureAwait(false);
+                await Task.Run(() => PersistBackupIndexConsistencySummary(summarySnapshot)).ConfigureAwait(false);
                 string summary = BuildBackupIndexConsistencyStatus(report);
 
                 await Dispatcher.UIThread.InvokeAsync(() =>

--- a/src/VaultSync.UI/ViewModels/AppViewModel.NavigationOps.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.NavigationOps.cs
@@ -163,9 +163,9 @@ namespace VaultSync.UI.ViewModels
                 {
                     try
                     {
-                        AppConfig cfg = AppConfigStore.Load();
+                        AppConfig cfg = _configStore.Load();
                         cfg.LastView = viewToSave;
-                        AppConfigStore.Save(cfg);
+                        _configStore.Save(cfg);
                         Dispatcher.UIThread.Post(() => _config.LastView = viewToSave);
                     }
                     catch (Exception ex)
@@ -270,7 +270,7 @@ namespace VaultSync.UI.ViewModels
         {
             _ = Task.Run(() =>
             {
-                AppConfig cfg = AppConfigStore.GetSnapshot();
+                AppConfig cfg = _configStore.GetSnapshot();
                 string last = string.IsNullOrWhiteSpace(cfg.LastView)
                     ? "Dashboard"
                     : cfg.LastView;

--- a/src/VaultSync.UI/ViewModels/AppViewModel.ProjectRootOps.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.ProjectRootOps.cs
@@ -14,7 +14,7 @@ namespace VaultSync.UI.ViewModels
         {
             try
             {
-                AppConfig cfg = AppConfigStore.GetSnapshot();
+                AppConfig cfg = _configStore.GetSnapshot();
                 string? projectsRoot = cfg.ProjectsRoot?.Trim();
                 if (string.IsNullOrWhiteSpace(projectsRoot))
                 {

--- a/src/VaultSync.UI/ViewModels/AppViewModel.RuntimeOps.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.RuntimeOps.cs
@@ -123,7 +123,7 @@ namespace VaultSync.UI.ViewModels
 
             try
             {
-                AppConfig cfg = AppConfigStore.GetSnapshot();
+                AppConfig cfg = _configStore.GetSnapshot();
                 List<BackupDestination> destinations = GetActiveDestinations(cfg);
 
                 DateTime now = DateTime.UtcNow;
@@ -436,7 +436,7 @@ namespace VaultSync.UI.ViewModels
             if (!request.Confirmed)
                 return;
 
-            AppConfig cfg = await Task.Run(AppConfigStore.Load);
+            AppConfig cfg = await Task.Run(_configStore.Load);
             var projects = await Task.Run(() => _repo.GetAllProjects().ToList());
 
             Project? scopedProject = null;
@@ -558,7 +558,7 @@ namespace VaultSync.UI.ViewModels
 
         private async Task RefreshMetadataNowAsync()
         {
-            AppConfig cfg = await Task.Run(AppConfigStore.Load);
+            AppConfig cfg = await Task.Run(_configStore.Load);
             if (!cfg.Backups.EnableMetadataSync)
             {
                 Console.WriteLine("[MetadataSync] Refresh skipped: metadata sync disabled.");
@@ -874,7 +874,7 @@ namespace VaultSync.UI.ViewModels
             return cfg.Backups.LegacyArchiveUploadBufferBytes;
         }
 
-        private static void SaveArchiveUploadBufferBytes(AppConfig cfg, BackupDestination dest, int bufferBytes)
+        private void SaveArchiveUploadBufferBytes(AppConfig cfg, BackupDestination dest, int bufferBytes)
         {
             if (bufferBytes <= 0)
                 return;
@@ -892,7 +892,7 @@ namespace VaultSync.UI.ViewModels
                 cfg.Backups.LegacyArchiveUploadBufferBytes = bufferBytes;
             }
 
-            AppConfigStore.Save(cfg);
+            _configStore.Save(cfg);
         }
 
         private readonly record struct ArchiveProbeResult(int BufferBytes, double Mbps, bool TimedOut);
@@ -1028,6 +1028,7 @@ namespace VaultSync.UI.ViewModels
 
         private void TryImportMetadataForDestination(AppConfig cfg, BackupDestination dest, string effectivePath)
         {
+            using var dispatchTiming = RuntimeTiming.Measure("Metadata destination import dispatch");
             if (!IsMetadataImportEnabled(cfg, dest))
                 return;
 
@@ -1050,10 +1051,12 @@ namespace VaultSync.UI.ViewModels
             MetadataSyncOptions options = new MetadataSyncOptions(
                 AllowCreateProjects: true,
                 MarkNeedsRestoreOnImport: cfg.Backups.PromptRestoreAfterImport)
-                .AsReadOnlySource();
+                .AsReadOnlySource()
+                .WithUnchangedSourceSkip();
             string name = string.IsNullOrWhiteSpace(dest.Alias) ? dest.Path : dest.Alias!;
             _ = Task.Run(() =>
             {
+                using var importTiming = RuntimeTiming.Measure("Metadata destination import run");
                 try
                 {
                     Console.WriteLine($"[MetadataSync] Auto import started for '{name}'.");
@@ -1093,6 +1096,7 @@ namespace VaultSync.UI.ViewModels
 
         private void TryImportMetadataFromRoot(string rootPath)
         {
+            using var timing = RuntimeTiming.Measure("Metadata root import run");
             if (string.IsNullOrWhiteSpace(rootPath))
                 return;
 
@@ -1106,7 +1110,8 @@ namespace VaultSync.UI.ViewModels
             MetadataSyncOptions options = new MetadataSyncOptions(
                 AllowCreateProjects: true,
                 MarkNeedsRestoreOnImport: cfg.Backups.PromptRestoreAfterImport)
-                .AsReadOnlySource();
+                .AsReadOnlySource()
+                .WithUnchangedSourceSkip();
             try
             {
                 Console.WriteLine("[MetadataSync] Auto import started for projects root.");
@@ -1162,7 +1167,7 @@ namespace VaultSync.UI.ViewModels
 
             try
             {
-                AppConfig cfg = AppConfigStore.GetSnapshot();
+                AppConfig cfg = _configStore.GetSnapshot();
                 int maxSnapshotsToKeep = cfg.Backups.MaxSnapshotsPerProject;
                 if (maxSnapshotsToKeep <= 0)
                     return;
@@ -1262,7 +1267,7 @@ namespace VaultSync.UI.ViewModels
                     return;
 
                 Backup? latestBackup = _repo.GetLatestBackupForProject(projectId);
-                AppConfig cfg = await Task.Run(() => AppConfigStore.GetSnapshot());
+                AppConfig cfg = await Task.Run(() => _configStore.GetSnapshot());
                 List<BackupDestination> destinations = ResolveDestinationsForProject(project, cfg).Destinations;
                 if (destinations.Count == 0)
                 {
@@ -1319,12 +1324,12 @@ namespace VaultSync.UI.ViewModels
             {
                 try
                 {
-                    AppConfig cfg = AppConfigStore.Load();
+                    AppConfig cfg = _configStore.Load();
                     BackupDestination? destEntry = FindMatchingDestination(cfg, dest);
                     if (destEntry != null && destEntry.ForceMetadataBackfill)
                     {
                         destEntry.ForceMetadataBackfill = false;
-                        AppConfigStore.Save(cfg);
+                        _configStore.Save(cfg);
                     }
 
                     if (_settingsViewModel is null)
@@ -1379,7 +1384,7 @@ namespace VaultSync.UI.ViewModels
                 if (BackupsViewModel.IsBusy)
                     return Task.CompletedTask;
 
-                AppConfig cfg = AppConfigStore.GetSnapshot();
+                AppConfig cfg = _configStore.GetSnapshot();
 
                 if (_settingsViewModel?.PreferExternalDrives != true)
                     return Task.CompletedTask;

--- a/src/VaultSync.UI/ViewModels/AppViewModel.StartupConsistencyOps.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.StartupConsistencyOps.cs
@@ -48,11 +48,11 @@ namespace VaultSync.UI.ViewModels
             });
         }
 
-        private static void PersistBackupIndexConsistencySummary(BackupIndexConsistencySummary summary)
+        private void PersistBackupIndexConsistencySummary(BackupIndexConsistencySummary summary)
         {
             try
             {
-                AppConfig config = AppConfigStore.Load();
+                AppConfig config = _configStore.Load();
                 config.Advanced.BackupIndexLastScan = new BackupIndexScanSummary
                 {
                     CheckedUtc = summary.CheckedUtc,
@@ -63,7 +63,7 @@ namespace VaultSync.UI.ViewModels
                     WarningCount = summary.WarningCount,
                     TopFindingCodes = [.. summary.TopFindingCodes]
                 };
-                AppConfigStore.Save(config);
+                _configStore.Save(config);
             }
             catch (Exception ex)
             {

--- a/src/VaultSync.UI/ViewModels/AppViewModel.StartupDiagnosticsOps.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.StartupDiagnosticsOps.cs
@@ -51,9 +51,9 @@ namespace VaultSync.UI.ViewModels
                     Phases = [.. phases]
                 };
 
-                AppConfig cfg = AppConfigStore.Load();
+                AppConfig cfg = _configStore.Load();
                 cfg.Advanced.StartupDiagnostics = summary;
-                AppConfigStore.Save(cfg);
+                _configStore.Save(cfg);
 
                 _config.Advanced.StartupDiagnostics = new StartupDiagnosticsSummary
                 {

--- a/src/VaultSync.UI/ViewModels/AppViewModel.StartupOps.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.StartupOps.cs
@@ -12,12 +12,18 @@ namespace VaultSync.UI.ViewModels
     public partial class AppViewModel
     {
         public AppViewModel()
+            : this(StaticAppConfigStore.Instance)
         {
+        }
+
+        internal AppViewModel(IAppConfigStore configStore)
+        {
+            _configStore = configStore;
             _currentVersionString = GetCurrentVersionString();
             RecordStartupPhase("version-resolved");
 
             // 1) Config + DB + services
-            _config = AppConfigStore.Load();
+            _config = _configStore.Load();
             RecordStartupPhase("config-loaded");
             if (string.IsNullOrWhiteSpace(_config.Advanced.Language))
             {
@@ -36,9 +42,9 @@ namespace VaultSync.UI.ViewModels
 
             _repo = new SqliteRepository(_config.DbPath ?? string.Empty);
 
-            _backupService = new BackupService(_repo);
+            _backupService = new BackupService(_repo, configStore: _configStore);
             _backupService.BackupRetentionDeleted += OnBackupRetentionDeleted;
-            _metadataSyncService = new MetadataSyncService(_repo);
+            _metadataSyncService = new MetadataSyncService(_repo, _configStore);
             MetadataSyncService.ProjectColorResolver = project =>
                 AvatarColorProvider.GetColor(project.Name, project.RootPath, project.ExternalId);
             MetadataSyncService.ProjectColorApplier = (externalId, color) =>
@@ -53,7 +59,7 @@ namespace VaultSync.UI.ViewModels
 
             // 2) Section viewmodels
             _dashboardViewModel = null;
-            _projectsViewModel = new ProjectsViewModel();
+            _projectsViewModel = new ProjectsViewModel(_configStore);
             _projectsViewModel.EditProjectEncryptionRequested += OnProjectEncryptionRequestedFromProjects;
             _projectsViewModel.ProjectEncryptionPolicyChanged += OnProjectEncryptionPolicyChanged;
             _projectsViewModel.ProjectSettingsMetadataChanged += OnProjectSettingsMetadataChanged;
@@ -61,7 +67,7 @@ namespace VaultSync.UI.ViewModels
             _projectsViewModel.AutoBackupGroupPreferenceChanged += OnAutoBackupGroupPreferenceChanged;
             _projectsViewModel.ProjectRemovedFromDatabase += OnProjectRemovedFromDatabase;
             _backupsViewModel = null;
-            _settingsViewModel = new SettingsViewModel(_localizationService);
+            _settingsViewModel = new SettingsViewModel(_localizationService, _configStore);
             _settingsViewModel.PropertyChanged += OnSettingsChanged;
             _settingsViewModel.DestinationSettingsSaved += OnDestinationSettingsSaved;
             _settingsViewModel.OpenLogConsoleRequested += OnOpenLogConsoleRequested;
@@ -147,7 +153,7 @@ namespace VaultSync.UI.ViewModels
         {
             try
             {
-                await AppConfigStore.SaveAsync(_config).ConfigureAwait(false);
+                await _configStore.SaveAsync(_config).ConfigureAwait(false);
                 DiagnosticsLogger.Record($"Startup config persisted ({reason}).");
             }
             catch (Exception ex)
@@ -158,11 +164,13 @@ namespace VaultSync.UI.ViewModels
 
         private async Task RunStartupBackgroundWorkAsync()
         {
+            using var startupTiming = RuntimeTiming.Measure("Startup background work");
             DiagnosticsLogger.Record("Startup background work begin.");
 
             try
             {
                 RecordStartupPhase("db-schema-begin");
+                using var schemaTiming = RuntimeTiming.Measure("Startup background work db schema ensure");
                 await Task.Run(() => _repo.EnsureSchema()).ConfigureAwait(false);
                 RecordStartupPhase("db-schema-complete");
             }
@@ -226,7 +234,7 @@ namespace VaultSync.UI.ViewModels
 
         private BackupsViewModel CreateBackupsViewModel()
         {
-            var vm = new BackupsViewModel();
+            var vm = new BackupsViewModel(_configStore);
             vm.BackupProjectRequested += OnBackupProjectRequested;
             vm.CreateBackupForAllProjectsRequested += OnCreateBackupForAllProjectsRequested;
             vm.DeleteBackupRequested += OnDeleteBackupRequested;

--- a/src/VaultSync.UI/ViewModels/AppViewModel.TrayOps.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.TrayOps.cs
@@ -407,7 +407,7 @@ namespace VaultSync.UI.ViewModels
             if (backup is null)
                 return BackupFolderOpenPreparation.Failure;
 
-            AppConfig cfg = AppConfigStore.GetSnapshot();
+            AppConfig cfg = _configStore.GetSnapshot();
             List<BackupDestination> destinations = AppViewModel.GetAllDestinations(cfg);
             string? destinationRoot = ResolveDestinationRootForBackup(backup, destinations, cfg.Backups.BackupRoot);
             if (string.IsNullOrWhiteSpace(destinationRoot))

--- a/src/VaultSync.UI/ViewModels/AppViewModel.UpdateOps.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.UpdateOps.cs
@@ -146,6 +146,7 @@ namespace VaultSync.UI.ViewModels
 
         private void StartUpdateCheck(bool ignoreSettings = false)
         {
+            using var timing = RuntimeTiming.Measure(ignoreSettings ? "Update check start forced" : "Update check start");
             if (!CanUseSelfUpdate)
             {
                 DiagnosticsLogger.Record("GitHub update checks disabled for Store distribution.");
@@ -235,13 +236,16 @@ namespace VaultSync.UI.ViewModels
                     await Task.Delay(delay);
                     RecordStartupPhase("deferred-startup-begin");
 
-                    AppConfig cfg = AppConfigStore.GetSnapshot();
+                    AppConfig cfg = _configStore.GetSnapshot();
                     await RunStartupDestinationProbeAsync().ConfigureAwait(false);
                     RecordStartupPhase("destination-probe-complete");
 
                     if (cfg.Backups.EnableMetadataSync)
                     {
-                        TryImportMetadataFromRoot(cfg.ProjectsRoot ?? string.Empty);
+                        using (RuntimeTiming.Measure("Deferred startup metadata root import"))
+                        {
+                            TryImportMetadataFromRoot(cfg.ProjectsRoot ?? string.Empty);
+                        }
                         RecordStartupPhase("metadata-import-queued");
                     }
                     else
@@ -251,7 +255,10 @@ namespace VaultSync.UI.ViewModels
 
                     await RunStartupBackupIndexConsistencyCheckAsync().ConfigureAwait(false);
                     RecordStartupPhase("backup-index-scan-complete");
-                    StartUpdateCheck();
+                    using (RuntimeTiming.Measure("Deferred startup update check dispatch"))
+                    {
+                        StartUpdateCheck();
+                    }
                     RecordStartupPhase("update-check-started");
                     ConfigureUpdateCheckTimer();
                     RecordStartupPhase("update-timer-configured");
@@ -465,6 +472,7 @@ namespace VaultSync.UI.ViewModels
 
         private async Task RunUpdateCheckAsync(CancellationToken cancellationToken)
         {
+            using var timing = RuntimeTiming.Measure("Update check run");
             try
             {
                 DiagnosticsLogger.Record("Update check running.");
@@ -674,9 +682,9 @@ namespace VaultSync.UI.ViewModels
             {
                 try
                 {
-                    AppConfig cfg = AppConfigStore.Load();
+                    AppConfig cfg = _configStore.Load();
                     cfg.Advanced.SkippedUpdateTag = tag;
-                    AppConfigStore.Save(cfg);
+                    _configStore.Save(cfg);
                     Dispatcher.UIThread.Post(() => _config.Advanced.SkippedUpdateTag = tag);
                 }
                 catch (Exception ex)
@@ -738,9 +746,9 @@ namespace VaultSync.UI.ViewModels
         {
             try
             {
-                AppConfig cfg = AppConfigStore.Load();
+                AppConfig cfg = _configStore.Load();
                 cfg.Advanced.UpdateDiagnostics = diagnostics ?? new UpdateCheckDiagnostics();
-                AppConfigStore.Save(cfg);
+                _configStore.Save(cfg);
                 Dispatcher.UIThread.Post(() => _settingsViewModel.ReloadUpdateDiagnostics());
             }
             catch (Exception ex)

--- a/src/VaultSync.UI/ViewModels/AppViewModel.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.cs
@@ -98,6 +98,7 @@ namespace VaultSync.UI.ViewModels
         private readonly ProjectsViewModel _projectsViewModel;
         private BackupsViewModel? _backupsViewModel;
         private readonly SettingsViewModel _settingsViewModel;
+        private readonly IAppConfigStore _configStore;
         private AppConfig _config;
         private IBackupWidgetService? _backupWidgetService;
 
@@ -599,7 +600,7 @@ namespace VaultSync.UI.ViewModels
         public bool IsBackupsViewActive => CurrentViewName == "Backups";
         public bool IsSettingsActive => CurrentViewName == "Settings";
         public ProjectsViewModel ProjectsViewModel => _projectsViewModel;
-        public DashboardViewModel DashboardViewModel => _dashboardViewModel ??= new DashboardViewModel();
+        public DashboardViewModel DashboardViewModel => _dashboardViewModel ??= new DashboardViewModel(_configStore);
         public ICommand OpenReleasePageCommand => _openReleaseCommand;
         public ICommand InstallPatchCommand => _installPatchCommand;
         public ICommand SkipUpdateCommand => _skipUpdateCommand;

--- a/src/VaultSync.UI/ViewModels/BackupWidgetViewModel.cs
+++ b/src/VaultSync.UI/ViewModels/BackupWidgetViewModel.cs
@@ -58,8 +58,7 @@ namespace VaultSync.UI.ViewModels
 
         private void OnActiveBackupsChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
-            OnPropertyChanged(nameof(StatusText));
-            OnPropertyChanged(nameof(HasActiveBackups));
+            OnPropertiesChanged(nameof(StatusText), nameof(HasActiveBackups));
         }
     }
 }

--- a/src/VaultSync.UI/ViewModels/BackupsViewModel.cs
+++ b/src/VaultSync.UI/ViewModels/BackupsViewModel.cs
@@ -55,6 +55,7 @@ namespace VaultSync.UI.ViewModels
         private static readonly IBrush FreshnessStaleBrush = new ImmutableSolidColorBrush(Color.Parse("#F56A5A"));
         private static readonly IBrush FreshnessUnknownBrush = new ImmutableSolidColorBrush(Color.Parse("#7F8FA8"));
         private static readonly ConcurrentDictionary<string, ImmutableSolidColorBrush> AccentBrushCache = new(StringComparer.OrdinalIgnoreCase);
+        private readonly IAppConfigStore _configStore;
         // Simple SetProperty helper - note: no PropertyChanged here, we just need
         // equality checks + storage for our internal properties.
         protected static bool SetProperty<T>(ref T storage, T value)
@@ -944,7 +945,13 @@ namespace VaultSync.UI.ViewModels
             !string.Equals(SelectedSnapshotA.Id, SelectedSnapshotB.Id, StringComparison.Ordinal);
 
         public BackupsViewModel()
+            : this(StaticAppConfigStore.Instance)
         {
+        }
+
+        internal BackupsViewModel(IAppConfigStore configStore)
+        {
+            _configStore = configStore;
             _activeBackupFlushTimer.Tick += (_, _) => FlushPendingActiveBackupUpdates();
 
             // All-project backup
@@ -993,7 +1000,7 @@ namespace VaultSync.UI.ViewModels
             RefreshEncryptionPolicyOptions();
             RefreshRestoreModeOptions();
             RefreshVerificationPolicyOptions();
-            RefreshDestinationOptionsInternal(AppConfigStore.GetSnapshot());
+            RefreshDestinationOptionsInternal(_configStore.GetSnapshot());
             RefreshProjectSortOptions();
         }
 
@@ -1436,17 +1443,18 @@ namespace VaultSync.UI.ViewModels
             BackupDiskDriveLabel = driveLabel;
             BackupDiskHealthText = Lf("Backups.Health.Status.Unavailable", "Health ({0}): {1}", driveLabel, L("Backups.Health.NotAvailable", "not available"));
 
-            OnPropertyChanged(nameof(SnapshotsSummaryLine));
-            OnPropertyChanged(nameof(TotalSnapshotsSecondaryLine));
-            OnPropertyChanged(nameof(SnapshotActivitySummary));
-            OnPropertyChanged(nameof(LastBackupDisplay));
-            OnPropertyChanged(nameof(LastBackupSecondaryLine));
-            OnPropertyChanged(nameof(TotalStoredLocalLine));
-            OnPropertyChanged(nameof(TotalStoredImportedLine));
-            OnPropertyChanged(nameof(HistoryFilterProjectLabel));
-            OnPropertyChanged(nameof(BackupHealthSummaryLine));
-            OnPropertyChanged(nameof(BackupDiskDriveLabel));
-            OnPropertyChanged(nameof(BackupDiskHealthText));
+            OnPropertiesChanged(
+                nameof(SnapshotsSummaryLine),
+                nameof(TotalSnapshotsSecondaryLine),
+                nameof(SnapshotActivitySummary),
+                nameof(LastBackupDisplay),
+                nameof(LastBackupSecondaryLine),
+                nameof(TotalStoredLocalLine),
+                nameof(TotalStoredImportedLine),
+                nameof(HistoryFilterProjectLabel),
+                nameof(BackupHealthSummaryLine),
+                nameof(BackupDiskDriveLabel),
+                nameof(BackupDiskHealthText));
             TopStorageConsumers.Clear();
             OnPropertyChanged(nameof(HasTopStorageConsumers));
             RefreshProjectSortOptions();
@@ -2262,7 +2270,7 @@ namespace VaultSync.UI.ViewModels
             {
                 try
                 {
-                    AppConfig config = AppConfigStore.GetSnapshot();
+                    AppConfig config = _configStore.GetSnapshot();
                     (double usedPercent, string freeText, string thresholdText, bool isBelowThreshold, string _, DashboardViewModel.BackupDiskUsageStatus status) =
                         DashboardViewModel.ComputeBackupDiskUsageDetailed(config);
                     string driveLabel = Lf("Backups.Health.DriveLabel", "Drive: {0}", FormatDriveLabel(config.Backups.BackupRoot));
@@ -2736,31 +2744,32 @@ namespace VaultSync.UI.ViewModels
             RebuildSnapshotActivity(now);
 
             // Notify UI that summary properties changed
-            OnPropertyChanged(nameof(TotalSnapshots));
-            OnPropertyChanged(nameof(SnapshotsThisWeek));
-            OnPropertyChanged(nameof(SnapshotsToday));
-            OnPropertyChanged(nameof(SnapshotsYesterday));
-            OnPropertyChanged(nameof(AutoSnapshotsThisWeek));
-            OnPropertyChanged(nameof(ManualSnapshotsThisWeek));
-            OnPropertyChanged(nameof(ImportedSnapshotsThisWeek));
-            OnPropertyChanged(nameof(SnapshotsSummaryLine));
-            OnPropertyChanged(nameof(TotalSnapshotsSecondaryLine));
-            OnPropertyChanged(nameof(SnapshotActivitySummary));
-            OnPropertyChanged(nameof(LastBackupDisplay));
-            OnPropertyChanged(nameof(LastBackupRelative));
-            OnPropertyChanged(nameof(LastBackupSecondaryLine));
-            OnPropertyChanged(nameof(LastBackupSizeValueFormatted));
-            OnPropertyChanged(nameof(LastBackupProjectName));
-            OnPropertyChanged(nameof(LastBackupTypeDisplay));
-            OnPropertyChanged(nameof(LastBackupDestinationDisplay));
-            OnPropertyChanged(nameof(LastBackupSecurityDisplay));
-            OnPropertyChanged(nameof(LastBackupFreshnessPercent));
-            OnPropertyChanged(nameof(LastBackupFreshnessLabel));
-            OnPropertyChanged(nameof(LastBackupFreshnessTooltip));
-            OnPropertyChanged(nameof(LastBackupFreshnessBrush));
-            OnPropertyChanged(nameof(TotalBackupSizeFormatted));
-            OnPropertyChanged(nameof(LocalSnapshotsCount));
-            OnPropertyChanged(nameof(TotalStoredLocalLine));
+            OnPropertiesChanged(
+                nameof(TotalSnapshots),
+                nameof(SnapshotsThisWeek),
+                nameof(SnapshotsToday),
+                nameof(SnapshotsYesterday),
+                nameof(AutoSnapshotsThisWeek),
+                nameof(ManualSnapshotsThisWeek),
+                nameof(ImportedSnapshotsThisWeek),
+                nameof(SnapshotsSummaryLine),
+                nameof(TotalSnapshotsSecondaryLine),
+                nameof(SnapshotActivitySummary),
+                nameof(LastBackupDisplay),
+                nameof(LastBackupRelative),
+                nameof(LastBackupSecondaryLine),
+                nameof(LastBackupSizeValueFormatted),
+                nameof(LastBackupProjectName),
+                nameof(LastBackupTypeDisplay),
+                nameof(LastBackupDestinationDisplay),
+                nameof(LastBackupSecurityDisplay),
+                nameof(LastBackupFreshnessPercent),
+                nameof(LastBackupFreshnessLabel),
+                nameof(LastBackupFreshnessTooltip),
+                nameof(LastBackupFreshnessBrush),
+                nameof(TotalBackupSizeFormatted),
+                nameof(LocalSnapshotsCount),
+                nameof(TotalStoredLocalLine));
             OnPropertyChanged(nameof(TotalStoredLocalValueFormatted));
             OnPropertyChanged(nameof(TotalStoredImportedLine));
             OnPropertyChanged(nameof(TotalStoredImportedValueFormatted));
@@ -3161,7 +3170,7 @@ namespace VaultSync.UI.ViewModels
             if (projects is null) throw new ArgumentNullException(nameof(projects));
             if (backups  is null) throw new ArgumentNullException(nameof(backups));
 
-            AppConfig config = AppConfigStore.GetSnapshot();
+            AppConfig config = _configStore.GetSnapshot();
             ShowProjectAvatars = config.Appearance.ShowProjectAvatars;
             OnPropertyChanged(nameof(ShowProjectAvatars));
             RefreshEncryptionPolicyOptions();
@@ -3507,7 +3516,7 @@ namespace VaultSync.UI.ViewModels
             }
         }
 
-        private static Dictionary<int, Snapshot> LoadSnapshotLookup(AppConfig config, IReadOnlyList<Backup> backups)
+        private Dictionary<int, Snapshot> LoadSnapshotLookup(AppConfig config, IReadOnlyList<Backup> backups)
         {
             var snapshotIds = backups
                 .Select(backup => backup.SnapshotId)
@@ -3522,7 +3531,7 @@ namespace VaultSync.UI.ViewModels
             {
                 string dbPath = !string.IsNullOrWhiteSpace(config.DbPath)
                     ? config.DbPath
-                    : AppConfigStore.GetDefaultDbPath();
+                    : _configStore.GetDefaultDbPath();
                 var repo = new SqliteRepository(dbPath);
                 return repo.GetSnapshotsByIds(snapshotIds)
                     .ToDictionary(snapshot => snapshot.Id);
@@ -3612,7 +3621,7 @@ namespace VaultSync.UI.ViewModels
 
             try
             {
-                AppConfig cfg = AppConfigStore.GetSnapshot();
+                AppConfig cfg = _configStore.GetSnapshot();
                 HashSet<int> disabled = cfg.Backups.AutoBackupDisabledProjects?.ToHashSet() ?? [];
                 UpdateAutoBackupFlags(disabled);
                 _lastAutoBackupSignature = ComputeAutoBackupSignature(disabled);
@@ -3749,7 +3758,7 @@ namespace VaultSync.UI.ViewModels
 
             _ = Task.Run(() =>
             {
-                AppConfig config = AppConfigStore.GetSnapshot();
+                AppConfig config = _configStore.GetSnapshot();
                 Dispatcher.UIThread.Post(() =>
                 {
                     UpdateProjectDestinationDisplay(item, config);
@@ -3765,7 +3774,7 @@ namespace VaultSync.UI.ViewModels
 
             _ = Task.Run(() =>
             {
-                AppConfig config = AppConfigStore.GetSnapshot();
+                AppConfig config = _configStore.GetSnapshot();
                 Dispatcher.UIThread.Post(() =>
                 {
                     UpdateProjectEncryptionDisplay(item, config);
@@ -3864,10 +3873,8 @@ namespace VaultSync.UI.ViewModels
             public string ChangedBytes { get; }
         }
 
-        public class BackupSnapshotItem : INotifyPropertyChanged
+        public class BackupSnapshotItem : ViewModelBase
         {
-            public event PropertyChangedEventHandler? PropertyChanged;
-
         public string Id { get; set; } = string.Empty;
         public DateTime Timestamp { get; set; }
         public long SizeBytes { get; set; }
@@ -3925,8 +3932,8 @@ namespace VaultSync.UI.ViewModels
                 if (_isProtected != value)
                 {
                     _isProtected = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsProtected)));
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(RetentionOutcomeLabel)));
+                    OnPropertyChanged(nameof(IsProtected));
+                    OnPropertyChanged(nameof(RetentionOutcomeLabel));
                 }
             }
         }
@@ -4006,22 +4013,8 @@ namespace VaultSync.UI.ViewModels
         public override string ToString() => Label;
     }
 
-    public class ProjectBackupItem : INotifyPropertyChanged
+    public class ProjectBackupItem : ViewModelBase
     {
-        public event PropertyChangedEventHandler? PropertyChanged;
-
-        private bool SetField<T>(ref T field, T value, string propertyName)
-        {
-            if (EqualityComparer<T>.Default.Equals(field, value))
-                return false;
-            field = value;
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-            return true;
-        }
-
-        private void OnPropertyChanged(string propertyName) =>
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-
         public string Id { get; set; } = string.Empty;
         public string Name { get; set; } = string.Empty;
         public string ExternalId { get; set; } = string.Empty;
@@ -5059,33 +5052,4 @@ namespace VaultSync.UI.ViewModels
         public IBrush StateBrush { get; }
     }
 
-    /// <summary>
-    /// Minimal ICommand implementation so we don't depend on any toolkit.
-    /// </summary>
-    internal sealed class ActionCommand : ICommand
-    {
-        private readonly Action<object?> _execute;
-        private readonly Func<object?, bool>? _canExecute;
-
-        public ActionCommand(Action<object?> execute, Func<object?, bool>? canExecute = null)
-        {
-            _execute    = execute  ?? throw new ArgumentNullException(nameof(execute));
-            _canExecute = canExecute;
-        }
-
-        public bool CanExecute(object? parameter) => _canExecute?.Invoke(parameter) ?? true;
-        public void Execute(object? parameter)    => _execute(parameter);
-
-        public event EventHandler? CanExecuteChanged;
-        public void RaiseCanExecuteChanged()
-        {
-            if (Dispatcher.UIThread.CheckAccess())
-            {
-                CanExecuteChanged?.Invoke(this, EventArgs.Empty);
-                return;
-            }
-
-            Dispatcher.UIThread.Post(() => CanExecuteChanged?.Invoke(this, EventArgs.Empty));
-        }
-    }
 }

--- a/src/VaultSync.UI/ViewModels/DashboardViewModel.cs
+++ b/src/VaultSync.UI/ViewModels/DashboardViewModel.cs
@@ -414,9 +414,16 @@ namespace VaultSync.UI.ViewModels
         private SqliteRepository? _repo;
         private string? _repoDbPath;
         private IReadOnlyList<(Project project, long bytes)> _lastStorageSlices = [];
+        private readonly IAppConfigStore _configStore;
 
         public DashboardViewModel()
+            : this(StaticAppConfigStore.Instance)
         {
+        }
+
+        internal DashboardViewModel(IAppConfigStore configStore)
+        {
+            _configStore = configStore;
             RefreshCommand = new RelayCommand(async _ => await RefreshAsync(force: true));
             NewSnapshotCommand = new RelayCommand(_ => { /* wired later from dashboard actions */ });
             ToggleRestoreReadinessIssuesCommand = new RelayCommand(_ => ShowRestoreReadinessIssues = !ShowRestoreReadinessIssues, _ => HasRestoreReadinessIssues);
@@ -474,6 +481,7 @@ namespace VaultSync.UI.ViewModels
                 return;
             }
 
+            using var refreshTiming = RuntimeTiming.Measure(force ? "Dashboard refresh forced" : "Dashboard refresh");
             try
             {
                 DashboardData data = await Task.Run(() =>
@@ -481,10 +489,12 @@ namespace VaultSync.UI.ViewModels
                     if (!force && _lastDashboardData is not null &&
                         (DateTime.UtcNow - _lastDashboardDataUtc) < DashboardDataTtl)
                     {
+                        RuntimeLog.WriteVerbose("[Timing] Dashboard refresh reused cached data.");
                         return _lastDashboardData;
                     }
 
-                    AppConfig cfg = AppConfigStore.GetSnapshot();
+                    using var dataLoadTiming = RuntimeTiming.Measure("Dashboard refresh data load");
+                    AppConfig cfg = _configStore.GetSnapshot();
                     (double usedPercent, string freeText, string thresholdText, bool isBelowThreshold, string riskReason, BackupDiskUsageStatus status) diskUsage = ComputeBackupDiskUsageDetailed(cfg);
 
                     string dbPath = !string.IsNullOrWhiteSpace(cfg.DbPath)
@@ -627,161 +637,112 @@ namespace VaultSync.UI.ViewModels
                     return dashboardData;
                 });
 
-                await Dispatcher.UIThread.InvokeAsync(() =>
+                RuntimeTimingScope uiQueueTiming = RuntimeTiming.Measure("Dashboard refresh dispatcher queue wait");
+                bool uiQueueTimingDisposed = false;
+                try
                 {
-                    BackupDiskUsedPercent      = data.DiskUsage.UsedPercent;
-                    BackupDiskFreeText         = data.DiskUsage.FreeText;
-                    BackupDiskThresholdText    = data.DiskUsage.ThresholdText;
-                    BackupDiskIsBelowThreshold = data.DiskUsage.IsBelowThreshold;
-                    BackupDiskRiskReason       = data.DiskUsage.RiskReason;
-
-                    ProjectCount = data.Projects.Count;
-                    SnapshotCount = data.BackupCount;
-                    _backupsThisWeekCount = data.BackupsThisWeekCount;
-                    SnapshotsHint = string.Format(L("Dashboard.Hint.SnapshotsThisWeek", "{0} this week"), _backupsThisWeekCount);
-
-                    _activeProjectsCount = data.StorageSlices.Count;
-                    StorageUsed = FormatBytes(data.TotalLatestBytes);
-                    StorageUsedLocal = Lf("Dashboard.Kpi.StorageLocal", "Local: {0}", FormatBytes(data.TotalLocalBytes));
-
-                    if (data.Projects.Count == 0)
+                    await Dispatcher.UIThread.InvokeAsync(() =>
                     {
-                        ProjectsHint = L("Dashboard.Hint.NoProjects", "No projects yet");
-                    }
-                    else if (_activeProjectsCount == 0)
-                    {
-                        ProjectsHint = L("Dashboard.Hint.NoSnapshots", "No snapshots yet");
-                    }
-                    else
-                    {
-                        ProjectsHint = _activeProjectsCount == 1
-                            ? L("Dashboard.Hint.ActiveProjects.One", "1 active project")
-                            : string.Format(L("Dashboard.Hint.ActiveProjects.Many", "{0} active projects"), _activeProjectsCount);
-                    }
+                        uiQueueTiming.Dispose();
+                        uiQueueTimingDisposed = true;
+                        using var uiApplyTiming = RuntimeTiming.Measure("Dashboard refresh UI apply");
+                        BackupDiskUsedPercent      = data.DiskUsage.UsedPercent;
+                        BackupDiskFreeText         = data.DiskUsage.FreeText;
+                        BackupDiskThresholdText    = data.DiskUsage.ThresholdText;
+                        BackupDiskIsBelowThreshold = data.DiskUsage.IsBelowThreshold;
+                        BackupDiskRiskReason       = data.DiskUsage.RiskReason;
 
-                    StorageHint = _activeProjectsCount == 0
-                        ? L("Dashboard.Hint.StorageEmpty", "No storage used")
-                        : L("Dashboard.Hint.StorageTotal", "Total across all backups");
-                    ApplyRestoreReadinessSummary(data.RestoreReadiness);
+                        ProjectCount = data.Projects.Count;
+                        SnapshotCount = data.BackupCount;
+                        _backupsThisWeekCount = data.BackupsThisWeekCount;
+                        SnapshotsHint = string.Format(L("Dashboard.Hint.SnapshotsThisWeek", "{0} this week"), _backupsThisWeekCount);
 
-                    var activityItems = new List<ActivityItem>();
-                    Color[] projectPalette = new[]
-                    {
-                        Color.Parse("#4C8DFF"),
-                        Color.Parse("#22CC88"),
-                        Color.Parse("#FFB84C"),
-                        Color.Parse("#FF6B6B"),
-                        Color.Parse("#9B6BFF")
-                    };
-                    var projectDotBrushes = new Dictionary<int, IBrush>();
-                    int paletteIndex = 0;
+                        _activeProjectsCount = data.StorageSlices.Count;
+                        StorageUsed = FormatBytes(data.TotalLatestBytes);
+                        StorageUsedLocal = Lf("Dashboard.Kpi.StorageLocal", "Local: {0}", FormatBytes(data.TotalLocalBytes));
 
-                    IBrush GetBrush(Color color) => new ImmutableSolidColorBrush(color);
-
-                    foreach ((int? ProjectId, DateTime WhenUtc, string Subtitle) a in data.Activities
-                                 .OrderByDescending(a => a.WhenUtc)
-                                 .Take(5))
-                    {
-                        Project? project = null;
-                        if (a.ProjectId.HasValue)
+                        if (data.Projects.Count == 0)
                         {
-                            project = data.Projects.FirstOrDefault(p => p.Id == a.ProjectId.Value);
+                            ProjectsHint = L("Dashboard.Hint.NoProjects", "No projects yet");
                         }
-
-                        string title = project != null ? project.Name : L("Dashboard.Activity.UnknownProject", "Unknown project");
-                        string subtitle = a.Subtitle switch
+                        else if (_activeProjectsCount == 0)
                         {
-                            "auto"     => L("Dashboard.Activity.AutoBackup", "Auto backup created"),
-                            "manual"   => L("Dashboard.Activity.ManualBackup", "Manual backup created"),
-                            _          => L("Dashboard.Activity.SnapshotCreated", "Snapshot created")
-                        };
-                        string tagsDisplay = string.Empty;
-                        ProjectTagChip[] tagChips = [];
-                        if (project is not null)
-                        {
-                            string[] tags = [.. (project.Tags ?? string.Empty)
-                                .Split(',', StringSplitOptions.RemoveEmptyEntries)
-                                .Select(t => t.Trim())
-                                .Where(t => !string.IsNullOrWhiteSpace(t))
-                                .Distinct(StringComparer.OrdinalIgnoreCase)
-                                .Take(3)];
-                            if (tags.Length > 0)
-                                tagsDisplay = string.Join(" - ", tags);
-                            tagChips = [.. ProjectTagAppearance.CreateChips(project.Tags, max: 3)];
-                        }
-                        string when = a.WhenUtc.ToLocalTime().ToString("g");
-
-                        IBrush dotBrush;
-                        if (project != null)
-                        {
-                            if (!projectDotBrushes.TryGetValue(project.Id, out dotBrush!))
-                            {
-                                Color color = projectPalette[paletteIndex % projectPalette.Length];
-                                dotBrush = GetBrush(color);
-                                projectDotBrushes[project.Id] = dotBrush;
-                                paletteIndex++;
-                            }
+                            ProjectsHint = L("Dashboard.Hint.NoSnapshots", "No snapshots yet");
                         }
                         else
                         {
-                            dotBrush = GetBrush(Colors.Gray);
+                            ProjectsHint = _activeProjectsCount == 1
+                                ? L("Dashboard.Hint.ActiveProjects.One", "1 active project")
+                                : string.Format(L("Dashboard.Hint.ActiveProjects.Many", "{0} active projects"), _activeProjectsCount);
                         }
 
-                        activityItems.Add(new ActivityItem(title, subtitle, when, dotBrush, tagsDisplay, tagChips));
-                    }
+                        StorageHint = _activeProjectsCount == 0
+                            ? L("Dashboard.Hint.StorageEmpty", "No storage used")
+                            : L("Dashboard.Hint.StorageTotal", "Total across all backups");
+                        ApplyRestoreReadinessSummary(data.RestoreReadiness);
 
-                    ActivityItems.Clear();
-                    foreach (ActivityItem item in activityItems)
-                    {
-                        ActivityItems.Add(item);
-                    }
+                        List<ActivityItem> activityItems = BuildRecentActivityItems(data);
 
-                    for (int i = 0; i < _days.Length && i < data.DayLabels.Length; i++)
-                    {
-                        _days[i] = data.DayLabels[i];
-                    }
-                    Array.Clear(_snapshotCountsByDay, 0, _snapshotCountsByDay.Length);
-                    for (int i = 0; i < _snapshotCountsByDay.Length && i < data.SnapshotCounts.Length; i++)
-                    {
-                        _snapshotCountsByDay[i] = data.SnapshotCounts[i];
-                    }
-                    Array.Clear(_autoCountsByDay, 0, _autoCountsByDay.Length);
-                    Array.Clear(_manualCountsByDay, 0, _manualCountsByDay.Length);
-                    Array.Clear(_importedCountsByDay, 0, _importedCountsByDay.Length);
-                    for (int i = 0; i < _autoCountsByDay.Length && i < data.AutoCounts.Length; i++)
-                    {
-                        _autoCountsByDay[i] = data.AutoCounts[i];
-                    }
-                    for (int i = 0; i < _manualCountsByDay.Length && i < data.ManualCounts.Length; i++)
-                    {
-                        _manualCountsByDay[i] = data.ManualCounts[i];
-                    }
-                    for (int i = 0; i < _importedCountsByDay.Length && i < data.ImportedCounts.Length; i++)
-                    {
-                        _importedCountsByDay[i] = data.ImportedCounts[i];
-                    }
+                        ActivityItems.Clear();
+                        foreach (ActivityItem item in activityItems)
+                        {
+                            ActivityItems.Add(item);
+                        }
 
-                    UpdateBackupSummaryPills();
+                        for (int i = 0; i < _days.Length && i < data.DayLabels.Length; i++)
+                        {
+                            _days[i] = data.DayLabels[i];
+                        }
+                        Array.Clear(_snapshotCountsByDay, 0, _snapshotCountsByDay.Length);
+                        for (int i = 0; i < _snapshotCountsByDay.Length && i < data.SnapshotCounts.Length; i++)
+                        {
+                            _snapshotCountsByDay[i] = data.SnapshotCounts[i];
+                        }
+                        Array.Clear(_autoCountsByDay, 0, _autoCountsByDay.Length);
+                        Array.Clear(_manualCountsByDay, 0, _manualCountsByDay.Length);
+                        Array.Clear(_importedCountsByDay, 0, _importedCountsByDay.Length);
+                        for (int i = 0; i < _autoCountsByDay.Length && i < data.AutoCounts.Length; i++)
+                        {
+                            _autoCountsByDay[i] = data.AutoCounts[i];
+                        }
+                        for (int i = 0; i < _manualCountsByDay.Length && i < data.ManualCounts.Length; i++)
+                        {
+                            _manualCountsByDay[i] = data.ManualCounts[i];
+                        }
+                        for (int i = 0; i < _importedCountsByDay.Length && i < data.ImportedCounts.Length; i++)
+                        {
+                            _importedCountsByDay[i] = data.ImportedCounts[i];
+                        }
 
-                    BuildSnapshotSeries();
-                    BuildWeeklyActivity();
-                    BuildStorageDonut(data.StorageSlices);
-                    BuildBackupUsageBar(data.Config, data.StorageSlices);
-                    if (data.StorageSlices.Count > 0 &&
-                        (BackupUsageSegments.Count == 0 ||
-                         (BackupUsageSegments.Count == 1 &&
-                          BackupUsageSegments[0].Name.StartsWith(
-                              L("Dashboard.Storage.Other", "Other"),
-                              StringComparison.OrdinalIgnoreCase))))
+                        UpdateBackupSummaryPills();
+
+                        BuildSnapshotSeries();
+                        BuildWeeklyActivity();
+                        BuildStorageDonut(data.StorageSlices);
+                        BuildBackupUsageBar(data.Config, data.StorageSlices);
+                        if (data.StorageSlices.Count > 0 &&
+                            (BackupUsageSegments.Count == 0 ||
+                             (BackupUsageSegments.Count == 1 &&
+                              BackupUsageSegments[0].Name.StartsWith(
+                                  L("Dashboard.Storage.Other", "Other"),
+                                  StringComparison.OrdinalIgnoreCase))))
+                        {
+                            BuildBackupUsageBarFromVaultSync(
+                                data.StorageSlices,
+                                data.StorageSlices.Sum(x => Math.Max(0L, x.bytes)));
+                        }
+
+                        OnPropertyChanged(nameof(TotalSnapshotsWeek));
+                        OnPropertyChanged(nameof(TotalSnapshotsWeekLabel));
+                    });
+                }
+                finally
+                {
+                    if (!uiQueueTimingDisposed)
                     {
-                        BuildBackupUsageBarFromVaultSync(
-                            data.StorageSlices,
-                            data.StorageSlices.Sum(x => Math.Max(0L, x.bytes)));
+                        uiQueueTiming.Dispose();
                     }
-
-                    OnPropertyChanged(nameof(TotalSnapshotsWeek));
-                    OnPropertyChanged(nameof(TotalSnapshotsWeekLabel));
-                });
+                }
             }
             catch (Exception ex)
             {
@@ -817,8 +778,90 @@ namespace VaultSync.UI.ViewModels
             public RestoreReadinessSummary RestoreReadiness { get; init; } = new();
         }
 
+        private static List<ActivityItem> BuildRecentActivityItems(DashboardData data)
+        {
+            using var timing = RuntimeTiming.Measure("Dashboard recent activity rebuild");
+            Color[] projectPalette =
+            [
+                Color.Parse("#4C8DFF"),
+                Color.Parse("#22CC88"),
+                Color.Parse("#FFB84C"),
+                Color.Parse("#FF6B6B"),
+                Color.Parse("#9B6BFF")
+            ];
+
+            var projectsById = data.Projects.ToDictionary(project => project.Id);
+            var projectDotBrushes = new Dictionary<int, IBrush>();
+            var activityItems = new List<ActivityItem>();
+            int paletteIndex = 0;
+
+            IBrush GetBrush(Color color) => new ImmutableSolidColorBrush(color);
+
+            foreach ((int? ProjectId, DateTime WhenUtc, string Subtitle) activity in data.Activities
+                         .OrderByDescending(item => item.WhenUtc)
+                         .Take(5))
+            {
+                Project? project = activity.ProjectId.HasValue &&
+                    projectsById.TryGetValue(activity.ProjectId.Value, out Project? matchedProject)
+                        ? matchedProject
+                        : null;
+
+                string title = project != null
+                    ? project.Name
+                    : L("Dashboard.Activity.UnknownProject", "Unknown project");
+                string subtitle = activity.Subtitle switch
+                {
+                    "auto" => L("Dashboard.Activity.AutoBackup", "Auto backup created"),
+                    "manual" => L("Dashboard.Activity.ManualBackup", "Manual backup created"),
+                    _ => L("Dashboard.Activity.SnapshotCreated", "Snapshot created")
+                };
+                (string tagsDisplay, ProjectTagChip[] tagChips) = BuildActivityProjectTags(project);
+                string when = activity.WhenUtc.ToLocalTime().ToString("g");
+
+                IBrush dotBrush;
+                if (project != null)
+                {
+                    if (!projectDotBrushes.TryGetValue(project.Id, out dotBrush!))
+                    {
+                        Color color = projectPalette[paletteIndex % projectPalette.Length];
+                        dotBrush = GetBrush(color);
+                        projectDotBrushes[project.Id] = dotBrush;
+                        paletteIndex++;
+                    }
+                }
+                else
+                {
+                    dotBrush = GetBrush(Colors.Gray);
+                }
+
+                activityItems.Add(new ActivityItem(title, subtitle, when, dotBrush, tagsDisplay, tagChips));
+            }
+
+            return activityItems;
+        }
+
+        private static (string TagsDisplay, ProjectTagChip[] TagChips) BuildActivityProjectTags(Project? project)
+        {
+            if (project is null)
+                return (string.Empty, []);
+
+            string[] tags = [.. (project.Tags ?? string.Empty)
+                .Split(',', StringSplitOptions.RemoveEmptyEntries)
+                .Select(tag => tag.Trim())
+                .Where(tag => !string.IsNullOrWhiteSpace(tag))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Take(3)];
+            string tagsDisplay = tags.Length > 0
+                ? string.Join(" - ", tags)
+                : string.Empty;
+            ProjectTagChip[] tagChips = [.. ProjectTagAppearance.CreateChips(project.Tags, max: 3)];
+
+            return (tagsDisplay, tagChips);
+        }
+
         private void BuildSnapshotSeries()
         {
+            using var timing = RuntimeTiming.Measure("Dashboard snapshot series rebuild");
             // Simple, readable chart: one bar per day showing how many backups ran.
             var accent = SKColor.Parse("#22CCFF");
 
@@ -837,6 +880,7 @@ namespace VaultSync.UI.ViewModels
 
         private void BuildWeeklyActivity()
         {
+            using var timing = RuntimeTiming.Measure("Dashboard weekly activity rebuild");
             WeeklySnapshotActivity.Clear();
 
             double max = _snapshotCountsByDay.DefaultIfEmpty(0d).Max();
@@ -912,6 +956,7 @@ namespace VaultSync.UI.ViewModels
 
         private void BuildStorageDonut(IReadOnlyList<(Project project, long bytes)> perProject)
         {
+            using var timing = RuntimeTiming.Measure("Dashboard storage donut rebuild");
             _lastStorageSlices = perProject ?? [];
 
             // If we have no per-project data, show an empty donut.
@@ -1003,6 +1048,7 @@ namespace VaultSync.UI.ViewModels
 
         private void BuildDemoSeriesIfNeeded()
         {
+            using var timing = RuntimeTiming.Measure("Dashboard empty series rebuild");
             if (SnapshotSeries is { Length: > 0 } && StorageSeries is { Length: > 0 })
                 return;
 
@@ -1025,7 +1071,7 @@ namespace VaultSync.UI.ViewModels
             ApplyRestoreReadinessSummary(new RestoreReadinessSummary());
 
             BuildStorageDonut([]);
-            AppConfig cfg = AppConfigStore.GetSnapshot();
+            AppConfig cfg = _configStore.GetSnapshot();
             BuildBackupUsageBar(cfg, []);
             OnPropertyChanged(nameof(TotalSnapshotsWeek));
             OnPropertyChanged(nameof(TotalSnapshotsWeekLabel));
@@ -1033,6 +1079,7 @@ namespace VaultSync.UI.ViewModels
 
         private void BuildBackupUsageBar(AppConfig config, IReadOnlyList<(Project project, long bytes)> perProject)
         {
+            using var timing = RuntimeTiming.Measure("Dashboard backup usage bar rebuild");
             try
             {
                 // Default to empty segments if backup root is not configured.
@@ -1203,13 +1250,7 @@ namespace VaultSync.UI.ViewModels
                 }
             };
 
-            OnPropertyChanged(nameof(BackupUsageSegments));
-            OnPropertyChanged(nameof(BackupTopConsumers));
-            OnPropertyChanged(nameof(HasBackupTopConsumers));
-            OnPropertyChanged(nameof(HasBackupUsageSegments));
-            OnPropertyChanged(nameof(BackupUsageSeries));
-            OnPropertyChanged(nameof(BackupUsageXAxes));
-            OnPropertyChanged(nameof(BackupUsageYAxes));
+            NotifyBackupUsageChanged();
             return;
         }
 
@@ -1234,13 +1275,7 @@ namespace VaultSync.UI.ViewModels
                 }
             };
 
-            OnPropertyChanged(nameof(BackupUsageSegments));
-            OnPropertyChanged(nameof(BackupTopConsumers));
-            OnPropertyChanged(nameof(HasBackupTopConsumers));
-            OnPropertyChanged(nameof(HasBackupUsageSegments));
-            OnPropertyChanged(nameof(BackupUsageSeries));
-            OnPropertyChanged(nameof(BackupUsageXAxes));
-            OnPropertyChanged(nameof(BackupUsageYAxes));
+            NotifyBackupUsageChanged();
             return;
         }
 
@@ -1287,13 +1322,7 @@ namespace VaultSync.UI.ViewModels
             }
         };
 
-        OnPropertyChanged(nameof(BackupUsageSegments));
-        OnPropertyChanged(nameof(BackupTopConsumers));
-        OnPropertyChanged(nameof(HasBackupTopConsumers));
-        OnPropertyChanged(nameof(HasBackupUsageSegments));
-        OnPropertyChanged(nameof(BackupUsageSeries));
-        OnPropertyChanged(nameof(BackupUsageXAxes));
-        OnPropertyChanged(nameof(BackupUsageYAxes));
+        NotifyBackupUsageChanged();
     }
     catch (Exception ex)
     {
@@ -1305,17 +1334,13 @@ namespace VaultSync.UI.ViewModels
         BackupUsageXAxes    = [];
         BackupUsageYAxes    = [];
 
-        OnPropertyChanged(nameof(BackupUsageSegments));
-        OnPropertyChanged(nameof(BackupTopConsumers));
-        OnPropertyChanged(nameof(HasBackupTopConsumers));
-        OnPropertyChanged(nameof(BackupUsageSeries));
-        OnPropertyChanged(nameof(BackupUsageXAxes));
-        OnPropertyChanged(nameof(BackupUsageYAxes));
+        NotifyBackupUsageChanged();
     }
 }
 
         private void BuildBackupUsageBarFromVaultSync(IReadOnlyList<(Project project, long bytes)> perProject, long vaultSyncBytes)
         {
+            using var timing = RuntimeTiming.Measure("Dashboard backup usage fallback rebuild");
             if (vaultSyncBytes <= 0 || perProject == null || perProject.Count == 0)
             {
             BackupUsageSegments = [];
@@ -1324,12 +1349,7 @@ namespace VaultSync.UI.ViewModels
             BackupUsageXAxes    = [];
             BackupUsageYAxes    = [];
 
-            OnPropertyChanged(nameof(BackupUsageSegments));
-            OnPropertyChanged(nameof(BackupTopConsumers));
-            OnPropertyChanged(nameof(HasBackupTopConsumers));
-            OnPropertyChanged(nameof(BackupUsageSeries));
-            OnPropertyChanged(nameof(BackupUsageXAxes));
-            OnPropertyChanged(nameof(BackupUsageYAxes));
+            NotifyBackupUsageChanged();
             return;
             }
 
@@ -1407,13 +1427,7 @@ namespace VaultSync.UI.ViewModels
                     }
                 };
 
-                OnPropertyChanged(nameof(BackupUsageSegments));
-                OnPropertyChanged(nameof(BackupTopConsumers));
-                OnPropertyChanged(nameof(HasBackupTopConsumers));
-                OnPropertyChanged(nameof(HasBackupUsageSegments));
-                OnPropertyChanged(nameof(BackupUsageSeries));
-                OnPropertyChanged(nameof(BackupUsageXAxes));
-                OnPropertyChanged(nameof(BackupUsageYAxes));
+                NotifyBackupUsageChanged();
                 return;
             }
 
@@ -1460,14 +1474,18 @@ namespace VaultSync.UI.ViewModels
                 }
             };
 
-            OnPropertyChanged(nameof(BackupUsageSegments));
-            OnPropertyChanged(nameof(BackupTopConsumers));
-            OnPropertyChanged(nameof(HasBackupTopConsumers));
-            OnPropertyChanged(nameof(HasBackupUsageSegments));
-            OnPropertyChanged(nameof(BackupUsageSeries));
-            OnPropertyChanged(nameof(BackupUsageXAxes));
-            OnPropertyChanged(nameof(BackupUsageYAxes));
+            NotifyBackupUsageChanged();
         }
+
+        private void NotifyBackupUsageChanged() =>
+            OnPropertiesChanged(
+                nameof(BackupUsageSegments),
+                nameof(BackupTopConsumers),
+                nameof(HasBackupTopConsumers),
+                nameof(HasBackupUsageSegments),
+                nameof(BackupUsageSeries),
+                nameof(BackupUsageXAxes),
+                nameof(BackupUsageYAxes));
 
         private static IReadOnlyList<BackupUsageSegment> BuildTopConsumerList(IReadOnlyList<BackupUsageSegment> segments)
         {
@@ -1975,6 +1993,7 @@ namespace VaultSync.UI.ViewModels
 
         private void UpdateBackupSummaryPills()
         {
+            using var timing = RuntimeTiming.Measure("Dashboard backup summary rebuild");
             // Dashboard tracks the last 7 days (UTC date, including today) in the chart arrays.
             int todayCount = _snapshotCountsByDay.Length > 0 ? (int)_snapshotCountsByDay[^1] : 0;
             int autoWeek = _autoCountsByDay.Sum();
@@ -2092,6 +2111,7 @@ namespace VaultSync.UI.ViewModels
 
         private void RebuildStorageSortOptions()
         {
+            using var timing = RuntimeTiming.Measure("Dashboard storage sort options rebuild");
             StorageLegendSortMode selectedMode = _selectedStorageSortOption?.Mode ?? StorageLegendSortMode.LargestFirst;
             StorageSortOptions.Clear();
             StorageSortOptions.Add(new StorageLegendSortOption(
@@ -2109,6 +2129,7 @@ namespace VaultSync.UI.ViewModels
 
         private void ApplyRestoreReadinessSummary(RestoreReadinessSummary summary)
         {
+            using var timing = RuntimeTiming.Measure("Dashboard restore readiness rebuild");
             RestoreReadinessReadyCount = summary.ReadyCount;
             RestoreReadinessAttentionCount = summary.AttentionCount;
             RestoreReadinessRiskCount = summary.RiskCount;
@@ -2201,9 +2222,9 @@ namespace VaultSync.UI.ViewModels
         private static string FormatBytes(long bytes) =>
             bytes <= 0 ? "0 B" : UiFormat.FormatBytes(bytes, "0.#");
 
-        private static string GetDefaultDbPath()
+        private string GetDefaultDbPath()
         {
-            return AppConfigStore.GetDefaultDbPath();
+            return _configStore.GetDefaultDbPath();
         }
 
         // Bindables
@@ -2257,4 +2278,3 @@ namespace VaultSync.UI.ViewModels
         }
     }
 }
-

--- a/src/VaultSync.UI/ViewModels/NotificationState.cs
+++ b/src/VaultSync.UI/ViewModels/NotificationState.cs
@@ -101,8 +101,7 @@ namespace VaultSync.UI.ViewModels.Notifications
             {
                 if (SetField(ref _repeatCount, value))
                 {
-                    OnPropertyChanged(nameof(HasRepeatCount));
-                    OnPropertyChanged(nameof(RepeatCountLabel));
+                    OnPropertiesChanged(nameof(HasRepeatCount), nameof(RepeatCountLabel));
                 }
             }
         }

--- a/src/VaultSync.UI/ViewModels/OnboardingTourViewModel.cs
+++ b/src/VaultSync.UI/ViewModels/OnboardingTourViewModel.cs
@@ -535,7 +535,7 @@ public sealed class OnboardingTourViewModel : ViewModelBase
                 {
                     try
                     {
-                        AppConfig cfg = AppConfigStore.GetSnapshot();
+                        AppConfig cfg = _app.GetConfigSnapshot();
                         Dispatcher.UIThread.Post(() =>
                         {
                             _cachedConfig = cfg;
@@ -552,7 +552,7 @@ public sealed class OnboardingTourViewModel : ViewModelBase
             return _cachedConfig;
         }
 
-        AppConfig fresh = AppConfigStore.GetSnapshot();
+        AppConfig fresh = _app.GetConfigSnapshot();
         _cachedConfig = fresh;
         _lastConfigAt = now;
         return fresh;

--- a/src/VaultSync.UI/ViewModels/ProjectsViewModel.cs
+++ b/src/VaultSync.UI/ViewModels/ProjectsViewModel.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using Avalonia.Media;
 using Avalonia.Threading;
@@ -47,6 +46,7 @@ public class ProjectsViewModel : ViewModelBase
         string EncryptionKeyRef);
 
     private readonly ProjectDiscoveryService _discovery = new();
+    private readonly IAppConfigStore _configStore;
     private IReadOnlyList<DiscoveredProject> _cachedDiscovery = [];
     private string? _cachedDiscoveryRoot;
     private DateTime _cachedDiscoveryUtc;
@@ -148,7 +148,7 @@ public class ProjectsViewModel : ViewModelBase
         get => _selectedProject;
         set
         {
-            if (SetProperty(ref _selectedProject, value))
+            if (SetField(ref _selectedProject, value))
             {
                 if (value is not null && !string.IsNullOrWhiteSpace(value.Name))
                     _lastSelectedProjectName = value.Name;
@@ -186,14 +186,14 @@ public class ProjectsViewModel : ViewModelBase
     public string SnapshotActionLabel
     {
         get => _snapshotActionLabel;
-        set => SetProperty(ref _snapshotActionLabel, value);
+        set => SetField(ref _snapshotActionLabel, value);
     }
 
     private bool _isLoading;
     public bool IsLoading
     {
         get => _isLoading;
-        set => SetProperty(ref _isLoading, value);
+        set => SetField(ref _isLoading, value);
     }
 
     // Reusable notification state for the Projects view.
@@ -245,7 +245,7 @@ public class ProjectsViewModel : ViewModelBase
         get => _groupTagInput;
         set
         {
-            if (!SetProperty(ref _groupTagInput, value ?? string.Empty))
+            if (!SetField(ref _groupTagInput, value ?? string.Empty))
                 return;
 
             ConsumeGroupTagInputDelimiters();
@@ -260,7 +260,7 @@ public class ProjectsViewModel : ViewModelBase
         get => _projectTagInput;
         set
         {
-            if (!SetProperty(ref _projectTagInput, value ?? string.Empty))
+            if (!SetField(ref _projectTagInput, value ?? string.Empty))
                 return;
 
             ConsumeProjectTagInputDelimiters();
@@ -286,7 +286,7 @@ public class ProjectsViewModel : ViewModelBase
         get => _isProjectTagColorEditorOpen;
         set
         {
-            if (!SetProperty(ref _isProjectTagColorEditorOpen, value))
+            if (!SetField(ref _isProjectTagColorEditorOpen, value))
                 return;
 
             OnPropertyChanged(nameof(ProjectTagColorToggleLabel));
@@ -332,7 +332,7 @@ public class ProjectsViewModel : ViewModelBase
         set
         {
             var normalized = ProjectTagAppearance.NormalizeHex(value, _projectTagColorHex);
-            if (!SetProperty(ref _projectTagColorHex, normalized))
+            if (!SetField(ref _projectTagColorHex, normalized))
                 return;
 
             if (Color.TryParse(normalized, out var parsed))
@@ -352,7 +352,7 @@ public class ProjectsViewModel : ViewModelBase
         set
         {
             var clamped = Math.Clamp(value, 0d, 255d);
-            if (!SetProperty(ref _projectTagColorRed, clamped))
+            if (!SetField(ref _projectTagColorRed, clamped))
                 return;
             SyncHexFromRgb();
         }
@@ -364,7 +364,7 @@ public class ProjectsViewModel : ViewModelBase
         set
         {
             var clamped = Math.Clamp(value, 0d, 255d);
-            if (!SetProperty(ref _projectTagColorGreen, clamped))
+            if (!SetField(ref _projectTagColorGreen, clamped))
                 return;
             SyncHexFromRgb();
         }
@@ -376,7 +376,7 @@ public class ProjectsViewModel : ViewModelBase
         set
         {
             var clamped = Math.Clamp(value, 0d, 255d);
-            if (!SetProperty(ref _projectTagColorBlue, clamped))
+            if (!SetField(ref _projectTagColorBlue, clamped))
                 return;
             SyncHexFromRgb();
         }
@@ -388,7 +388,7 @@ public class ProjectsViewModel : ViewModelBase
         set
         {
             var normalized = Math.Clamp(value, 0d, 360d);
-            if (!SetProperty(ref _projectTagColorHue, normalized))
+            if (!SetField(ref _projectTagColorHue, normalized))
                 return;
             SyncHexFromHsv();
         }
@@ -400,7 +400,7 @@ public class ProjectsViewModel : ViewModelBase
         set
         {
             var normalized = Math.Clamp(value, 0d, 100d);
-            if (!SetProperty(ref _projectTagColorSaturation, normalized))
+            if (!SetField(ref _projectTagColorSaturation, normalized))
                 return;
             SyncHexFromHsv();
         }
@@ -412,7 +412,7 @@ public class ProjectsViewModel : ViewModelBase
         set
         {
             var normalized = Math.Clamp(value, 0d, 100d);
-            if (!SetProperty(ref _projectTagColorValue, normalized))
+            if (!SetField(ref _projectTagColorValue, normalized))
                 return;
             SyncHexFromHsv();
         }
@@ -428,35 +428,35 @@ public class ProjectsViewModel : ViewModelBase
     public string PresetEditorContent
     {
         get => _presetEditorContent;
-        set => SetProperty(ref _presetEditorContent, value ?? string.Empty);
+        set => SetField(ref _presetEditorContent, value ?? string.Empty);
     }
 
     private string _presetEditorStatus = string.Empty;
     public string PresetEditorStatus
     {
         get => _presetEditorStatus;
-        set => SetProperty(ref _presetEditorStatus, value ?? string.Empty);
+        set => SetField(ref _presetEditorStatus, value ?? string.Empty);
     }
 
     private string _presetEditorPath = string.Empty;
     public string PresetEditorPath
     {
         get => _presetEditorPath;
-        set => SetProperty(ref _presetEditorPath, value ?? string.Empty);
+        set => SetField(ref _presetEditorPath, value ?? string.Empty);
     }
 
     private string _presetEditorPathDisplay = string.Empty;
     public string PresetEditorPathDisplay
     {
         get => _presetEditorPathDisplay;
-        set => SetProperty(ref _presetEditorPathDisplay, value ?? string.Empty);
+        set => SetField(ref _presetEditorPathDisplay, value ?? string.Empty);
     }
 
     private bool _hasPresetEditorTarget;
     public bool HasPresetEditorTarget
     {
         get => _hasPresetEditorTarget;
-        set => SetProperty(ref _hasPresetEditorTarget, value);
+        set => SetField(ref _hasPresetEditorTarget, value);
     }
 
     private bool _isPresetEditorVisible;
@@ -465,7 +465,7 @@ public class ProjectsViewModel : ViewModelBase
         get => _isPresetEditorVisible;
         set
         {
-            if (!SetProperty(ref _isPresetEditorVisible, value))
+            if (!SetField(ref _isPresetEditorVisible, value))
                 return;
 
             OnPropertyChanged(nameof(PresetEditorToggleLabel));
@@ -481,14 +481,14 @@ public class ProjectsViewModel : ViewModelBase
     public string PresetEditorCloneId
     {
         get => _presetEditorCloneId;
-        set => SetProperty(ref _presetEditorCloneId, value ?? string.Empty);
+        set => SetField(ref _presetEditorCloneId, value ?? string.Empty);
     }
 
     private string _presetEditorImportPath = string.Empty;
     public string PresetEditorImportPath
     {
         get => _presetEditorImportPath;
-        set => SetProperty(ref _presetEditorImportPath, value ?? string.Empty);
+        set => SetField(ref _presetEditorImportPath, value ?? string.Empty);
     }
     public string SearchText
     {
@@ -537,7 +537,7 @@ public class ProjectsViewModel : ViewModelBase
         get => _selectedGroup;
         set
         {
-            if (SetProperty(ref _selectedGroup, value))
+            if (SetField(ref _selectedGroup, value))
             {
                 ApplyFilterAndSort();
                 _snapshotGroupCommand.RaiseCanExecuteChanged();
@@ -551,7 +551,13 @@ public class ProjectsViewModel : ViewModelBase
     }
 
     public ProjectsViewModel()
+        : this(StaticAppConfigStore.Instance)
     {
+    }
+
+    internal ProjectsViewModel(IAppConfigStore configStore)
+    {
+        _configStore = configStore;
         RefreshCommand = new RelayCommand(_ => Refresh());
         _openFolderCommand = new RelayCommand(_ => OpenFolder(), _ => SelectedProject is not null);
         _removeProjectCommand = new RelayCommand(_ => RemoveProject(), _ => SelectedProject is not null);
@@ -675,9 +681,9 @@ public class ProjectsViewModel : ViewModelBase
         Notification.Show(message, severity);
     }
 
-    private static void NotifySnapshotOutcome(string message, bool success)
+    private void NotifySnapshotOutcome(string message, bool success)
     {
-        var cfg = AppConfigStore.GetSnapshot();
+        var cfg = _configStore.GetSnapshot();
 
         var wants = success
             ? cfg.Notifications.OnSnapshotSuccess
@@ -719,7 +725,7 @@ public class ProjectsViewModel : ViewModelBase
         {
             IsLoading = true;
 
-            var config = await Task.Run(AppConfigStore.GetSnapshot);
+            var config = await Task.Run(_configStore.GetSnapshot);
             RefreshGroupAutoBackupStateFromConfig(config);
             ShowProjectAvatars = config.Appearance.ShowProjectAvatars;
             OnPropertyChanged(nameof(ShowProjectAvatars));
@@ -1457,10 +1463,10 @@ public class ProjectsViewModel : ViewModelBase
         if (!CanEditProjectTagColor || string.IsNullOrWhiteSpace(tag))
             return;
 
-        var cfg = AppConfigStore.Load();
+        var cfg = _configStore.Load();
         cfg.Appearance.TagColors ??= new Dictionary<string, TagColorConfig>(StringComparer.OrdinalIgnoreCase);
         cfg.Appearance.TagColors[tag] = ProjectTagAppearance.BuildConfigFromAccent(ProjectTagColorHex);
-        AppConfigStore.Save(cfg);
+        _configStore.Save(cfg);
         RefreshProjectTagAppearance(cfg);
         ShowNotification(Lf("Projects.Tags.ColorApplied", "Saved custom color for tag '{0}'.", tag));
     }
@@ -1474,17 +1480,17 @@ public class ProjectsViewModel : ViewModelBase
         var (background, _, _) = ProjectTagChip.GetDefaultPalette(tag);
         ProjectTagColorHex = background;
 
-        var cfg = AppConfigStore.Load();
+        var cfg = _configStore.Load();
         cfg.Appearance.TagColors ??= new Dictionary<string, TagColorConfig>(StringComparer.OrdinalIgnoreCase);
         cfg.Appearance.TagColors.Remove(tag);
-        AppConfigStore.Save(cfg);
+        _configStore.Save(cfg);
         RefreshProjectTagAppearance(cfg);
         ShowNotification(Lf("Projects.Tags.ColorReset", "Reset tag '{0}' to the default palette.", tag));
     }
 
     private void RefreshProjectTagAppearance(AppConfig? config = null)
     {
-        config ??= AppConfigStore.GetSnapshot();
+        config ??= _configStore.GetSnapshot();
         RefreshSelectedProjectTags();
         RefreshReusableProjectTags();
         foreach (var project in _allProjects)
@@ -1502,7 +1508,7 @@ public class ProjectsViewModel : ViewModelBase
 
     private void SyncProjectTagColorDraft(string tag)
     {
-        var cfg = AppConfigStore.GetSnapshot();
+        var cfg = _configStore.GetSnapshot();
         var accent = ProjectTagAppearance.Resolve(tag, cfg.Appearance.TagColors).Background;
 
         _projectTagColorSyncing = true;
@@ -1769,7 +1775,7 @@ public class ProjectsViewModel : ViewModelBase
 
     private void RefreshGroupAutoBackupStateFromConfig(AppConfig? config = null)
     {
-        config ??= AppConfigStore.GetSnapshot();
+        config ??= _configStore.GetSnapshot();
         _autoBackupDisabledProjectIds = [.. config.Backups.AutoBackupDisabledProjects ?? []];
         _disableAutoBackupGroupCommand.RaiseCanExecuteChanged();
         _enableAutoBackupGroupCommand.RaiseCanExecuteChanged();
@@ -1796,7 +1802,7 @@ public class ProjectsViewModel : ViewModelBase
 
         await Task.Run(() =>
         {
-            var config = AppConfigStore.GetSnapshot();
+            var config = _configStore.GetSnapshot();
             var dbPath = !string.IsNullOrWhiteSpace(config.DbPath)
                 ? config.DbPath
                 : GetDefaultDbPath();
@@ -1861,7 +1867,7 @@ public class ProjectsViewModel : ViewModelBase
 
         try
         {
-            var config = await Task.Run(AppConfigStore.GetSnapshot).ConfigureAwait(false);
+            var config = await Task.Run(_configStore.GetSnapshot).ConfigureAwait(false);
             var dbPath = !string.IsNullOrWhiteSpace(config.DbPath)
                 ? config.DbPath
                 : GetDefaultDbPath();
@@ -1969,13 +1975,13 @@ public class ProjectsViewModel : ViewModelBase
 
         await Task.Run(() =>
         {
-            var cfg = AppConfigStore.Load();
+            var cfg = _configStore.Load();
             var disabled = cfg.Backups.AutoBackupDisabledProjects ?? [];
             disabled = enabled
                 ? [.. disabled.Except(ids).Distinct()]
                 : [.. disabled.Concat(ids).Distinct()];
             cfg.Backups.AutoBackupDisabledProjects = disabled;
-            AppConfigStore.Save(cfg);
+            _configStore.Save(cfg);
         }).ConfigureAwait(false);
 
         await Dispatcher.UIThread.InvokeAsync(() =>
@@ -2299,7 +2305,7 @@ public class ProjectsViewModel : ViewModelBase
         {
             try
             {
-                var config = AppConfigStore.GetSnapshot();
+                var config = _configStore.GetSnapshot();
                 var dbPath = !string.IsNullOrWhiteSpace(config.DbPath)
                     ? config.DbPath
                     : GetDefaultDbPath();
@@ -2366,7 +2372,7 @@ public class ProjectsViewModel : ViewModelBase
         try
         {
             // 1. Resolve DB path from shared AppConfig (with a sensible default).
-            var config = await Task.Run(AppConfigStore.GetSnapshot);
+            var config = await Task.Run(_configStore.GetSnapshot);
             var dbPath = !string.IsNullOrWhiteSpace(config.DbPath)
                 ? config.DbPath
                 : GetDefaultDbPath();
@@ -2519,13 +2525,13 @@ public class ProjectsViewModel : ViewModelBase
         return set;
     }
 
-    private static void HideProjectPathInConfig(string? projectPath)
+    private void HideProjectPathInConfig(string? projectPath)
     {
         var normalized = NormalizeProjectPath(projectPath);
         if (string.IsNullOrWhiteSpace(normalized))
             return;
 
-        var cfg = AppConfigStore.Load();
+        var cfg = _configStore.Load();
         cfg.Behavior.HiddenProjectPaths ??= [];
         var exists = cfg.Behavior.HiddenProjectPaths
             .Any(path => string.Equals(NormalizeProjectPath(path), normalized, StringComparison.OrdinalIgnoreCase));
@@ -2533,23 +2539,23 @@ public class ProjectsViewModel : ViewModelBase
             return;
 
         cfg.Behavior.HiddenProjectPaths.Add(normalized);
-        AppConfigStore.Save(cfg);
+        _configStore.Save(cfg);
     }
 
-    private static void UnhideProjectPathInConfig(string? projectPath)
+    private void UnhideProjectPathInConfig(string? projectPath)
     {
         var normalized = NormalizeProjectPath(projectPath);
         if (string.IsNullOrWhiteSpace(normalized))
             return;
 
-        var cfg = AppConfigStore.Load();
+        var cfg = _configStore.Load();
         cfg.Behavior.HiddenProjectPaths ??= [];
         var originalCount = cfg.Behavior.HiddenProjectPaths.Count;
         cfg.Behavior.HiddenProjectPaths = [.. cfg.Behavior.HiddenProjectPaths.Where(path => !string.Equals(NormalizeProjectPath(path), normalized, StringComparison.OrdinalIgnoreCase))];
         if (cfg.Behavior.HiddenProjectPaths.Count == originalCount)
             return;
 
-        AppConfigStore.Save(cfg);
+        _configStore.Save(cfg);
     }
 
     private void RemoveProjectFromCurrentList(string? projectPath)
@@ -2652,11 +2658,11 @@ public class ProjectsViewModel : ViewModelBase
         }
     }
 
-    private static ProjectRegistrationSnapshot LoadProjectRegistrationSnapshot(string projectName)
+    private ProjectRegistrationSnapshot LoadProjectRegistrationSnapshot(string projectName)
     {
         try
         {
-            var config = AppConfigStore.GetSnapshot();
+            var config = _configStore.GetSnapshot();
             var dbPath = !string.IsNullOrWhiteSpace(config.DbPath)
                 ? config.DbPath
                 : GetDefaultDbPath();
@@ -2712,7 +2718,7 @@ public class ProjectsViewModel : ViewModelBase
             SelectedProject.PreferredDestinationId = snapshot.PreferredDestinationId;
             SelectedProject.EncryptionPolicy = snapshot.EncryptionPolicy;
             SelectedProject.EncryptionKeyRef = snapshot.EncryptionKeyRef;
-            var cfg = AppConfigStore.GetSnapshot();
+            var cfg = _configStore.GetSnapshot();
             UpdateProjectDestinationDisplay(SelectedProject, cfg);
             UpdateProjectEncryptionDisplay(SelectedProject, cfg);
             UpdateProjectPresetDisplay(SelectedProject);
@@ -2745,7 +2751,7 @@ public class ProjectsViewModel : ViewModelBase
 
         try
         {
-            var config = AppConfigStore.GetSnapshot();
+            var config = _configStore.GetSnapshot();
             var dbPath = !string.IsNullOrWhiteSpace(config.DbPath)
                 ? config.DbPath
                 : GetDefaultDbPath();
@@ -2813,7 +2819,7 @@ public class ProjectsViewModel : ViewModelBase
             {
                 try
                 {
-                    var config = AppConfigStore.GetSnapshot();
+                    var config = _configStore.GetSnapshot();
                     var dbPath = !string.IsNullOrWhiteSpace(config.DbPath)
                         ? config.DbPath
                         : GetDefaultDbPath();
@@ -2916,7 +2922,7 @@ public class ProjectsViewModel : ViewModelBase
             ? L("Snapshots.Action.Default", "Snapshot now")
             : L("Snapshots.Action.AddProject", "Add project");
         OnPropertyChanged(nameof(SortModeLabel));
-        var config = AppConfigStore.GetSnapshot();
+        var config = _configStore.GetSnapshot();
         LoadGroupOptions();
         OnPropertyChanged(nameof(ProjectTagColorToggleLabel));
         RefreshEncryptionPolicyOptions();
@@ -3487,22 +3493,9 @@ public class ProjectsViewModel : ViewModelBase
 
     private sealed record PresetRecommendation(string PresetId, string Reason);
 
-    private static string GetDefaultDbPath()
+    private string GetDefaultDbPath()
     {
-        // Fallback DB location when AppConfig.DbPath is not set.
-        // Later this will be fully unified with the CLI DB resolution logic.
-        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-        var dir = Path.Combine(appData, "VaultSync");
-        Directory.CreateDirectory(dir);
-        return Path.Combine(dir, "vaultsync.db");
-    }
-
-    private bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string? propertyName = null)
-    {
-        if (Equals(storage, value)) return false;
-        storage = value;
-        OnPropertyChanged(propertyName);
-        return true;
+        return _configStore.GetDefaultDbPath();
     }
 
     public void SetAvatarForSelectedProject(string avatarPath)
@@ -3549,28 +3542,28 @@ public class ProjectItemViewModel : ViewModelBase
     public string Name
     {
         get => _name;
-        set => SetProperty(ref _name, value);
+        set => SetField(ref _name, value);
     }
 
     private string _path = string.Empty;
     public string Path
     {
         get => _path;
-        set => SetProperty(ref _path, value);
+        set => SetField(ref _path, value);
     }
 
     private string _externalId = string.Empty;
     public string ExternalId
     {
         get => _externalId;
-        set => SetProperty(ref _externalId, value ?? string.Empty);
+        set => SetField(ref _externalId, value ?? string.Empty);
     }
 
     private int _projectId;
     public int ProjectId
     {
         get => _projectId;
-        set => SetProperty(ref _projectId, value);
+        set => SetField(ref _projectId, value);
     }
 
     private ProjectHealthStatus _health;
@@ -3579,7 +3572,7 @@ public class ProjectItemViewModel : ViewModelBase
         get => _health;
         set
         {
-            if (SetProperty(ref _health, value))
+            if (SetField(ref _health, value))
             {
                 OnPropertyChanged(nameof(HealthBackground));
                 OnPropertyChanged(nameof(HealthForeground));
@@ -3591,7 +3584,7 @@ public class ProjectItemViewModel : ViewModelBase
     public string HealthTag
     {
         get => _healthTag;
-        set => SetProperty(ref _healthTag, value);
+        set => SetField(ref _healthTag, value);
     }
 
     private DateTime _lastSnapshot;
@@ -3600,7 +3593,7 @@ public class ProjectItemViewModel : ViewModelBase
         get => _lastSnapshot;
         set
         {
-            if (SetProperty(ref _lastSnapshot, value))
+            if (SetField(ref _lastSnapshot, value))
             {
                 OnPropertyChanged(nameof(LastSnapshotSummary));
                 OnPropertyChanged(nameof(LastSnapshotShort));
@@ -3616,7 +3609,7 @@ public class ProjectItemViewModel : ViewModelBase
         get => _sizeBytes;
         set
         {
-            if (SetProperty(ref _sizeBytes, value))
+            if (SetField(ref _sizeBytes, value))
             {
                 OnPropertyChanged(nameof(SizeDisplay));
                 OnPropertyChanged(nameof(LatestSnapshotSizeDisplay));
@@ -3628,21 +3621,21 @@ public class ProjectItemViewModel : ViewModelBase
     public string Preset
     {
         get => _preset;
-        set => SetProperty(ref _preset, value);
+        set => SetField(ref _preset, value);
     }
 
     private string _presetDescription = string.Empty;
     public string PresetDescription
     {
         get => _presetDescription;
-        set => SetProperty(ref _presetDescription, value ?? string.Empty);
+        set => SetField(ref _presetDescription, value ?? string.Empty);
     }
 
     private string _presetExample = string.Empty;
     public string PresetExample
     {
         get => _presetExample;
-        set => SetProperty(ref _presetExample, value ?? string.Empty);
+        set => SetField(ref _presetExample, value ?? string.Empty);
     }
 
     private string _tagsCsv = string.Empty;
@@ -3651,7 +3644,7 @@ public class ProjectItemViewModel : ViewModelBase
         get => _tagsCsv;
         set
         {
-            if (!SetProperty(ref _tagsCsv, value ?? string.Empty))
+            if (!SetField(ref _tagsCsv, value ?? string.Empty))
                 return;
 
             RebuildTagChips();
@@ -3686,21 +3679,21 @@ public class ProjectItemViewModel : ViewModelBase
     public string RecommendedPreset
     {
         get => _recommendedPreset;
-        set => SetProperty(ref _recommendedPreset, value ?? string.Empty);
+        set => SetField(ref _recommendedPreset, value ?? string.Empty);
     }
 
     private string _recommendedPresetReason = string.Empty;
     public string RecommendedPresetReason
     {
         get => _recommendedPresetReason;
-        set => SetProperty(ref _recommendedPresetReason, value ?? string.Empty);
+        set => SetField(ref _recommendedPresetReason, value ?? string.Empty);
     }
 
     private string _preferredDestinationId = string.Empty;
     public string PreferredDestinationId
     {
         get => _preferredDestinationId;
-        set => SetProperty(ref _preferredDestinationId, value ?? string.Empty);
+        set => SetField(ref _preferredDestinationId, value ?? string.Empty);
     }
 
     private DestinationOption? _preferredDestinationOption;
@@ -3714,7 +3707,7 @@ public class ProjectItemViewModel : ViewModelBase
             if (value is null)
                 return;
 
-            if (SetProperty(ref _preferredDestinationOption, value))
+            if (SetField(ref _preferredDestinationOption, value))
                 PreferredDestinationId = value.Id;
         }
     }
@@ -3723,7 +3716,7 @@ public class ProjectItemViewModel : ViewModelBase
     public string PreferredDestinationDisplay
     {
         get => _preferredDestinationDisplay;
-        set => SetProperty(ref _preferredDestinationDisplay, value ?? string.Empty);
+        set => SetField(ref _preferredDestinationDisplay, value ?? string.Empty);
     }
 
     public void SetPreferredDestinationOption(DestinationOption? option)
@@ -3739,14 +3732,14 @@ public class ProjectItemViewModel : ViewModelBase
     public string EncryptionPolicy
     {
         get => _encryptionPolicy;
-        set => SetProperty(ref _encryptionPolicy, ProjectEncryptionPolicy.Normalize(value));
+        set => SetField(ref _encryptionPolicy, ProjectEncryptionPolicy.Normalize(value));
     }
 
     private string _encryptionKeyRef = string.Empty;
     public string EncryptionKeyRef
     {
         get => _encryptionKeyRef;
-        set => SetProperty(ref _encryptionKeyRef, value ?? string.Empty);
+        set => SetField(ref _encryptionKeyRef, value ?? string.Empty);
     }
 
     private EncryptionPolicyOption? _encryptionPolicyOption;
@@ -3755,7 +3748,7 @@ public class ProjectItemViewModel : ViewModelBase
         get => _encryptionPolicyOption;
         set
         {
-            if (SetProperty(ref _encryptionPolicyOption, value))
+            if (SetField(ref _encryptionPolicyOption, value))
             {
                 // Ignore transient null selection events fired while option sources refresh.
                 // Real "inherit" selection is represented by a non-null option with Id="inherit".
@@ -3771,42 +3764,42 @@ public class ProjectItemViewModel : ViewModelBase
     public string EffectiveEncryptionDisplay
     {
         get => _effectiveEncryptionDisplay;
-        set => SetProperty(ref _effectiveEncryptionDisplay, value ?? string.Empty);
+        set => SetField(ref _effectiveEncryptionDisplay, value ?? string.Empty);
     }
 
     private bool _hasEncryptionSecret;
     public bool HasEncryptionSecret
     {
         get => _hasEncryptionSecret;
-        set => SetProperty(ref _hasEncryptionSecret, value);
+        set => SetField(ref _hasEncryptionSecret, value);
     }
 
     private string _encryptionSecretStatus = string.Empty;
     public string EncryptionSecretStatus
     {
         get => _encryptionSecretStatus;
-        set => SetProperty(ref _encryptionSecretStatus, value ?? string.Empty);
+        set => SetField(ref _encryptionSecretStatus, value ?? string.Empty);
     }
 
     private string _encryptionBadgeText = string.Empty;
     public string EncryptionBadgeText
     {
         get => _encryptionBadgeText;
-        set => SetProperty(ref _encryptionBadgeText, value ?? string.Empty);
+        set => SetField(ref _encryptionBadgeText, value ?? string.Empty);
     }
 
     private string _encryptionBadgeBackground = "#2F3650";
     public string EncryptionBadgeBackground
     {
         get => _encryptionBadgeBackground;
-        set => SetProperty(ref _encryptionBadgeBackground, value ?? "#2F3650");
+        set => SetField(ref _encryptionBadgeBackground, value ?? "#2F3650");
     }
 
     private string _encryptionBadgeForeground = "#C7D2FE";
     public string EncryptionBadgeForeground
     {
         get => _encryptionBadgeForeground;
-        set => SetProperty(ref _encryptionBadgeForeground, value ?? "#C7D2FE");
+        set => SetField(ref _encryptionBadgeForeground, value ?? "#C7D2FE");
     }
 
     public void SetEncryptionPolicyOption(EncryptionPolicyOption? option)
@@ -3822,7 +3815,7 @@ public class ProjectItemViewModel : ViewModelBase
     public bool IsRegistered
     {
         get => _isRegistered;
-        set => SetProperty(ref _isRegistered, value);
+        set => SetField(ref _isRegistered, value);
     }
 
     public bool SnapshotHistoryLoaded { get; set; }
@@ -3932,10 +3925,11 @@ public class ProjectItemViewModel : ViewModelBase
         }
 
         // Notify that aggregate snapshot stats have changed.
-        OnPropertyChanged(nameof(SnapshotCount));
-        OnPropertyChanged(nameof(TotalSnapshotSizeDisplay));
-        OnPropertyChanged(nameof(AverageSnapshotSizeDisplay));
-        OnPropertyChanged(nameof(DaysSinceLastSnapshotDisplay));
+        OnPropertiesChanged(
+            nameof(SnapshotCount),
+            nameof(TotalSnapshotSizeDisplay),
+            nameof(AverageSnapshotSizeDisplay),
+            nameof(DaysSinceLastSnapshotDisplay));
     }
 
     // ---- Convenience / formatted properties ----
@@ -3974,10 +3968,11 @@ public class ProjectItemViewModel : ViewModelBase
 
     public void NotifySnapshotTextChanged()
     {
-        OnPropertyChanged(nameof(LastSnapshotSummary));
-        OnPropertyChanged(nameof(LastSnapshotShort));
-        OnPropertyChanged(nameof(LatestSnapshotSizeDisplay));
-        OnPropertyChanged(nameof(DaysSinceLastSnapshotDisplay));
+        OnPropertiesChanged(
+            nameof(LastSnapshotSummary),
+            nameof(LastSnapshotShort),
+            nameof(LatestSnapshotSizeDisplay),
+            nameof(DaysSinceLastSnapshotDisplay));
     }
 
     public string SizeDisplay
@@ -4096,13 +4091,6 @@ public class ProjectItemViewModel : ViewModelBase
             TagChips.Add(ProjectTagChip.Create(tag, config));
     }
 
-    private bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string? propertyName = null)
-    {
-        if (Equals(storage, value)) return false;
-        storage = value;
-        OnPropertyChanged(propertyName);
-        return true;
-    }
 }
 
 public sealed class DestinationOption(string id, string label)

--- a/src/VaultSync.UI/ViewModels/SettingsViewModel.ThemeEditor.cs
+++ b/src/VaultSync.UI/ViewModels/SettingsViewModel.ThemeEditor.cs
@@ -8,12 +8,13 @@ using System.Windows.Input;
 using Avalonia.Media;
 using VaultSync.Core.Config;
 using VaultSync.UI.Services;
+using VaultSync.UI.ViewModels;
 
 namespace VaultSync.UI
 {
     public sealed partial class SettingsViewModel
     {
-        public sealed class ThemeColorSlotViewModel : INotifyPropertyChanged
+        public sealed class ThemeColorSlotViewModel : ViewModelBase
         {
             private string _hex;
             private bool _isSelected;
@@ -26,8 +27,6 @@ namespace VaultSync.UI
                 _hex = hex;
                 _swatchBrush = new SolidColorBrush(Color.Parse(_hex));
             }
-
-            public event PropertyChangedEventHandler? PropertyChanged;
 
             public string Id { get; }
             public string Label { get; }
@@ -43,9 +42,9 @@ namespace VaultSync.UI
 
                     _hex = normalized;
                     _swatchBrush = new SolidColorBrush(Color.Parse(_hex));
-                    RaiseProperty(nameof(Hex));
-                    RaiseProperty(nameof(SwatchColor));
-                    RaiseProperty(nameof(SwatchBrush));
+                    OnPropertyChanged(nameof(Hex));
+                    OnPropertyChanged(nameof(SwatchColor));
+                    OnPropertyChanged(nameof(SwatchBrush));
                 }
             }
 
@@ -58,7 +57,7 @@ namespace VaultSync.UI
                         return;
 
                     _isSelected = value;
-                    RaiseProperty(nameof(IsSelected));
+                    OnPropertyChanged(nameof(IsSelected));
                 }
             }
 
@@ -79,10 +78,6 @@ namespace VaultSync.UI
                     : fallback;
             }
 
-            private void RaiseProperty(string propertyName)
-            {
-                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-            }
         }
 
         public sealed class ThemePresetOptionViewModel
@@ -93,7 +88,7 @@ namespace VaultSync.UI
             public required ThemePaletteConfig Palette { get; init; }
         }
 
-        public sealed class ThemePaletteSwatchViewModel : INotifyPropertyChanged
+        public sealed class ThemePaletteSwatchViewModel : ViewModelBase
         {
             private bool _isSelected;
 
@@ -105,7 +100,6 @@ namespace VaultSync.UI
                 OutlineBrush = CreateOutlineBrush(SwatchColor);
             }
 
-            public event PropertyChangedEventHandler? PropertyChanged;
             public string Hex { get; }
             public Color SwatchColor { get; }
             public IBrush SwatchBrush { get; }
@@ -120,7 +114,7 @@ namespace VaultSync.UI
                         return;
 
                     _isSelected = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsSelected)));
+                    OnPropertyChanged(nameof(IsSelected));
                 }
             }
 

--- a/src/VaultSync.UI/ViewModels/SettingsViewModel.cs
+++ b/src/VaultSync.UI/ViewModels/SettingsViewModel.cs
@@ -27,11 +27,12 @@ using VaultSync.Core.Services;
 using VaultSync.Core.Models;
 using VaultSync.UI.Infrastructure;
 using VaultSync.UI.Notifications;
+using VaultSync.UI.ViewModels;
 using VaultSync.UI.ViewModels.Notifications;
 
 namespace VaultSync.UI
 {
-    public sealed partial class SettingsViewModel : INotifyPropertyChanged
+    public sealed partial class SettingsViewModel : ViewModelBase
     {
         // ---------------- Core backing fields ----------------
 
@@ -124,6 +125,7 @@ namespace VaultSync.UI
         private string _rsyncStatusHint = string.Empty;
         private bool _showRsyncStatusHint;
         private string _selectedLanguageCode = "en";
+        private readonly IAppConfigStore _configStore;
         private readonly CredentialVault _credentialVault = CredentialVault.Instance;
         private readonly BackupEncryptionSecretService _backupEncryptionSecretService = new();
         private readonly NetworkMountService _networkMountService = new();
@@ -210,7 +212,7 @@ namespace VaultSync.UI
             public required string ImportedTags { get; init; }
         }
 
-        public sealed class TagColorRuleViewModel : INotifyPropertyChanged
+        public sealed class TagColorRuleViewModel : ViewModelBase
         {
             private enum ColorSlot
             {
@@ -247,7 +249,6 @@ namespace VaultSync.UI
                     p => p is ThemePaletteSwatchViewModel);
             }
 
-            public event PropertyChangedEventHandler? PropertyChanged;
             public IReadOnlyList<ThemePaletteSwatchViewModel> PaletteSwatches { get; }
             public ICommand ApplyPaletteSwatchCommand { get; }
 
@@ -413,35 +414,31 @@ namespace VaultSync.UI
 
             private void RaiseSelection()
             {
-                RaiseProperty(nameof(IsEditingBackground));
-                RaiseProperty(nameof(IsEditingForeground));
-                RaiseProperty(nameof(IsEditingBorder));
-                RaiseProperty(nameof(ActiveColor));
-                RaiseProperty(nameof(ActiveColorHex));
-            }
-
-            private void RaiseProperty(string propertyName)
-            {
-                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+                OnPropertiesChanged(
+                    nameof(IsEditingBackground),
+                    nameof(IsEditingForeground),
+                    nameof(IsEditingBorder),
+                    nameof(ActiveColor),
+                    nameof(ActiveColorHex));
             }
 
             private void RaiseAll()
             {
-                RaiseProperty(nameof(Tag));
-                RaiseProperty(nameof(Background));
-                RaiseProperty(nameof(Foreground));
-                RaiseProperty(nameof(Border));
-                RaiseProperty(nameof(PreviewTag));
-                RaiseProperty(nameof(PreviewBackground));
-                RaiseProperty(nameof(PreviewForeground));
-                RaiseProperty(nameof(PreviewBorder));
-                RaiseProperty(nameof(ActiveColor));
-                RaiseProperty(nameof(ActiveColorHex));
+                OnPropertiesChanged(
+                    nameof(Tag),
+                    nameof(Background),
+                    nameof(Foreground),
+                    nameof(Border),
+                    nameof(PreviewTag),
+                    nameof(PreviewBackground),
+                    nameof(PreviewForeground),
+                    nameof(PreviewBorder),
+                    nameof(ActiveColor),
+                    nameof(ActiveColorHex));
                 RaiseSelection();
             }
         }
 
-        public event PropertyChangedEventHandler? PropertyChanged;
         public ObservableCollection<ProjectMetadataConflictItemViewModel> ProjectMetadataConflicts { get; } = [];
         public ObservableCollection<TagColorRuleViewModel> TagColorRules { get; } = [];
 
@@ -450,9 +447,10 @@ namespace VaultSync.UI
             ShowLegacyBackupLocation = !UseAdvancedDestinations;
         }
 
-        public SettingsViewModel(LocalizationService localizationService)
+        public SettingsViewModel(LocalizationService localizationService, IAppConfigStore? configStore = null)
         {
             _localizationService = localizationService;
+            _configStore = configStore ?? StaticAppConfigStore.Instance;
             _selectedLanguageCode = localizationService.CurrentLanguage;
             _localizationService.LanguageChanged += () =>
             {
@@ -582,19 +580,6 @@ namespace VaultSync.UI
             _isInitialized = true;
         }
 
-        // ---------------- INPC helpers ----------------
-
-        private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
-            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-
-        private bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
-        {
-            if (Equals(field, value)) return false;
-            field = value;
-            OnPropertyChanged(propertyName);
-            return true;
-        }
-
         // ---------------- Load + Save ----------------
 
         private void LoadFromConfig()
@@ -602,7 +587,7 @@ namespace VaultSync.UI
             _isReloadingFromConfig = true;
             try
             {
-                AppConfig cfg = AppConfigStore.Load();
+                AppConfig cfg = _configStore.Load();
                 _selectedLanguageCode = string.IsNullOrWhiteSpace(cfg.Advanced.Language)
                     ? _localizationService.CurrentLanguage
                     : cfg.Advanced.Language;
@@ -899,7 +884,7 @@ namespace VaultSync.UI
                     Password: c.Password))
                 .ToList();
 
-            AppConfig cfg = AppConfigStore.Load();
+            AppConfig cfg = _configStore.Load();
 
             // Reload latest disabled list to avoid clobbering project-level auto-backup toggles.
             _autoBackupDisabledProjects = cfg.Backups.AutoBackupDisabledProjects ?? [];
@@ -1062,7 +1047,7 @@ namespace VaultSync.UI
                 _ = Task.Run(() => AutoStartService.SetLaunchOnLogin(launchOnLogin));
             }
 
-            await AppConfigStore.SaveAsync(cfg);
+            await _configStore.SaveAsync(cfg);
             if (destinationSettingsChanged)
             {
                 DestinationSettingsSaved?.Invoke();
@@ -2264,9 +2249,9 @@ namespace VaultSync.UI
             {
                 try
                 {
-                    AppConfig cfg = AppConfigStore.Load();
+                    AppConfig cfg = _configStore.Load();
                     cfg.Advanced.Language = _selectedLanguageCode;
-                    AppConfigStore.Save(cfg);
+                    _configStore.Save(cfg);
                 }
                 catch
                 {
@@ -2284,17 +2269,17 @@ namespace VaultSync.UI
 
         public void ReloadUpdateDiagnostics()
         {
-            RefreshUpdateDiagnostics(AppConfigStore.GetSnapshot().Advanced.UpdateDiagnostics);
+            RefreshUpdateDiagnostics(_configStore.GetSnapshot().Advanced.UpdateDiagnostics);
         }
 
         public void ReloadStartupDiagnostics()
         {
-            RefreshStartupDiagnostics(AppConfigStore.GetSnapshot().Advanced.StartupDiagnostics);
+            RefreshStartupDiagnostics(_configStore.GetSnapshot().Advanced.StartupDiagnostics);
         }
 
         public void ReloadCheckpointResumeDiagnostics()
         {
-            RefreshCheckpointResumeDiagnostics(AppConfigStore.GetSnapshot().Advanced.CheckpointResumeTelemetry);
+            RefreshCheckpointResumeDiagnostics(_configStore.GetSnapshot().Advanced.CheckpointResumeTelemetry);
         }
 
         private void RefreshUpdateCheckStatus()
@@ -2825,9 +2810,9 @@ namespace VaultSync.UI
 
             try
             {
-                AppConfig config = await Task.Run(AppConfigStore.Load);
+                AppConfig config = await Task.Run(_configStore.Load);
                 config.ProjectsRoot = path;
-                await AppConfigStore.SaveAsync(config);
+                await _configStore.SaveAsync(config);
             }
             catch
             {
@@ -2894,7 +2879,7 @@ namespace VaultSync.UI
 
         private void ResetToDefaults()
         {
-            AppConfigStore.Save(new AppConfig());
+            _configStore.Save(new AppConfig());
             LoadFromConfig();
         }
 
@@ -2992,7 +2977,7 @@ namespace VaultSync.UI
             }
 
             string display = dest.DisplayName;
-            AppConfig cfg = await Task.Run(AppConfigStore.Load);
+            AppConfig cfg = await Task.Run(_configStore.Load);
             NetworkCredentialProfile? profile = string.IsNullOrWhiteSpace(dest.CredentialName)
                 ? null
                 : cfg.Network.Credentials.FirstOrDefault(c =>
@@ -3208,7 +3193,7 @@ namespace VaultSync.UI
             return (true, true);
         }
 
-        private static void ForgetAllProjects()
+        private void ForgetAllProjects()
         {
             _ = Task.Run(() =>
             {
@@ -3216,7 +3201,7 @@ namespace VaultSync.UI
                 {
                     // Dev helper: reset the VaultSync SQLite DB to a "fresh install" state
                     // without touching any real project files or backup folders on disk.
-                    AppConfig cfg  = AppConfigStore.Load();
+                    AppConfig cfg  = _configStore.Load();
                     var repo = new SqliteRepository(cfg.DbPath ?? string.Empty);
 
                     repo.EnsureSchema();
@@ -3533,7 +3518,7 @@ namespace VaultSync.UI
             {
                 BackupRetentionSimulationResult result = await Task.Run(() =>
                 {
-                    AppConfig cfg = AppConfigStore.Load();
+                    AppConfig cfg = _configStore.Load();
                     var repo = new SqliteRepository(cfg.DbPath ?? string.Empty);
                     var service = new BackupRetentionSimulationService(repo);
                     return service.Simulate(ClampInt(cfg.Backups.MaxSnapshotsPerProject, 1, 999, 20));
@@ -3661,7 +3646,7 @@ namespace VaultSync.UI
             {
                 BackupIndexRepairPlan plan = await Task.Run(() =>
                 {
-                    AppConfig cfg = AppConfigStore.Load();
+                    AppConfig cfg = _configStore.Load();
                     var repo = new SqliteRepository(cfg.DbPath ?? string.Empty);
                     var service = new BackupIndexRepairService(repo);
                     return service.BuildPlan();
@@ -3736,7 +3721,7 @@ namespace VaultSync.UI
             {
                 int applied = await Task.Run(() =>
                 {
-                    AppConfig cfg = AppConfigStore.Load();
+                    AppConfig cfg = _configStore.Load();
                     var repo = new SqliteRepository(cfg.DbPath ?? string.Empty);
                     var service = new BackupIndexRepairService(repo);
                     return service.ApplyPlan(plan);
@@ -3897,7 +3882,7 @@ namespace VaultSync.UI
             {
                 await Task.Run(() =>
                 {
-                    AppConfig cfg = AppConfigStore.Load();
+                    AppConfig cfg = _configStore.Load();
                     var repo = new SqliteRepository(cfg.DbPath ?? string.Empty);
                     repo.UpdateProjectPreferredDestination(item.ProjectId, EmptyToNull(item.ImportedPreferredDestinationId));
                     repo.UpdateProjectRestoreMode(item.ProjectId, EmptyToNull(item.ImportedRestoreMode));
@@ -3906,7 +3891,7 @@ namespace VaultSync.UI
 
                     RemoveProjectMetadataConflictRecord(cfg, item.ProjectId, item.ProjectExternalId);
                     UpdateMetadataConflictTelemetry(cfg, "accept-imported", item.ProjectName, Math.Max(0, cfg.Advanced.ProjectMetadataConflicts.Count));
-                    AppConfigStore.Save(cfg);
+                    _configStore.Save(cfg);
                 }).ConfigureAwait(false);
 
                 string status = string.Format(
@@ -3967,10 +3952,10 @@ namespace VaultSync.UI
             {
                 await Task.Run(() =>
                 {
-                    AppConfig cfg = AppConfigStore.Load();
+                    AppConfig cfg = _configStore.Load();
                     RemoveProjectMetadataConflictRecord(cfg, item.ProjectId, item.ProjectExternalId);
                     UpdateMetadataConflictTelemetry(cfg, "keep-local", item.ProjectName, Math.Max(0, cfg.Advanced.ProjectMetadataConflicts.Count));
-                    AppConfigStore.Save(cfg);
+                    _configStore.Save(cfg);
                 }).ConfigureAwait(false);
 
                 string status = string.Format(
@@ -4027,13 +4012,13 @@ namespace VaultSync.UI
             }
         }
 
-        private static void PersistMetadataConflictTelemetry(string? lastAction, string? lastResolvedProject, int pendingCount)
+        private void PersistMetadataConflictTelemetry(string? lastAction, string? lastResolvedProject, int pendingCount)
         {
             try
             {
-                AppConfig cfg = AppConfigStore.Load();
+                AppConfig cfg = _configStore.Load();
                 UpdateMetadataConflictTelemetry(cfg, lastAction, lastResolvedProject, pendingCount);
-                AppConfigStore.Save(cfg);
+                _configStore.Save(cfg);
             }
             catch (Exception ex)
             {
@@ -4054,11 +4039,11 @@ namespace VaultSync.UI
                 cfg.Advanced.MetadataConflictTelemetry.LastResolvedProject = lastResolvedProject;
         }
 
-        private static void PersistBackupRepairTelemetry(BackupIndexRepairPlan? plan, int? appliedCount, string status)
+        private void PersistBackupRepairTelemetry(BackupIndexRepairPlan? plan, int? appliedCount, string status)
         {
             try
             {
-                AppConfig cfg = AppConfigStore.Load();
+                AppConfig cfg = _configStore.Load();
                 cfg.Advanced.BackupRepairTelemetry ??= new BackupRepairTelemetry();
                 BackupRepairTelemetry telemetry = cfg.Advanced.BackupRepairTelemetry;
                 telemetry.LastScanUtc = DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture);
@@ -4082,7 +4067,7 @@ namespace VaultSync.UI
                     telemetry.LastAppliedCount = appliedCount.Value;
                 }
 
-                AppConfigStore.Save(cfg);
+                _configStore.Save(cfg);
             }
             catch (Exception ex)
             {
@@ -4155,9 +4140,9 @@ namespace VaultSync.UI
                     return (false, L("Settings.Advanced.SupportBundleImportMissingConfig", "Support bundle does not contain importable settings."));
                 }
 
-                AppConfig cfg = AppConfigStore.Load();
+                AppConfig cfg = _configStore.Load();
                 ApplyImportableSettings(redactedConfig, cfg);
-                AppConfigStore.Save(cfg);
+                _configStore.Save(cfg);
                 return (true, L("Settings.Advanced.SupportBundleImportApplied", "Support bundle settings imported (diagnostics ignored)."));
             }
             catch (Exception ex)

--- a/src/VaultSync.UI/ViewModels/TrayPanelViewModel.cs
+++ b/src/VaultSync.UI/ViewModels/TrayPanelViewModel.cs
@@ -160,8 +160,7 @@ public sealed class TrayPanelViewModel : ViewModelBase
             {
                 if (SetField(ref _reachable, value))
                 {
-                    OnPropertyChanged(nameof(StatusText));
-                    OnPropertyChanged(nameof(StatusBrush));
+                    OnPropertiesChanged(nameof(StatusText), nameof(StatusBrush));
                 }
             }
         }

--- a/src/VaultSync.UI/ViewModels/ViewModelBase.cs
+++ b/src/VaultSync.UI/ViewModels/ViewModelBase.cs
@@ -10,6 +10,12 @@ namespace VaultSync.UI.ViewModels
         protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
             => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 
+        protected void OnPropertiesChanged(params string[] propertyNames)
+        {
+            foreach (string propertyName in propertyNames)
+                OnPropertyChanged(propertyName);
+        }
+
         // Optional helper if you want a single-line setter in future:
         protected bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
         {

--- a/tests/VaultSync.Core.Tests/AppConfigStoreTests.cs
+++ b/tests/VaultSync.Core.Tests/AppConfigStoreTests.cs
@@ -1,0 +1,72 @@
+using System.IO;
+using VaultSync.Core.Config;
+using VaultSync.Core.Tests.TestSupport;
+using Xunit;
+
+namespace VaultSync.Core.Tests;
+
+public sealed class AppConfigStoreTests
+{
+    [Fact]
+    public void UseDirectoryForTests_IsolatesConfigPersistence()
+    {
+        using var scope = new TestAppConfigScope();
+        var config = new AppConfig
+        {
+            ProjectsRoot = Path.Combine(scope.ConfigDirectory, "Projects"),
+            DbPath = Path.Combine(scope.ConfigDirectory, "vaultsync.db")
+        };
+
+        AppConfigStore.Save(config);
+
+        AppConfig reloaded = AppConfigStore.Load();
+        Assert.Equal(config.ProjectsRoot, reloaded.ProjectsRoot);
+        Assert.Equal(config.DbPath, reloaded.DbPath);
+        Assert.True(File.Exists(Path.Combine(scope.ConfigDirectory, "appsettings.json")));
+    }
+
+    [Fact]
+    public void SaveLoad_RoundTripsMetadataImportCache()
+    {
+        using var scope = new TestAppConfigScope();
+        var config = new AppConfig
+        {
+            ProjectsRoot = Path.Combine(scope.ConfigDirectory, "Projects"),
+            DbPath = Path.Combine(scope.ConfigDirectory, "vaultsync.db")
+        };
+        config.Advanced.MetadataImportCache.Sources.Add(new MetadataImportSourceStamp
+        {
+            SourceKey = "destination:primary",
+            SourcePath = "/backups/.vaultsync/meta",
+            SourceMachineId = "desktop-01",
+            StoreUpdatedUtc = "2026-05-21T08:30:00Z",
+            StoreSchemaVersion = 1,
+            StoreFileLengthBytes = 4096,
+            StoreFileUpdatedUtc = "2026-05-21T08:31:00Z",
+            StoreSidecarStamp = "none",
+            ImportedUtc = "2026-05-21T08:35:00Z",
+            ProjectCount = 2,
+            SnapshotCount = 3,
+            BackupCount = 4,
+            TombstoneCount = 1
+        });
+
+        AppConfigStore.Save(config);
+
+        AppConfig reloaded = AppConfigStore.Load();
+        MetadataImportSourceStamp source = Assert.Single(reloaded.Advanced.MetadataImportCache.Sources);
+        Assert.Equal("destination:primary", source.SourceKey);
+        Assert.Equal("/backups/.vaultsync/meta", source.SourcePath);
+        Assert.Equal("desktop-01", source.SourceMachineId);
+        Assert.Equal("2026-05-21T08:30:00Z", source.StoreUpdatedUtc);
+        Assert.Equal(1, source.StoreSchemaVersion);
+        Assert.Equal(4096, source.StoreFileLengthBytes);
+        Assert.Equal("2026-05-21T08:31:00Z", source.StoreFileUpdatedUtc);
+        Assert.Equal("none", source.StoreSidecarStamp);
+        Assert.Equal("2026-05-21T08:35:00Z", source.ImportedUtc);
+        Assert.Equal(2, source.ProjectCount);
+        Assert.Equal(3, source.SnapshotCount);
+        Assert.Equal(4, source.BackupCount);
+        Assert.Equal(1, source.TombstoneCount);
+    }
+}

--- a/tests/VaultSync.Core.Tests/BackupCheckpointResumeTests.cs
+++ b/tests/VaultSync.Core.Tests/BackupCheckpointResumeTests.cs
@@ -4,28 +4,20 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using VaultSync.Core.Config;
-using VaultSync.Core.Repositories;
 using VaultSync.Core.Services;
+using VaultSync.Core.Tests.TestSupport;
 using Xunit;
 
 namespace VaultSync.Core.Tests;
 
 public sealed class BackupCheckpointResumeTests : IDisposable
 {
-    private readonly string _tempDir;
-    private readonly string _dbPath;
-
-    public BackupCheckpointResumeTests()
-    {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"vaultsync-checkpoint-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_tempDir);
-        _dbPath = Path.Combine(_tempDir, "vaultsync.db");
-    }
+    private readonly TempDirectory _tempDir = new();
 
     [Fact]
     public void BuildArchiveResumeFingerprint_IsStableAcrossFileOrder()
     {
-        string sourceDir = Path.Combine(_tempDir, "source");
+        string sourceDir = Path.Combine(_tempDir.Path, "source");
         Directory.CreateDirectory(sourceDir);
 
         string a = Path.Combine(sourceDir, "a.txt");
@@ -43,8 +35,8 @@ public sealed class BackupCheckpointResumeTests : IDisposable
     [Fact]
     public void ValidateArchiveResumePrefix_ReturnsTrueOnlyForMatchingPrefix()
     {
-        string local = Path.Combine(_tempDir, "local.zip");
-        string dest = Path.Combine(_tempDir, "dest.zip");
+        string local = Path.Combine(_tempDir.Path, "local.zip");
+        string dest = Path.Combine(_tempDir.Path, "dest.zip");
         File.WriteAllBytes(local, Enumerable.Range(0, 64).Select(i => (byte)i).ToArray());
         File.WriteAllBytes(dest, Enumerable.Range(0, 32).Select(i => (byte)i).ToArray());
 
@@ -57,7 +49,7 @@ public sealed class BackupCheckpointResumeTests : IDisposable
     [Fact]
     public void CleanupIncompleteBackups_PreservesCheckpointedArchiveFolders()
     {
-        string backupRoot = Path.Combine(_tempDir, "backups");
+        string backupRoot = Path.Combine(_tempDir.Path, "backups");
         string projectDir = Path.Combine(backupRoot, "project");
         string resumableDir = Path.Combine(projectDir, "2026-03-13_10-00-00");
         string staleDir = Path.Combine(projectDir, "2026-03-13_09-00-00");
@@ -81,9 +73,6 @@ public sealed class BackupCheckpointResumeTests : IDisposable
 
         File.WriteAllText(Path.Combine(staleDir, ".vaultsync_inprogress"), "started");
         File.WriteAllText(Path.Combine(staleDir, "orphan.txt"), "stale");
-
-        var repo = new SqliteRepository(_dbPath);
-        var service = new BackupService(repo);
 
         int removed = BackupService.CleanupIncompleteBackups(backupRoot);
 
@@ -118,15 +107,6 @@ public sealed class BackupCheckpointResumeTests : IDisposable
 
     public void Dispose()
     {
-        try
-        {
-            if (Directory.Exists(_tempDir))
-            {
-                Directory.Delete(_tempDir, recursive: true);
-            }
-        }
-        catch
-        {
-        }
+        _tempDir.Dispose();
     }
 }

--- a/tests/VaultSync.Core.Tests/BackupCryptoDescriptorTests.cs
+++ b/tests/VaultSync.Core.Tests/BackupCryptoDescriptorTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.Json;
 using VaultSync.Core.Models;
 using VaultSync.Core.Services;
+using VaultSync.Core.Tests.TestSupport;
 using Xunit;
 
 namespace VaultSync.Core.Tests;
@@ -96,29 +97,5 @@ public sealed class BackupCryptoDescriptorTests
         Assert.Equal("aes-256-gcm", root.GetProperty("algorithm").GetString());
         Assert.Equal("pbkdf2-sha256-v1", root.GetProperty("kdfProfile").GetString());
         Assert.Equal("preset-2026-01", root.GetProperty("kdfParamRef").GetString());
-    }
-
-    private sealed class TempDirectory : IDisposable
-    {
-        public TempDirectory()
-        {
-            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"vaultsync-test-{Guid.NewGuid():N}");
-            Directory.CreateDirectory(Path);
-        }
-
-        public string Path { get; }
-
-        public void Dispose()
-        {
-            try
-            {
-                if (Directory.Exists(Path))
-                    Directory.Delete(Path, recursive: true);
-            }
-            catch
-            {
-                // Ignore cleanup failures in tests.
-            }
-        }
     }
 }

--- a/tests/VaultSync.Core.Tests/BackupIndexConsistencyServiceTests.cs
+++ b/tests/VaultSync.Core.Tests/BackupIndexConsistencyServiceTests.cs
@@ -3,37 +3,30 @@ using System.IO;
 using System.Linq;
 using Dapper;
 using Microsoft.Data.Sqlite;
-using VaultSync.Core.Models;
 using VaultSync.Core.Repositories;
 using VaultSync.Core.Services;
+using VaultSync.Core.Tests.TestSupport;
 using Xunit;
 
 namespace VaultSync.Core.Tests;
 
 public sealed class BackupIndexConsistencyServiceTests : IDisposable
 {
-    private readonly string _tempDir;
+    private readonly TempDirectory _tempDir = new();
     private readonly string _dbPath;
 
     public BackupIndexConsistencyServiceTests()
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"vaultsync-consistency-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_tempDir);
-        _dbPath = Path.Combine(_tempDir, "vaultsync.db");
+        _dbPath = Path.Combine(_tempDir.Path, "vaultsync.db");
     }
 
     [Fact]
     public void Scan_WithHealthyIndex_ReturnsNoFindings()
     {
         SqliteRepository repo = CreateRepository();
-        int projectId = repo.AddProject(new Project
-        {
-            Name = "Project One",
-            RootPath = Path.Combine(_tempDir, "ProjectOne"),
-            Preset = "dotnet"
-        });
+        int projectId = TestRepository.AddProject(repo, "Project One", Path.Combine(_tempDir.Path, "ProjectOne"));
         int snapshotId = repo.CreateSnapshot(projectId, 10, 2048);
-        repo.CreateBackup(projectId, snapshotId, "manual", 1024, "project-one/backup", _tempDir, "Primary");
+        repo.CreateBackup(projectId, snapshotId, "manual", 1024, "project-one/backup", _tempDir.Path, "Primary");
 
         var service = new BackupIndexConsistencyService(repo);
         BackupIndexConsistencyReport report = service.Scan();
@@ -49,18 +42,8 @@ public sealed class BackupIndexConsistencyServiceTests : IDisposable
     public void Scan_DetectsDuplicateExternalIds_AndProjectMismatch()
     {
         SqliteRepository repo = CreateRepository();
-        int projectOneId = repo.AddProject(new Project
-        {
-            Name = "Project One",
-            RootPath = Path.Combine(_tempDir, "ProjectOne"),
-            Preset = "dotnet"
-        });
-        int projectTwoId = repo.AddProject(new Project
-        {
-            Name = "Project Two",
-            RootPath = Path.Combine(_tempDir, "ProjectTwo"),
-            Preset = "dotnet"
-        });
+        int projectOneId = TestRepository.AddProject(repo, "Project One", Path.Combine(_tempDir.Path, "ProjectOne"));
+        int projectTwoId = TestRepository.AddProject(repo, "Project Two", Path.Combine(_tempDir.Path, "ProjectTwo"));
         int snapshotId = repo.CreateSnapshot(projectOneId, 20, 4096);
         int secondSnapshotId = repo.CreateSnapshot(projectTwoId, 30, 8192);
         int backupId = repo.CreateBackupFromMetadata(
@@ -71,7 +54,7 @@ public sealed class BackupIndexConsistencyServiceTests : IDisposable
             "manual",
             2048,
             "project-two/backup",
-            _tempDir,
+            _tempDir.Path,
             "Primary",
             isProtected: false,
             isImported: false);
@@ -88,7 +71,7 @@ public sealed class BackupIndexConsistencyServiceTests : IDisposable
                     projectId = projectTwoId,
                     snapshotId,
                     createdUtc = DateTime.UtcNow.ToString("u"),
-                    dest = _tempDir
+                    dest = _tempDir.Path
                 });
         }
 
@@ -106,14 +89,9 @@ public sealed class BackupIndexConsistencyServiceTests : IDisposable
     public void Scan_DetectsMissingExternalIds()
     {
         SqliteRepository repo = CreateRepository();
-        int projectId = repo.AddProject(new Project
-        {
-            Name = "Project No External",
-            RootPath = Path.Combine(_tempDir, "ProjectNoExternal"),
-            Preset = "dotnet"
-        });
+        int projectId = TestRepository.AddProject(repo, "Project No External", Path.Combine(_tempDir.Path, "ProjectNoExternal"));
         int snapshotId = repo.CreateSnapshot(projectId, 5, 512);
-        int backupId = repo.CreateBackup(projectId, snapshotId, "manual", 64, "project-no-external/backup", _tempDir, "Primary");
+        int backupId = repo.CreateBackup(projectId, snapshotId, "manual", 64, "project-no-external/backup", _tempDir.Path, "Primary");
 
         using var connection = new SqliteConnection($"Data Source={_dbPath}");
         connection.Open();
@@ -133,18 +111,8 @@ public sealed class BackupIndexConsistencyServiceTests : IDisposable
     public void Scan_SortsSamplesDeterministically_AndBuildsStableSummary()
     {
         SqliteRepository repo = CreateRepository();
-        int projectB = repo.AddProject(new Project
-        {
-            Name = "Zulu",
-            RootPath = Path.Combine(_tempDir, "Zulu"),
-            Preset = "dotnet"
-        });
-        int projectA = repo.AddProject(new Project
-        {
-            Name = "Alpha",
-            RootPath = Path.Combine(_tempDir, "Alpha"),
-            Preset = "dotnet"
-        });
+        int projectB = TestRepository.AddProject(repo, "Zulu", Path.Combine(_tempDir.Path, "Zulu"));
+        int projectA = TestRepository.AddProject(repo, "Alpha", Path.Combine(_tempDir.Path, "Alpha"));
 
         using var connection = new SqliteConnection($"Data Source={_dbPath}");
         connection.Open();
@@ -163,20 +131,11 @@ public sealed class BackupIndexConsistencyServiceTests : IDisposable
 
     private SqliteRepository CreateRepository()
     {
-        var repo = new SqliteRepository(_dbPath);
-        repo.EnsureSchema();
-        return repo;
+        return TestRepository.Create(_dbPath);
     }
 
     public void Dispose()
     {
-        try
-        {
-            if (Directory.Exists(_tempDir))
-                Directory.Delete(_tempDir, true);
-        }
-        catch
-        {
-        }
+        _tempDir.Dispose();
     }
 }

--- a/tests/VaultSync.Core.Tests/BackupIndexRepairServiceTests.cs
+++ b/tests/VaultSync.Core.Tests/BackupIndexRepairServiceTests.cs
@@ -6,20 +6,19 @@ using Microsoft.Data.Sqlite;
 using VaultSync.Core.Models;
 using VaultSync.Core.Repositories;
 using VaultSync.Core.Services;
+using VaultSync.Core.Tests.TestSupport;
 using Xunit;
 
 namespace VaultSync.Core.Tests;
 
 public sealed class BackupIndexRepairServiceTests : IDisposable
 {
-    private readonly string _tempDir;
+    private readonly TempDirectory _tempDir = new();
     private readonly string _dbPath;
 
     public BackupIndexRepairServiceTests()
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"vaultsync-repair-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_tempDir);
-        _dbPath = Path.Combine(_tempDir, "vaultsync.db");
+        _dbPath = Path.Combine(_tempDir.Path, "vaultsync.db");
     }
 
     [Fact]
@@ -37,7 +36,7 @@ public sealed class BackupIndexRepairServiceTests : IDisposable
             "manual",
             1024,
             "alpha/backup",
-            _tempDir,
+            _tempDir.Path,
             "Primary",
             isProtected: false,
             isImported: false);
@@ -67,7 +66,7 @@ public sealed class BackupIndexRepairServiceTests : IDisposable
             "manual",
             1024,
             "alpha/backup",
-            _tempDir,
+            _tempDir.Path,
             "Primary",
             isProtected: false,
             isImported: false);
@@ -95,7 +94,7 @@ public sealed class BackupIndexRepairServiceTests : IDisposable
             "manual",
             1024,
             "alpha/backup",
-            _tempDir,
+            _tempDir.Path,
             "Primary",
             isProtected: false,
             isImported: false);
@@ -120,30 +119,16 @@ public sealed class BackupIndexRepairServiceTests : IDisposable
 
     private SqliteRepository CreateRepository()
     {
-        var repo = new SqliteRepository(_dbPath);
-        repo.EnsureSchema();
-        return repo;
+        return TestRepository.Create(_dbPath);
     }
 
     private int CreateProject(SqliteRepository repo, string name)
     {
-        return repo.AddProject(new Project
-        {
-            Name = name,
-            RootPath = Path.Combine(_tempDir, name),
-            Preset = "dotnet"
-        });
+        return TestRepository.AddProject(repo, name, Path.Combine(_tempDir.Path, name));
     }
 
     public void Dispose()
     {
-        try
-        {
-            if (Directory.Exists(_tempDir))
-                Directory.Delete(_tempDir, true);
-        }
-        catch
-        {
-        }
+        _tempDir.Dispose();
     }
 }

--- a/tests/VaultSync.Core.Tests/BackupKeyRotationServiceTests.cs
+++ b/tests/VaultSync.Core.Tests/BackupKeyRotationServiceTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.IO.Compression;
 using VaultSync.Core.Config;
 using VaultSync.Core.Services;
+using VaultSync.Core.Tests.TestSupport;
 using Xunit;
 
 namespace VaultSync.Core.Tests;
@@ -13,70 +14,54 @@ public sealed class BackupKeyRotationServiceTests
     [Fact]
     public void RotateEncryptedBackup_ReencryptsWithNewPassword_AndInvalidatesOldPassword()
     {
-        string backupFolder = CreateEncryptedBackupFolder("old-password");
-        try
-        {
-            var service = new BackupKeyRotationService();
-            BackupKeyRotationService.RotationResult result = BackupKeyRotationService.RotateEncryptedBackup(
-                backupFolder,
-                oldPassword: "old-password",
-                newPassword: "new-password",
-                new BackupEncryptionConfig { Enabled = true });
+        using var root = new TempDirectory();
+        string backupFolder = CreateEncryptedBackupFolder(root.Path, "old-password");
 
-            Assert.True(result.Success);
-            Assert.True(result.TotalBytes > 0);
+        BackupKeyRotationService.RotationResult result = BackupKeyRotationService.RotateEncryptedBackup(
+            backupFolder,
+            oldPassword: "old-password",
+            newPassword: "new-password",
+            new BackupEncryptionConfig { Enabled = true });
 
-            var crypto = new BackupArchiveCryptoService();
-            string restoredWithNew = Path.Combine(backupFolder, "restored-new.zip");
-            BackupArchiveCryptoService.DecryptArchiveToPlainZip(backupFolder, "new-password", restoredWithNew);
-            Assert.True(File.Exists(restoredWithNew));
+        Assert.True(result.Success);
+        Assert.True(result.TotalBytes > 0);
 
-            string restoredWithOld = Path.Combine(backupFolder, "restored-old.zip");
-            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() =>
-                BackupArchiveCryptoService.DecryptArchiveToPlainZip(backupFolder, "old-password", restoredWithOld));
-            Assert.Equal(BackupArchiveCryptoService.InvalidPasswordOrCorruptedMessage, ex.Message);
-        }
-        finally
-        {
-            SafeDelete(backupFolder);
-        }
+        string restoredWithNew = Path.Combine(backupFolder, "restored-new.zip");
+        BackupArchiveCryptoService.DecryptArchiveToPlainZip(backupFolder, "new-password", restoredWithNew);
+        Assert.True(File.Exists(restoredWithNew));
+
+        string restoredWithOld = Path.Combine(backupFolder, "restored-old.zip");
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() =>
+            BackupArchiveCryptoService.DecryptArchiveToPlainZip(backupFolder, "old-password", restoredWithOld));
+        Assert.Equal(BackupArchiveCryptoService.InvalidPasswordOrCorruptedMessage, ex.Message);
     }
 
     [Fact]
     public void RotateEncryptedBackup_WithWrongOldPassword_LeavesOriginalArchiveIntact()
     {
-        string backupFolder = CreateEncryptedBackupFolder("old-password");
-        try
-        {
-            string archivePath = Path.Combine(backupFolder, BackupArchiveCryptoService.EncryptedArchiveFileName);
-            byte[] before = File.ReadAllBytes(archivePath);
+        using var root = new TempDirectory();
+        string backupFolder = CreateEncryptedBackupFolder(root.Path, "old-password");
+        string archivePath = Path.Combine(backupFolder, BackupArchiveCryptoService.EncryptedArchiveFileName);
+        byte[] before = File.ReadAllBytes(archivePath);
 
-            var service = new BackupKeyRotationService();
-            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() =>
-                BackupKeyRotationService.RotateEncryptedBackup(
-                    backupFolder,
-                    oldPassword: "wrong-password",
-                    newPassword: "new-password",
-                    new BackupEncryptionConfig { Enabled = true }));
-            Assert.Equal(BackupArchiveCryptoService.InvalidPasswordOrCorruptedMessage, ex.Message);
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() =>
+            BackupKeyRotationService.RotateEncryptedBackup(
+                backupFolder,
+                oldPassword: "wrong-password",
+                newPassword: "new-password",
+                new BackupEncryptionConfig { Enabled = true }));
+        Assert.Equal(BackupArchiveCryptoService.InvalidPasswordOrCorruptedMessage, ex.Message);
 
-            byte[] after = File.ReadAllBytes(archivePath);
-            Assert.Equal(before, after);
+        byte[] after = File.ReadAllBytes(archivePath);
+        Assert.Equal(before, after);
 
-            var crypto = new BackupArchiveCryptoService();
-            string restoredWithOld = Path.Combine(backupFolder, "restored-old.zip");
-            BackupArchiveCryptoService.DecryptArchiveToPlainZip(backupFolder, "old-password", restoredWithOld);
-            Assert.True(File.Exists(restoredWithOld));
-        }
-        finally
-        {
-            SafeDelete(backupFolder);
-        }
+        string restoredWithOld = Path.Combine(backupFolder, "restored-old.zip");
+        BackupArchiveCryptoService.DecryptArchiveToPlainZip(backupFolder, "old-password", restoredWithOld);
+        Assert.True(File.Exists(restoredWithOld));
     }
 
-    private static string CreateEncryptedBackupFolder(string password)
+    private static string CreateEncryptedBackupFolder(string root, string password)
     {
-        string root = Path.Combine(Path.GetTempPath(), $"vaultsync-rotate-tests-{Guid.NewGuid():N}");
         string backupFolder = Path.Combine(root, "project", "2026-02-09_00-00-00");
         Directory.CreateDirectory(backupFolder);
 
@@ -94,18 +79,5 @@ public sealed class BackupKeyRotationServiceTests
         BackupArchiveCryptoService.EncryptArchiveInPlace(backupFolder, password, new BackupEncryptionConfig { Enabled = true });
 
         return backupFolder;
-    }
-
-    private static void SafeDelete(string path)
-    {
-        try
-        {
-            if (Directory.Exists(path))
-                Directory.Delete(path, recursive: true);
-        }
-        catch
-        {
-            // Best effort cleanup.
-        }
     }
 }

--- a/tests/VaultSync.Core.Tests/BackupRetentionPreflightTests.cs
+++ b/tests/VaultSync.Core.Tests/BackupRetentionPreflightTests.cs
@@ -7,22 +7,21 @@ using Microsoft.Data.Sqlite;
 using VaultSync.Core.Models;
 using VaultSync.Core.Repositories;
 using VaultSync.Core.Services;
+using VaultSync.Core.Tests.TestSupport;
 using Xunit;
 
 namespace VaultSync.Core.Tests;
 
 public sealed class BackupRetentionPreflightTests : IDisposable
 {
-    private readonly string _tempDir;
+    private readonly TempDirectory _tempDir = new();
     private readonly string _dbPath;
     private readonly string _backupRoot;
 
     public BackupRetentionPreflightTests()
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"vaultsync-retention-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_tempDir);
-        _dbPath = Path.Combine(_tempDir, "vaultsync.db");
-        _backupRoot = Path.Combine(_tempDir, "backups");
+        _dbPath = Path.Combine(_tempDir.Path, "vaultsync.db");
+        _backupRoot = Path.Combine(_tempDir.Path, "backups");
         Directory.CreateDirectory(_backupRoot);
     }
 
@@ -186,30 +185,16 @@ public sealed class BackupRetentionPreflightTests : IDisposable
 
     private SqliteRepository CreateRepository()
     {
-        var repo = new SqliteRepository(_dbPath);
-        repo.EnsureSchema();
-        return repo;
+        return TestRepository.Create(_dbPath);
     }
 
     private int CreateProject(SqliteRepository repo, string name)
     {
-        return repo.AddProject(new Project
-        {
-            Name = name,
-            RootPath = Path.Combine(_tempDir, name.Replace(' ', '_')),
-            Preset = "dotnet"
-        });
+        return TestRepository.AddProject(repo, name, Path.Combine(_tempDir.Path, name.Replace(' ', '_')));
     }
 
     public void Dispose()
     {
-        try
-        {
-            if (Directory.Exists(_tempDir))
-                Directory.Delete(_tempDir, true);
-        }
-        catch
-        {
-        }
+        _tempDir.Dispose();
     }
 }

--- a/tests/VaultSync.Core.Tests/BackupRetentionSimulationServiceTests.cs
+++ b/tests/VaultSync.Core.Tests/BackupRetentionSimulationServiceTests.cs
@@ -4,20 +4,19 @@ using System.Linq;
 using VaultSync.Core.Models;
 using VaultSync.Core.Repositories;
 using VaultSync.Core.Services;
+using VaultSync.Core.Tests.TestSupport;
 using Xunit;
 
 namespace VaultSync.Core.Tests;
 
 public sealed class BackupRetentionSimulationServiceTests : IDisposable
 {
-    private readonly string _dbPath;
+    private readonly TempDirectory _tempDir = new();
     private readonly SqliteRepository _repo;
 
     public BackupRetentionSimulationServiceTests()
     {
-        _dbPath = Path.Combine(Path.GetTempPath(), $"vaultsync-retention-sim-{Guid.NewGuid():N}.db");
-        _repo = new SqliteRepository(_dbPath);
-        _repo.EnsureSchema();
+        _repo = TestRepository.Create(Path.Combine(_tempDir.Path, "vaultsync.db"));
     }
 
     [Fact]
@@ -66,12 +65,7 @@ public sealed class BackupRetentionSimulationServiceTests : IDisposable
 
     private Project CreateProject(string name)
     {
-        _repo.AddProject(new Project
-        {
-            Name = name,
-            RootPath = $@"C:\Projects\{name}",
-            Preset = "dotnet"
-        });
+        TestRepository.AddProject(_repo, name, $@"C:\Projects\{name}");
         return _repo.GetAllProjects().Single(project => project.Name == name);
     }
 
@@ -92,14 +86,6 @@ public sealed class BackupRetentionSimulationServiceTests : IDisposable
 
     public void Dispose()
     {
-        try
-        {
-            if (File.Exists(_dbPath))
-                File.Delete(_dbPath);
-        }
-        catch
-        {
-            // ignore
-        }
+        _tempDir.Dispose();
     }
 }

--- a/tests/VaultSync.Core.Tests/BackupSafetyServiceTests.cs
+++ b/tests/VaultSync.Core.Tests/BackupSafetyServiceTests.cs
@@ -3,24 +3,19 @@ using System.IO;
 using System.Linq;
 using VaultSync.Core.Models;
 using VaultSync.Core.Services;
+using VaultSync.Core.Tests.TestSupport;
 using Xunit;
 
 namespace VaultSync.Core.Tests;
 
 public sealed class BackupSafetyServiceTests : IDisposable
 {
-    private readonly string _tempDir;
-
-    public BackupSafetyServiceTests()
-    {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"vaultsync-safety-tests-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_tempDir);
-    }
+    private readonly TempDirectory _tempDir = new();
 
     [Fact]
     public void EnsureSafeBackupRoot_BlocksBackupRootInsideProjectRoot()
     {
-        var projectRoot = Path.Combine(_tempDir, "project");
+        var projectRoot = Path.Combine(_tempDir.Path, "project");
         var backupRoot = Path.Combine(projectRoot, ".vaultsync-temp-backups");
         Directory.CreateDirectory(projectRoot);
 
@@ -33,7 +28,7 @@ public sealed class BackupSafetyServiceTests : IDisposable
     [Fact]
     public void EnsureSafeBackupRoot_BlocksProjectRootInsideBackupRoot()
     {
-        var backupRoot = Path.Combine(_tempDir, "backups");
+        var backupRoot = Path.Combine(_tempDir.Path, "backups");
         var projectRoot = Path.Combine(backupRoot, "project");
         Directory.CreateDirectory(projectRoot);
 
@@ -46,7 +41,7 @@ public sealed class BackupSafetyServiceTests : IDisposable
     [Fact]
     public void EnsureSafeBackupRoot_BlocksSameDirectory()
     {
-        var projectRoot = Path.Combine(_tempDir, "project");
+        var projectRoot = Path.Combine(_tempDir.Path, "project");
         Directory.CreateDirectory(projectRoot);
 
         Assert.Throws<InvalidOperationException>(() =>
@@ -56,8 +51,8 @@ public sealed class BackupSafetyServiceTests : IDisposable
     [Fact]
     public void EnsureSafeBackupRoot_AllowsSiblingBackupRoot()
     {
-        var projectRoot = Path.Combine(_tempDir, "project");
-        var backupRoot = Path.Combine(_tempDir, "backups");
+        var projectRoot = Path.Combine(_tempDir.Path, "project");
+        var backupRoot = Path.Combine(_tempDir.Path, "backups");
         Directory.CreateDirectory(projectRoot);
         Directory.CreateDirectory(backupRoot);
 
@@ -67,9 +62,13 @@ public sealed class BackupSafetyServiceTests : IDisposable
     [Fact]
     public void GetOfflineStagingRoot_IsOutsideProjectRoot()
     {
-        var projectRoot = Path.Combine(_tempDir, "project");
+        var projectRoot = Path.Combine(_tempDir.Path, "project");
         Directory.CreateDirectory(projectRoot);
-        var project = new Project { Id = 42, Name = "Project", RootPath = projectRoot, Preset = string.Empty };
+        var project = new ProjectBuilder()
+            .WithId(42)
+            .WithName("Project")
+            .WithRootPath(projectRoot)
+            .Build();
 
         var stagingRoot = BackupSafetyService.GetOfflineStagingRoot(project);
 
@@ -80,7 +79,7 @@ public sealed class BackupSafetyServiceTests : IDisposable
     [Fact]
     public void TryCombinePathUnderRoot_AllowsNestedRelativePath()
     {
-        var backupRoot = Path.Combine(_tempDir, "backups");
+        var backupRoot = Path.Combine(_tempDir.Path, "backups");
         Directory.CreateDirectory(backupRoot);
 
         bool combined = BackupSafetyService.TryCombinePathUnderRoot(
@@ -98,7 +97,7 @@ public sealed class BackupSafetyServiceTests : IDisposable
     [InlineData("Project/../../outside")]
     public void TryCombinePathUnderRoot_BlocksTraversal(string relativePath)
     {
-        var backupRoot = Path.Combine(_tempDir, "backups");
+        var backupRoot = Path.Combine(_tempDir.Path, "backups");
         Directory.CreateDirectory(backupRoot);
 
         bool combined = BackupSafetyService.TryCombinePathUnderRoot(backupRoot, relativePath, out _);
@@ -109,9 +108,9 @@ public sealed class BackupSafetyServiceTests : IDisposable
     [Fact]
     public void TryCombinePathUnderRoot_BlocksAbsolutePath()
     {
-        var backupRoot = Path.Combine(_tempDir, "backups");
+        var backupRoot = Path.Combine(_tempDir.Path, "backups");
         Directory.CreateDirectory(backupRoot);
-        string absolutePath = Path.Combine(_tempDir, "outside");
+        string absolutePath = Path.Combine(_tempDir.Path, "outside");
 
         bool combined = BackupSafetyService.TryCombinePathUnderRoot(backupRoot, absolutePath, out _);
 
@@ -121,7 +120,7 @@ public sealed class BackupSafetyServiceTests : IDisposable
     [Fact]
     public void FilterService_AlwaysExcludesVaultSyncBackupArtifacts()
     {
-        var projectRoot = Path.Combine(_tempDir, "project");
+        var projectRoot = Path.Combine(_tempDir.Path, "project");
         var tempBackupDir = Path.Combine(projectRoot, ".vaultsync-temp-backups", "Project", "2026-05-11_10-00-00");
         var backupsDir = Path.Combine(projectRoot, "Backups", "Project", "2026-05-11_09-00-00");
         Directory.CreateDirectory(tempBackupDir);
@@ -142,7 +141,7 @@ public sealed class BackupSafetyServiceTests : IDisposable
     [Fact]
     public void FilterService_DoubleStarDirectoryPatternExcludesNestedBuildOutput()
     {
-        var projectRoot = Path.Combine(_tempDir, "project");
+        var projectRoot = Path.Combine(_tempDir.Path, "project");
         var nestedBin = Path.Combine(projectRoot, "src", "App", "bin", "Debug");
         Directory.CreateDirectory(nestedBin);
         File.WriteAllText(Path.Combine(projectRoot, "Program.cs"), "keep");
@@ -162,7 +161,7 @@ public sealed class BackupSafetyServiceTests : IDisposable
     [InlineData("**/RenderCache/**", "episodes/scene/RenderCache/frame.tmp")]
     public void FilterService_NestedGeneratedOutputPatternsExcludeExpectedFiles(string pattern, string generatedPath)
     {
-        var projectRoot = Path.Combine(_tempDir, Guid.NewGuid().ToString("N"));
+        var projectRoot = Path.Combine(_tempDir.Path, Guid.NewGuid().ToString("N"));
         string generatedFile = Path.Combine(projectRoot, generatedPath.Replace('/', Path.DirectorySeparatorChar));
         Directory.CreateDirectory(Path.GetDirectoryName(generatedFile)!);
         File.WriteAllText(Path.Combine(projectRoot, "source.txt"), "keep");
@@ -185,7 +184,7 @@ public sealed class BackupSafetyServiceTests : IDisposable
     [InlineData("unreal", "Intermediate/Build/cache.bin")]
     public void BuiltInSourcePresets_ExcludeGeneratedOutputsButKeepRepoMetadata(string preset, string generatedPath)
     {
-        var projectRoot = Path.Combine(_tempDir, Guid.NewGuid().ToString("N"));
+        var projectRoot = Path.Combine(_tempDir.Path, Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(projectRoot);
 
         WriteProjectFile(projectRoot, "src/source.txt", "keep");
@@ -233,13 +232,6 @@ public sealed class BackupSafetyServiceTests : IDisposable
 
     public void Dispose()
     {
-        try
-        {
-            if (Directory.Exists(_tempDir))
-                Directory.Delete(_tempDir, recursive: true);
-        }
-        catch
-        {
-        }
+        _tempDir.Dispose();
     }
 }

--- a/tests/VaultSync.Core.Tests/BackupSkipNoChangesTests.cs
+++ b/tests/VaultSync.Core.Tests/BackupSkipNoChangesTests.cs
@@ -7,31 +7,29 @@ using System.Threading.Tasks;
 using VaultSync.Core.Models;
 using VaultSync.Core.Repositories;
 using VaultSync.Core.Services;
+using VaultSync.Core.Tests.TestSupport;
 using Xunit;
 
 namespace VaultSync.Core.Tests;
 
 public sealed class BackupSkipNoChangesTests : IDisposable
 {
-    private readonly string _tempDir;
+    private readonly TempDirectory _tempDir = new();
     private readonly string _dbPath;
 
     public BackupSkipNoChangesTests()
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"vaultsync-skip-tests-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_tempDir);
-        _dbPath = Path.Combine(_tempDir, "vaultsync.db");
+        _dbPath = Path.Combine(_tempDir.Path, "vaultsync.db");
     }
 
     [Fact]
     public async Task RunBackupAsync_DoesNotSkipNoChanges_WhenNoUsableBackupExists()
     {
-        var repo = new SqliteRepository(_dbPath);
-        repo.EnsureSchema();
+        SqliteRepository repo = TestRepository.Create(_dbPath);
         Project project = CreateProject(repo);
         await CreateBaselineSnapshotAsync(repo, project);
 
-        string backupRoot = Path.Combine(_tempDir, "backups");
+        string backupRoot = Path.Combine(_tempDir.Path, "backups");
         Directory.CreateDirectory(backupRoot);
         var service = new BackupService(repo);
 
@@ -53,10 +51,9 @@ public sealed class BackupSkipNoChangesTests : IDisposable
     [Fact]
     public async Task RunBackupAsync_SkipsNoChanges_WhenUsableBackupAlreadyExists()
     {
-        var repo = new SqliteRepository(_dbPath);
-        repo.EnsureSchema();
+        SqliteRepository repo = TestRepository.Create(_dbPath);
         Project project = CreateProject(repo);
-        string backupRoot = Path.Combine(_tempDir, "backups");
+        string backupRoot = Path.Combine(_tempDir.Path, "backups");
         Directory.CreateDirectory(backupRoot);
         var service = new BackupService(repo);
 
@@ -88,8 +85,7 @@ public sealed class BackupSkipNoChangesTests : IDisposable
     [Fact]
     public async Task RunBackupAsync_BackupAllStyleParallelRun_CreatesUsableBackupsForAllProjects()
     {
-        var repo = new SqliteRepository(_dbPath);
-        repo.EnsureSchema();
+        SqliteRepository repo = TestRepository.Create(_dbPath);
         Project[] projects = new[]
         {
             CreateProject(repo, "Project One", "one.txt", "one"),
@@ -102,7 +98,7 @@ public sealed class BackupSkipNoChangesTests : IDisposable
             await CreateBaselineSnapshotAsync(repo, project);
         }
 
-        string backupRoot = Path.Combine(_tempDir, "backups");
+        string backupRoot = Path.Combine(_tempDir.Path, "backups");
         Directory.CreateDirectory(backupRoot);
         var service = new BackupService(repo);
 
@@ -135,16 +131,11 @@ public sealed class BackupSkipNoChangesTests : IDisposable
 
     private Project CreateProject(SqliteRepository repo, string name, string fileName, string contents)
     {
-        string sourceRoot = Path.Combine(_tempDir, name.Replace(' ', '-'));
+        string sourceRoot = Path.Combine(_tempDir.Path, name.Replace(' ', '-'));
         Directory.CreateDirectory(sourceRoot);
         File.WriteAllText(Path.Combine(sourceRoot, fileName), contents, Encoding.UTF8);
 
-        int projectId = repo.AddProject(new Project
-        {
-            Name = name,
-            RootPath = sourceRoot,
-            Preset = string.Empty
-        });
+        int projectId = TestRepository.AddProject(repo, name, sourceRoot, preset: string.Empty);
 
         return repo.GetProjectById(projectId)!;
     }
@@ -162,13 +153,6 @@ public sealed class BackupSkipNoChangesTests : IDisposable
 
     public void Dispose()
     {
-        try
-        {
-            if (Directory.Exists(_tempDir))
-                Directory.Delete(_tempDir, recursive: true);
-        }
-        catch
-        {
-        }
+        _tempDir.Dispose();
     }
 }

--- a/tests/VaultSync.Core.Tests/DestinationIdentityServiceTests.cs
+++ b/tests/VaultSync.Core.Tests/DestinationIdentityServiceTests.cs
@@ -1,6 +1,7 @@
 using VaultSync.Core.Config;
 using VaultSync.Core.Models;
 using VaultSync.Core.Services;
+using VaultSync.Core.Tests.TestSupport;
 using Xunit;
 
 namespace VaultSync.Core.Tests;
@@ -10,21 +11,17 @@ public sealed class DestinationIdentityServiceTests
     [Fact]
     public void GetId_IsStableAcrossAliasChanges()
     {
-        var first = new BackupDestination
-        {
-            Path = @"\\nas\share\vaultsync",
-            Alias = "Home NAS",
-            CredentialName = "vault",
-            PreMounted = false
-        };
+        var first = new BackupDestinationBuilder()
+            .WithPath(@"\\nas\share\vaultsync")
+            .WithAlias("Home NAS")
+            .WithCredentialName("vault")
+            .Build();
 
-        var second = new BackupDestination
-        {
-            Path = @"\\nas\share\vaultsync",
-            Alias = "Renamed NAS",
-            CredentialName = "vault",
-            PreMounted = false
-        };
+        var second = new BackupDestinationBuilder()
+            .WithPath(@"\\nas\share\vaultsync")
+            .WithAlias("Renamed NAS")
+            .WithCredentialName("vault")
+            .Build();
 
         Assert.Equal(DestinationIdentityService.GetId(first), DestinationIdentityService.GetId(second));
     }
@@ -32,12 +29,10 @@ public sealed class DestinationIdentityServiceTests
     [Fact]
     public void NormalizePreferredDestinationId_MapsLegacyAliasToStableId()
     {
-        var destination = new BackupDestination
-        {
-            Path = @"D:\VaultSyncBackups",
-            Alias = "USB",
-            CredentialName = string.Empty
-        };
+        var destination = new BackupDestinationBuilder()
+            .WithPath(@"D:\VaultSyncBackups")
+            .WithAlias("USB")
+            .Build();
 
         string normalized = DestinationIdentityService.NormalizePreferredDestinationId("USB", new[] { destination });
 
@@ -47,11 +42,10 @@ public sealed class DestinationIdentityServiceTests
     [Fact]
     public void NormalizePreferredDestinationId_MapsLegacyPathToStableId()
     {
-        var destination = new BackupDestination
-        {
-            Path = @"D:\VaultSyncBackups",
-            Alias = "USB"
-        };
+        var destination = new BackupDestinationBuilder()
+            .WithPath(@"D:\VaultSyncBackups")
+            .WithAlias("USB")
+            .Build();
 
         string normalized = DestinationIdentityService.NormalizePreferredDestinationId(@"D:\VaultSyncBackups", new[] { destination });
 

--- a/tests/VaultSync.Core.Tests/DestinationTests.cs
+++ b/tests/VaultSync.Core.Tests/DestinationTests.cs
@@ -1,8 +1,8 @@
 using System;
-using System.IO;
 using System.Reflection;
 using VaultSync.Core.Config;
 using VaultSync.Core.Services;
+using VaultSync.Core.Tests.TestSupport;
 using Xunit;
 
 namespace VaultSync.Core.Tests;
@@ -46,30 +46,6 @@ public sealed class NetworkMountServiceTests
 
         Assert.False(result.IsSuccess);
         Assert.Contains("unreachable", result.Message, StringComparison.OrdinalIgnoreCase);
-    }
-
-    private sealed class TempDirectory : IDisposable
-    {
-        public TempDirectory()
-        {
-            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"vaultsync-test-{Guid.NewGuid():N}");
-            Directory.CreateDirectory(Path);
-        }
-
-        public string Path { get; }
-
-        public void Dispose()
-        {
-            try
-            {
-                if (Directory.Exists(Path))
-                    Directory.Delete(Path, recursive: true);
-            }
-            catch
-            {
-                // Ignore cleanup failures in tests.
-            }
-        }
     }
 }
 

--- a/tests/VaultSync.Core.Tests/MetadataSyncTests.cs
+++ b/tests/VaultSync.Core.Tests/MetadataSyncTests.cs
@@ -10,6 +10,7 @@ using VaultSync.Core.Config;
 using VaultSync.Core.Models;
 using VaultSync.Core.Repositories;
 using VaultSync.Core.Services;
+using VaultSync.Core.Tests.TestSupport;
 using Xunit;
 
 namespace VaultSync.Core.Tests;
@@ -80,6 +81,48 @@ public sealed class MetadataSyncTests : IDisposable
     }
 
     [Fact]
+    public void ImportFromStore_UnchangedReadOnlySource_UsesSuccessfulImportCache()
+    {
+        string metaRoot = CreateTempDir();
+        string dbPath = Path.Combine(CreateTempDir(), "vaultsync.db");
+        using var configScope = new TestAppConfigScope();
+        AppConfigStore.Save(new AppConfig
+        {
+            ProjectsRoot = CreateTempDir(),
+            DbPath = dbPath
+        });
+
+        MetadataStore store = CreateStore(metaRoot);
+        SeedMetaInfo(store, "machine-cache");
+        store.UpsertProject(new MetaProject
+        {
+            ExternalId = "proj-cache",
+            Name = "Cache Project",
+            Preset = "dotnet",
+            RootPathHint = CreateTempDir(),
+            CreatedUtc = DateTime.UtcNow.AddDays(-1),
+            SettingsJson = "{}",
+            UpdatedUtc = DateTime.UtcNow
+        });
+
+        SqliteRepository repo = CreateRepository(dbPath);
+        var service = new MetadataSyncService(repo);
+        MetadataSyncOptions options = new MetadataSyncOptions(true, false)
+            .AsReadOnlySource()
+            .WithUnchangedSourceSkip();
+
+        MetadataSyncResult first = service.ImportFromStore(metaRoot, options);
+        MetadataSyncResult second = service.ImportFromStore(metaRoot, options);
+
+        Assert.Equal(MetadataSyncStatus.Success, first.Status);
+        Assert.Equal(1, first.ImportedProjects);
+        Assert.Equal(MetadataSyncStatus.Success, second.Status);
+        Assert.Equal(0, second.ImportedProjects);
+        Assert.Equal("Metadata source unchanged.", second.Message);
+        Assert.Single(AppConfigStore.Load().Advanced.MetadataImportCache.Sources);
+    }
+
+    [Fact]
     public void ImportFromStore_RebuildsHistoryFromDestinationFoldersWhenMetadataHasNoBackups()
     {
         string metaRoot = CreateTempDir();
@@ -92,52 +135,42 @@ public sealed class MetadataSyncTests : IDisposable
         Directory.CreateDirectory(secondBackupFolder);
         File.WriteAllBytes(Path.Combine(firstBackupFolder, "data.bin"), new byte[123]);
         File.WriteAllBytes(Path.Combine(secondBackupFolder, "data.bin"), new byte[456]);
-        AppConfig originalConfig = CloneConfig(AppConfigStore.Load());
+        using var configScope = new TestAppConfigScope();
+        AppConfigStore.Save(new AppConfig { ProjectsRoot = projectsRoot });
 
-        try
+        MetadataStore store = CreateStore(metaRoot);
+        SeedMetaInfo(store, "machine-legacy-folder");
+        store.UpsertProject(new MetaProject
         {
-            AppConfig cfg = CloneConfig(originalConfig);
-            cfg.ProjectsRoot = projectsRoot;
-            AppConfigStore.Save(cfg);
+            ExternalId = "proj-blueprints",
+            Name = "Blueprints",
+            Preset = "dotnet",
+            RootPathHint = @"\\server\share\Dev\Blueprints",
+            CreatedUtc = new DateTime(2026, 5, 5, 14, 26, 32, DateTimeKind.Utc),
+            SettingsJson = "{}",
+            UpdatedUtc = DateTime.UtcNow
+        });
 
-            MetadataStore store = CreateStore(metaRoot);
-            SeedMetaInfo(store, "machine-legacy-folder");
-            store.UpsertProject(new MetaProject
-            {
-                ExternalId = "proj-blueprints",
-                Name = "Blueprints",
-                Preset = "dotnet",
-                RootPathHint = @"\\server\share\Dev\Blueprints",
-                CreatedUtc = new DateTime(2026, 5, 5, 14, 26, 32, DateTimeKind.Utc),
-                SettingsJson = "{}",
-                UpdatedUtc = DateTime.UtcNow
-            });
+        SqliteRepository repo = CreateRepository(dbPath);
+        var service = new MetadataSyncService(repo);
+        MetadataSyncResult result = service.ImportFromStore(metaRoot, MetadataSyncOptions.Default);
 
-            SqliteRepository repo = CreateRepository(dbPath);
-            var service = new MetadataSyncService(repo);
-            MetadataSyncResult result = service.ImportFromStore(metaRoot, MetadataSyncOptions.Default);
+        Assert.Equal(MetadataSyncStatus.Success, result.Status);
+        Assert.Equal(1, result.ImportedProjects);
+        Assert.Equal(2, result.ImportedSnapshots);
+        Assert.Equal(2, result.ImportedBackups);
 
-            Assert.Equal(MetadataSyncStatus.Success, result.Status);
-            Assert.Equal(1, result.ImportedProjects);
-            Assert.Equal(2, result.ImportedSnapshots);
-            Assert.Equal(2, result.ImportedBackups);
+        Project project = repo.GetProjectByName("Blueprints");
+        Assert.NotNull(project);
+        Assert.True(project!.NeedsRestore);
 
-            Project project = repo.GetProjectByName("Blueprints");
-            Assert.NotNull(project);
-            Assert.True(project!.NeedsRestore);
-
-            List<Backup> backups = [.. repo.GetBackupsForProject(project.Id)];
-            Assert.Equal(2, backups.Count);
-            Assert.All(backups, backup => Assert.True(backup.IsImported));
-            Assert.Contains(backups, backup => backup.TotalBytes == 123);
-            Assert.Contains(backups, backup => backup.TotalBytes == 456);
-            Assert.Contains(backups, backup => backup.Path == Path.Combine("blueprints", "2026-05-06_08-15-06"));
-            Assert.Contains(backups, backup => backup.Path == Path.Combine("blueprints", "2026-05-07_12-42-10"));
-        }
-        finally
-        {
-            AppConfigStore.Save(originalConfig);
-        }
+        List<Backup> backups = [.. repo.GetBackupsForProject(project.Id)];
+        Assert.Equal(2, backups.Count);
+        Assert.All(backups, backup => Assert.True(backup.IsImported));
+        Assert.Contains(backups, backup => backup.TotalBytes == 123);
+        Assert.Contains(backups, backup => backup.TotalBytes == 456);
+        Assert.Contains(backups, backup => backup.Path == Path.Combine("blueprints", "2026-05-06_08-15-06"));
+        Assert.Contains(backups, backup => backup.Path == Path.Combine("blueprints", "2026-05-07_12-42-10"));
     }
 
     [Fact]
@@ -153,35 +186,25 @@ public sealed class MetadataSyncTests : IDisposable
         File.WriteAllBytes(Path.Combine(firstBackupFolder, "data.bin"), new byte[321]);
         File.WriteAllBytes(Path.Combine(secondBackupFolder, "data.bin"), new byte[654]);
         Directory.CreateDirectory(Path.Combine(backupRoot, ".vaultsync"));
-        AppConfig originalConfig = CloneConfig(AppConfigStore.Load());
+        using var configScope = new TestAppConfigScope();
+        AppConfigStore.Save(new AppConfig { ProjectsRoot = projectsRoot });
 
-        try
-        {
-            AppConfig cfg = CloneConfig(originalConfig);
-            cfg.ProjectsRoot = projectsRoot;
-            AppConfigStore.Save(cfg);
+        SqliteRepository repo = CreateRepository(dbPath);
+        var service = new MetadataSyncService(repo);
+        MetadataSyncResult result = service.ImportFromStore(backupRoot, MetadataSyncOptions.Default);
 
-            SqliteRepository repo = CreateRepository(dbPath);
-            var service = new MetadataSyncService(repo);
-            MetadataSyncResult result = service.ImportFromStore(backupRoot, MetadataSyncOptions.Default);
+        Assert.Equal(MetadataSyncStatus.Success, result.Status);
+        Assert.Equal(1, result.ImportedProjects);
+        Assert.Equal(2, result.ImportedSnapshots);
+        Assert.Equal(2, result.ImportedBackups);
 
-            Assert.Equal(MetadataSyncStatus.Success, result.Status);
-            Assert.Equal(1, result.ImportedProjects);
-            Assert.Equal(2, result.ImportedSnapshots);
-            Assert.Equal(2, result.ImportedBackups);
-
-            Project project = repo.GetProjectByName("risiko-3d");
-            Assert.NotNull(project);
-            Assert.Equal(Path.Combine(projectsRoot, "risiko-3d"), project!.RootPath);
-            List<Backup> backups = [.. repo.GetBackupsForProject(project.Id)];
-            Assert.Equal(2, backups.Count);
-            Assert.Contains(backups, backup => backup.TotalBytes == 321);
-            Assert.Contains(backups, backup => backup.TotalBytes == 654);
-        }
-        finally
-        {
-            AppConfigStore.Save(originalConfig);
-        }
+        Project project = repo.GetProjectByName("risiko-3d");
+        Assert.NotNull(project);
+        Assert.Equal(Path.Combine(projectsRoot, "risiko-3d"), project!.RootPath);
+        List<Backup> backups = [.. repo.GetBackupsForProject(project.Id)];
+        Assert.Equal(2, backups.Count);
+        Assert.Contains(backups, backup => backup.TotalBytes == 321);
+        Assert.Contains(backups, backup => backup.TotalBytes == 654);
     }
 
     [Fact]
@@ -192,44 +215,34 @@ public sealed class MetadataSyncTests : IDisposable
         string projectsRoot = CreateTempDir();
         string backupFolder = Path.Combine(backupRoot, "legacy-project", "2026-05-08_10-00-00");
         Directory.CreateDirectory(backupFolder);
-        AppConfig originalConfig = CloneConfig(AppConfigStore.Load());
+        using var configScope = new TestAppConfigScope();
+        AppConfigStore.Save(new AppConfig { ProjectsRoot = projectsRoot });
 
-        try
-        {
-            AppConfig cfg = CloneConfig(originalConfig);
-            cfg.ProjectsRoot = projectsRoot;
-            AppConfigStore.Save(cfg);
+        SqliteRepository repo = CreateRepository(dbPath);
+        var service = new MetadataSyncService(repo);
+        MetadataSyncResult firstImport = service.ImportFromStore(backupRoot, MetadataSyncOptions.Default);
 
-            SqliteRepository repo = CreateRepository(dbPath);
-            var service = new MetadataSyncService(repo);
-            MetadataSyncResult firstImport = service.ImportFromStore(backupRoot, MetadataSyncOptions.Default);
+        Assert.Equal(MetadataSyncStatus.Success, firstImport.Status);
+        Assert.Equal(1, firstImport.ImportedBackups);
 
-            Assert.Equal(MetadataSyncStatus.Success, firstImport.Status);
-            Assert.Equal(1, firstImport.ImportedBackups);
+        Project project = repo.GetProjectByName("legacy-project");
+        Assert.NotNull(project);
+        Backup originalBackup = Assert.Single(repo.GetBackupsForProject(project!.Id));
+        Assert.Equal(0, originalBackup.TotalBytes);
 
-            Project project = repo.GetProjectByName("legacy-project");
-            Assert.NotNull(project);
-            Backup originalBackup = Assert.Single(repo.GetBackupsForProject(project!.Id));
-            Assert.Equal(0, originalBackup.TotalBytes);
+        File.WriteAllBytes(Path.Combine(backupFolder, "restored-size.bin"), new byte[789]);
 
-            File.WriteAllBytes(Path.Combine(backupFolder, "restored-size.bin"), new byte[789]);
+        MetadataSyncResult repairImport = service.ImportFromStore(backupRoot, MetadataSyncOptions.Default);
 
-            MetadataSyncResult repairImport = service.ImportFromStore(backupRoot, MetadataSyncOptions.Default);
+        Assert.Equal(MetadataSyncStatus.Success, repairImport.Status);
+        Assert.Equal(0, repairImport.ImportedBackups);
+        Assert.Equal(1, repairImport.RepairedBackups);
 
-            Assert.Equal(MetadataSyncStatus.Success, repairImport.Status);
-            Assert.Equal(0, repairImport.ImportedBackups);
-            Assert.Equal(1, repairImport.RepairedBackups);
-
-            Backup repairedBackup = Assert.Single(repo.GetBackupsForProject(project.Id));
-            Assert.Equal(789, repairedBackup.TotalBytes);
-            Snapshot repairedSnapshot = repo.GetSnapshotById(repairedBackup.SnapshotId);
-            Assert.NotNull(repairedSnapshot);
-            Assert.Equal(789, repairedSnapshot!.TotalBytes);
-        }
-        finally
-        {
-            AppConfigStore.Save(originalConfig);
-        }
+        Backup repairedBackup = Assert.Single(repo.GetBackupsForProject(project.Id));
+        Assert.Equal(789, repairedBackup.TotalBytes);
+        Snapshot repairedSnapshot = repo.GetSnapshotById(repairedBackup.SnapshotId);
+        Assert.NotNull(repairedSnapshot);
+        Assert.Equal(789, repairedSnapshot!.TotalBytes);
     }
 
     [Fact]
@@ -459,26 +472,17 @@ public sealed class MetadataSyncTests : IDisposable
         });
 
         SqliteRepository repo = CreateRepository(dbPath);
-        AppConfig cfg = AppConfigStore.Load();
-        cfg.ProjectsRoot = localProjectsRoot;
-        AppConfigStore.Save(cfg);
+        using var configScope = new TestAppConfigScope();
+        AppConfigStore.Save(new AppConfig { ProjectsRoot = localProjectsRoot });
 
-        try
-        {
-            var service = new MetadataSyncService(repo);
-            MetadataSyncResult result = service.ImportFromStore(metaRoot, new MetadataSyncOptions(true, false));
+        var service = new MetadataSyncService(repo);
+        MetadataSyncResult result = service.ImportFromStore(metaRoot, new MetadataSyncOptions(true, false));
 
-            Assert.Equal(MetadataSyncStatus.Success, result.Status);
+        Assert.Equal(MetadataSyncStatus.Success, result.Status);
 
-            Project project = repo.GetProjectByName("Unsafe Root Project");
-            Assert.NotNull(project);
-            Assert.Equal(Path.Combine(localProjectsRoot, "Unsafe Root Project"), project!.RootPath);
-        }
-        finally
-        {
-            cfg.ProjectsRoot = string.Empty;
-            AppConfigStore.Save(cfg);
-        }
+        Project project = repo.GetProjectByName("Unsafe Root Project");
+        Assert.NotNull(project);
+        Assert.Equal(Path.Combine(localProjectsRoot, "Unsafe Root Project"), project!.RootPath);
     }
 
     [Fact]
@@ -508,26 +512,17 @@ public sealed class MetadataSyncTests : IDisposable
         });
 
         var repo = CreateRepository(dbPath);
-        var cfg = AppConfigStore.Load();
-        cfg.ProjectsRoot = localProjectsRoot;
-        AppConfigStore.Save(cfg);
+        using var configScope = new TestAppConfigScope();
+        AppConfigStore.Save(new AppConfig { ProjectsRoot = localProjectsRoot });
 
-        try
-        {
-            var service = new MetadataSyncService(repo);
-            var result = service.ImportFromStore(metaRoot, new MetadataSyncOptions(true, false));
+        var service = new MetadataSyncService(repo);
+        var result = service.ImportFromStore(metaRoot, new MetadataSyncOptions(true, false));
 
-            Assert.Equal(MetadataSyncStatus.Success, result.Status);
+        Assert.Equal(MetadataSyncStatus.Success, result.Status);
 
-            var project = repo.GetProjectByName("Temp Root Project");
-            Assert.NotNull(project);
-            Assert.Equal(Path.Combine(localProjectsRoot, "Temp Root Project"), project!.RootPath);
-        }
-        finally
-        {
-            cfg.ProjectsRoot = string.Empty;
-            AppConfigStore.Save(cfg);
-        }
+        var project = repo.GetProjectByName("Temp Root Project");
+        Assert.NotNull(project);
+        Assert.Equal(Path.Combine(localProjectsRoot, "Temp Root Project"), project!.RootPath);
     }
 
     [Fact]
@@ -550,27 +545,19 @@ public sealed class MetadataSyncTests : IDisposable
         });
 
         SqliteRepository repo = CreateRepository(dbPath);
+        using var configScope = new TestAppConfigScope();
         AppConfig cfg = AppConfigStore.Load();
-        string oldProjectsRoot = cfg.ProjectsRoot;
         cfg.ProjectsRoot = string.Empty;
         AppConfigStore.Save(cfg);
 
-        try
-        {
-            var service = new MetadataSyncService(repo);
-            MetadataSyncResult result = service.ImportFromStore(metaRoot, new MetadataSyncOptions(true, false));
+        var service = new MetadataSyncService(repo);
+        MetadataSyncResult result = service.ImportFromStore(metaRoot, new MetadataSyncOptions(true, false));
 
-            Assert.Equal(MetadataSyncStatus.Success, result.Status);
+        Assert.Equal(MetadataSyncStatus.Success, result.Status);
 
-            Project project = repo.GetProjectByName("Preserve Root Hint");
-            Assert.NotNull(project);
-            Assert.Equal(sourceRootHint, project!.RootPath);
-        }
-        finally
-        {
-            cfg.ProjectsRoot = oldProjectsRoot;
-            AppConfigStore.Save(cfg);
-        }
+        Project project = repo.GetProjectByName("Preserve Root Hint");
+        Assert.NotNull(project);
+        Assert.Equal(sourceRootHint, project!.RootPath);
     }
 
     [Fact]
@@ -593,13 +580,7 @@ public sealed class MetadataSyncTests : IDisposable
         });
 
         SqliteRepository repo = CreateRepository(dbPath);
-        repo.AddProject(new Project
-        {
-            Name = "Repair Existing Root",
-            RootPath = string.Empty,
-            Preset = "unity",
-            CreatedUtc = DateTime.UtcNow
-        });
+        TestRepository.AddProject(repo, "Repair Existing Root", string.Empty, "unity", DateTime.UtcNow);
 
         var service = new MetadataSyncService(repo);
         MetadataSyncResult result = service.ImportFromStore(metaRoot, new MetadataSyncOptions(true, false));
@@ -619,48 +600,35 @@ public sealed class MetadataSyncTests : IDisposable
         string projectsRoot = CreateTempDir();
         string localProjectRoot = Path.Combine(projectsRoot, "real-folder");
         Directory.CreateDirectory(localProjectRoot);
-        AppConfig originalConfig = CloneConfig(AppConfigStore.Load());
 
-        try
+        using var configScope = new TestAppConfigScope();
+        AppConfig cfg = AppConfigStore.Load();
+        cfg.ProjectsRoot = projectsRoot;
+        AppConfigStore.Save(cfg);
+
+        MetadataStore store = CreateStore(metaRoot);
+        store.UpsertProject(new MetaProject
         {
-            AppConfig cfg = CloneConfig(originalConfig);
-            cfg.ProjectsRoot = projectsRoot;
-            AppConfigStore.Save(cfg);
+            ExternalId = "proj-cross-os-root",
+            Name = "Display Name",
+            Preset = "dotnet",
+            RootPathHint = @"D:\Dev\real-folder",
+            CreatedUtc = DateTime.UtcNow,
+            SettingsJson = "{}",
+            UpdatedUtc = DateTime.UtcNow
+        });
 
-            MetadataStore store = CreateStore(metaRoot);
-            store.UpsertProject(new MetaProject
-            {
-                ExternalId = "proj-cross-os-root",
-                Name = "Display Name",
-                Preset = "dotnet",
-                RootPathHint = @"D:\Dev\real-folder",
-                CreatedUtc = DateTime.UtcNow,
-                SettingsJson = "{}",
-                UpdatedUtc = DateTime.UtcNow
-            });
+        SqliteRepository repo = CreateRepository(dbPath);
+        TestRepository.AddProject(repo, "Display Name", @"D:\Dev\real-folder", "dotnet", DateTime.UtcNow);
 
-            SqliteRepository repo = CreateRepository(dbPath);
-            repo.AddProject(new Project
-            {
-                Name = "Display Name",
-                RootPath = @"D:\Dev\real-folder",
-                Preset = "dotnet",
-                CreatedUtc = DateTime.UtcNow
-            });
+        var service = new MetadataSyncService(repo);
+        MetadataSyncResult result = service.ImportFromStore(metaRoot, new MetadataSyncOptions(true, false));
 
-            var service = new MetadataSyncService(repo);
-            MetadataSyncResult result = service.ImportFromStore(metaRoot, new MetadataSyncOptions(true, false));
+        Assert.Equal(MetadataSyncStatus.Success, result.Status);
 
-            Assert.Equal(MetadataSyncStatus.Success, result.Status);
-
-            Project project = repo.GetProjectByName("Display Name");
-            Assert.NotNull(project);
-            Assert.Equal(localProjectRoot, project!.RootPath);
-        }
-        finally
-        {
-            AppConfigStore.Save(originalConfig);
-        }
+        Project project = repo.GetProjectByName("Display Name");
+        Assert.NotNull(project);
+        Assert.Equal(localProjectRoot, project!.RootPath);
     }
 
     [Fact]
@@ -693,13 +661,7 @@ public sealed class MetadataSyncTests : IDisposable
         string dbPath = Path.Combine(CreateTempDir(), "vaultsync.db");
 
         SqliteRepository repo = CreateRepository(dbPath);
-        int projectId = repo.AddProject(new Project
-        {
-            Name = "Project Tombstone",
-            RootPath = CreateTempDir(),
-            Preset = "unity",
-            CreatedUtc = DateTime.UtcNow
-        });
+        int projectId = TestRepository.AddProject(repo, "Project Tombstone", CreateTempDir(), "unity", DateTime.UtcNow);
 
         int snapshotId = repo.CreateSnapshotFromMetadata("snap-ts", projectId, DateTime.UtcNow, 1, 100);
         repo.CreateBackupFromMetadata(
@@ -740,13 +702,7 @@ public sealed class MetadataSyncTests : IDisposable
         string dbPath = Path.Combine(CreateTempDir(), "vaultsync.db");
 
         SqliteRepository repo = CreateRepository(dbPath);
-        int projectId = repo.AddProject(new Project
-        {
-            Name = "Project Export",
-            RootPath = CreateTempDir(),
-            Preset = "unity",
-            CreatedUtc = DateTime.UtcNow
-        });
+        int projectId = TestRepository.AddProject(repo, "Project Export", CreateTempDir(), "unity", DateTime.UtcNow);
 
         int snapshotId = repo.CreateSnapshot(projectId, 2, 500);
         int backupId = repo.CreateBackup(
@@ -811,41 +767,34 @@ public sealed class MetadataSyncTests : IDisposable
         string metaRoot = CreateTempDir();
         string dbPath = Path.Combine(CreateTempDir(), "vaultsync.db");
         string projectRoot = CreateTempDir();
-        AppConfig originalConfig = CloneConfig(AppConfigStore.Load());
 
-        try
+        using var configScope = new TestAppConfigScope();
+        AppConfig cfg = AppConfigStore.Load();
+        cfg.Backups.AutoBackupDisabledProjects.Clear();
+        AppConfigStore.Save(cfg);
+
+        MetadataStore store = CreateStore(metaRoot);
+        store.UpsertProject(new MetaProject
         {
-            AppConfig cfg = CloneConfig(originalConfig);
-            cfg.Backups.AutoBackupDisabledProjects.Clear();
-            AppConfigStore.Save(cfg);
+            ExternalId = "proj-settings-auto",
+            Name = "Project Auto Backup",
+            Preset = "unity",
+            RootPathHint = projectRoot,
+            CreatedUtc = DateTime.UtcNow,
+            SettingsJson = "{\"autoBackupEnabled\":false}",
+            UpdatedUtc = DateTime.UtcNow
+        });
 
-            MetadataStore store = CreateStore(metaRoot);
-            store.UpsertProject(new MetaProject
-            {
-                ExternalId = "proj-settings-auto",
-                Name = "Project Auto Backup",
-                Preset = "unity",
-                RootPathHint = projectRoot,
-                CreatedUtc = DateTime.UtcNow,
-                SettingsJson = "{\"autoBackupEnabled\":false}",
-                UpdatedUtc = DateTime.UtcNow
-            });
+        SqliteRepository repo = CreateRepository(dbPath);
+        var service = new MetadataSyncService(repo);
+        MetadataSyncResult result = service.ImportFromStore(metaRoot, MetadataSyncOptions.Default);
 
-            SqliteRepository repo = CreateRepository(dbPath);
-            var service = new MetadataSyncService(repo);
-            MetadataSyncResult result = service.ImportFromStore(metaRoot, MetadataSyncOptions.Default);
+        Assert.Equal(MetadataSyncStatus.Success, result.Status);
+        Project project = repo.GetProjectByName("Project Auto Backup");
+        Assert.NotNull(project);
 
-            Assert.Equal(MetadataSyncStatus.Success, result.Status);
-            Project project = repo.GetProjectByName("Project Auto Backup");
-            Assert.NotNull(project);
-
-            AppConfig refreshedConfig = AppConfigStore.Load();
-            Assert.Contains(project!.Id, refreshedConfig.Backups.AutoBackupDisabledProjects);
-        }
-        finally
-        {
-            AppConfigStore.Save(originalConfig);
-        }
+        AppConfig refreshedConfig = AppConfigStore.Load();
+        Assert.Contains(project!.Id, refreshedConfig.Backups.AutoBackupDisabledProjects);
     }
 
     [Fact]
@@ -939,66 +888,59 @@ public sealed class MetadataSyncTests : IDisposable
         string dbPath = Path.Combine(CreateTempDir(), "vaultsync.db");
         string projectRoot = CreateTempDir();
         DateTime now = DateTime.UtcNow;
-        AppConfig originalConfig = CloneConfig(AppConfigStore.Load());
 
-        try
+        using var configScope = new TestAppConfigScope();
+        AppConfig cfg = AppConfigStore.Load();
+        cfg.Advanced.ProjectMetadataConflicts.Clear();
+        AppConfigStore.Save(cfg);
+
+        SqliteRepository repo = CreateRepository(dbPath);
+        int projectId = repo.AddProject(new Project
         {
-            AppConfig cfg = CloneConfig(originalConfig);
-            cfg.Advanced.ProjectMetadataConflicts.Clear();
-            AppConfigStore.Save(cfg);
+            ExternalId = "proj-conflict-1",
+            Name = "Project Conflict",
+            RootPath = projectRoot,
+            Preset = "unity",
+            CreatedUtc = now.AddDays(-2),
+            PreferredDestinationId = "dest-local",
+            RestoreMode = ProjectRestoreMode.Direct,
+            VerificationPolicy = ProjectVerificationPolicy.Always,
+            Tags = "local,stable"
+        });
 
-            SqliteRepository repo = CreateRepository(dbPath);
-            int projectId = repo.AddProject(new Project
-            {
-                ExternalId = "proj-conflict-1",
-                Name = "Project Conflict",
-                RootPath = projectRoot,
-                Preset = "unity",
-                CreatedUtc = now.AddDays(-2),
-                PreferredDestinationId = "dest-local",
-                RestoreMode = ProjectRestoreMode.Direct,
-                VerificationPolicy = ProjectVerificationPolicy.Always,
-                Tags = "local,stable"
-            });
-
-            MetadataStore store = CreateStore(metaRoot);
-            SeedMetaInfo(store, "machine-conflict");
-            store.UpsertProject(new MetaProject
-            {
-                ExternalId = "proj-conflict-1",
-                Name = "Project Conflict",
-                Preset = "unity",
-                RootPathHint = projectRoot,
-                CreatedUtc = now.AddDays(-2),
-                SettingsJson = "{\"preferredDestinationId\":\"dest-imported\",\"restoreMode\":\"sandbox\",\"verificationPolicy\":\"manual\",\"tags\":\"imported,remote\"}",
-                UpdatedUtc = now
-            });
-
-            var service = new MetadataSyncService(repo);
-            MetadataSyncResult result = service.ImportFromStore(metaRoot, MetadataSyncOptions.Default);
-
-            Assert.Equal(MetadataSyncStatus.Success, result.Status);
-
-            Project project = repo.GetProjectById(projectId);
-            Assert.NotNull(project);
-            Assert.Equal("dest-local", project!.PreferredDestinationId);
-            Assert.Equal(ProjectRestoreMode.Direct, project.RestoreMode);
-            Assert.Equal(ProjectVerificationPolicy.Always, project.VerificationPolicy);
-            Assert.Equal("local,stable", project.Tags);
-
-            AppConfig refreshedConfig = AppConfigStore.Load();
-            ProjectMetadataConflictRecord conflict = Assert.Single(refreshedConfig.Advanced.ProjectMetadataConflicts);
-            Assert.Equal(projectId, conflict.ProjectId);
-            Assert.Equal("machine-conflict", conflict.SourceMachineId);
-            Assert.Equal("dest-local", conflict.Local.PreferredDestinationId);
-            Assert.Equal("dest-imported", conflict.Imported.PreferredDestinationId);
-            Assert.Equal(ProjectRestoreMode.Direct, conflict.Local.RestoreMode);
-            Assert.Equal(ProjectRestoreMode.Sandbox, conflict.Imported.RestoreMode);
-        }
-        finally
+        MetadataStore store = CreateStore(metaRoot);
+        SeedMetaInfo(store, "machine-conflict");
+        store.UpsertProject(new MetaProject
         {
-            AppConfigStore.Save(originalConfig);
-        }
+            ExternalId = "proj-conflict-1",
+            Name = "Project Conflict",
+            Preset = "unity",
+            RootPathHint = projectRoot,
+            CreatedUtc = now.AddDays(-2),
+            SettingsJson = "{\"preferredDestinationId\":\"dest-imported\",\"restoreMode\":\"sandbox\",\"verificationPolicy\":\"manual\",\"tags\":\"imported,remote\"}",
+            UpdatedUtc = now
+        });
+
+        var service = new MetadataSyncService(repo);
+        MetadataSyncResult result = service.ImportFromStore(metaRoot, MetadataSyncOptions.Default);
+
+        Assert.Equal(MetadataSyncStatus.Success, result.Status);
+
+        Project project = repo.GetProjectById(projectId);
+        Assert.NotNull(project);
+        Assert.Equal("dest-local", project!.PreferredDestinationId);
+        Assert.Equal(ProjectRestoreMode.Direct, project.RestoreMode);
+        Assert.Equal(ProjectVerificationPolicy.Always, project.VerificationPolicy);
+        Assert.Equal("local,stable", project.Tags);
+
+        AppConfig refreshedConfig = AppConfigStore.Load();
+        ProjectMetadataConflictRecord conflict = Assert.Single(refreshedConfig.Advanced.ProjectMetadataConflicts);
+        Assert.Equal(projectId, conflict.ProjectId);
+        Assert.Equal("machine-conflict", conflict.SourceMachineId);
+        Assert.Equal("dest-local", conflict.Local.PreferredDestinationId);
+        Assert.Equal("dest-imported", conflict.Imported.PreferredDestinationId);
+        Assert.Equal(ProjectRestoreMode.Direct, conflict.Local.RestoreMode);
+        Assert.Equal(ProjectRestoreMode.Sandbox, conflict.Imported.RestoreMode);
     }
 
     [Fact]
@@ -1085,47 +1027,34 @@ public sealed class MetadataSyncTests : IDisposable
     {
         string metaRoot = CreateTempDir();
         string dbPath = Path.Combine(CreateTempDir(), "vaultsync.db");
-        AppConfig originalConfig = CloneConfig(AppConfigStore.Load());
 
-        try
-        {
-            SqliteRepository repo = CreateRepository(dbPath);
-            int projectId = repo.AddProject(new Project
-            {
-                Name = "Project Export Auto Backup",
-                RootPath = CreateTempDir(),
-                Preset = "unity",
-                CreatedUtc = DateTime.UtcNow
-            });
+        using var configScope = new TestAppConfigScope();
+        SqliteRepository repo = CreateRepository(dbPath);
+        int projectId = TestRepository.AddProject(repo, "Project Export Auto Backup", CreateTempDir(), "unity", DateTime.UtcNow);
 
-            AppConfig cfg = CloneConfig(originalConfig);
-            cfg.Backups.AutoBackupDisabledProjects = [projectId];
-            AppConfigStore.Save(cfg);
+        AppConfig cfg = AppConfigStore.Load();
+        cfg.Backups.AutoBackupDisabledProjects = [projectId];
+        AppConfigStore.Save(cfg);
 
-            int snapshotId = repo.CreateSnapshot(projectId, 2, 500);
-            int backupId = repo.CreateBackup(
-                projectId,
-                snapshotId,
-                "manual",
-                500,
-                "project-export-auto-backup/2025-01-01_00-00-00",
-                metaRoot,
-                "Primary");
+        int snapshotId = repo.CreateSnapshot(projectId, 2, 500);
+        int backupId = repo.CreateBackup(
+            projectId,
+            snapshotId,
+            "manual",
+            500,
+            "project-export-auto-backup/2025-01-01_00-00-00",
+            metaRoot,
+            "Primary");
 
-            var service = new MetadataSyncService(repo);
-            MetadataSyncResult result = service.ExportBackupToStore(metaRoot, backupId, "1.7.2", "machine-settings");
-            Assert.Equal(MetadataSyncStatus.Success, result.Status);
+        var service = new MetadataSyncService(repo);
+        MetadataSyncResult result = service.ExportBackupToStore(metaRoot, backupId, "1.7.2", "machine-settings");
+        Assert.Equal(MetadataSyncStatus.Success, result.Status);
 
-            var store = new MetadataStore(metaRoot);
-            MetaProject metaProject = store.ListProjects().Single();
-            using var doc = JsonDocument.Parse(metaProject.SettingsJson);
-            Assert.True(doc.RootElement.TryGetProperty("autoBackupEnabled", out JsonElement autoBackupEnabled));
-            Assert.False(autoBackupEnabled.GetBoolean());
-        }
-        finally
-        {
-            AppConfigStore.Save(originalConfig);
-        }
+        var store = new MetadataStore(metaRoot);
+        MetaProject metaProject = store.ListProjects().Single();
+        using var doc = JsonDocument.Parse(metaProject.SettingsJson);
+        Assert.True(doc.RootElement.TryGetProperty("autoBackupEnabled", out JsonElement autoBackupEnabled));
+        Assert.False(autoBackupEnabled.GetBoolean());
     }
 
     [Fact]
@@ -1134,52 +1063,39 @@ public sealed class MetadataSyncTests : IDisposable
         string metaRoot = CreateTempDir();
         string sourceDbPath = Path.Combine(CreateTempDir(), "vaultsync-source.db");
         string targetDbPath = Path.Combine(CreateTempDir(), "vaultsync-target.db");
-        AppConfig originalConfig = CloneConfig(AppConfigStore.Load());
 
-        try
+        using var configScope = new TestAppConfigScope();
+        SqliteRepository sourceRepo = CreateRepository(sourceDbPath);
+        int projectId = TestRepository.AddProject(sourceRepo, "Project Settings Only", CreateTempDir(), "unity", DateTime.UtcNow);
+
+        AppConfig cfg = AppConfigStore.Load();
+        cfg.Backups.AutoBackupDisabledProjects = [projectId];
+        AppConfigStore.Save(cfg);
+
+        var exportService = new MetadataSyncService(sourceRepo);
+        MetadataSyncResult exportResult = exportService.ExportProjectToStore(metaRoot, projectId, "1.7.3", "machine-source");
+        Assert.Equal(MetadataSyncStatus.Success, exportResult.Status);
+
+        var store = new MetadataStore(metaRoot);
+        MetaProject metaProject = store.ListProjects().Single();
+        using (var doc = JsonDocument.Parse(metaProject.SettingsJson))
         {
-            SqliteRepository sourceRepo = CreateRepository(sourceDbPath);
-            int projectId = sourceRepo.AddProject(new Project
-            {
-                Name = "Project Settings Only",
-                RootPath = CreateTempDir(),
-                Preset = "unity",
-                CreatedUtc = DateTime.UtcNow
-            });
-
-            AppConfig cfg = CloneConfig(originalConfig);
-            cfg.Backups.AutoBackupDisabledProjects = [projectId];
-            AppConfigStore.Save(cfg);
-
-            var exportService = new MetadataSyncService(sourceRepo);
-            MetadataSyncResult exportResult = exportService.ExportProjectToStore(metaRoot, projectId, "1.7.3", "machine-source");
-            Assert.Equal(MetadataSyncStatus.Success, exportResult.Status);
-
-            var store = new MetadataStore(metaRoot);
-            MetaProject metaProject = store.ListProjects().Single();
-            using (var doc = JsonDocument.Parse(metaProject.SettingsJson))
-            {
-                Assert.True(doc.RootElement.TryGetProperty("autoBackupEnabled", out JsonElement autoBackupEnabled));
-                Assert.False(autoBackupEnabled.GetBoolean());
-            }
-
-            cfg.Backups.AutoBackupDisabledProjects.Clear();
-            AppConfigStore.Save(cfg);
-
-            SqliteRepository targetRepo = CreateRepository(targetDbPath);
-            var importService = new MetadataSyncService(targetRepo);
-            MetadataSyncResult importResult = importService.ImportFromStore(metaRoot, MetadataSyncOptions.Default);
-            Assert.Equal(MetadataSyncStatus.Success, importResult.Status);
-
-            Project importedProject = targetRepo.GetProjectByName("Project Settings Only");
-            Assert.NotNull(importedProject);
-            AppConfig refreshedConfig = AppConfigStore.Load();
-            Assert.Contains(importedProject!.Id, refreshedConfig.Backups.AutoBackupDisabledProjects);
+            Assert.True(doc.RootElement.TryGetProperty("autoBackupEnabled", out JsonElement autoBackupEnabled));
+            Assert.False(autoBackupEnabled.GetBoolean());
         }
-        finally
-        {
-            AppConfigStore.Save(originalConfig);
-        }
+
+        cfg.Backups.AutoBackupDisabledProjects.Clear();
+        AppConfigStore.Save(cfg);
+
+        SqliteRepository targetRepo = CreateRepository(targetDbPath);
+        var importService = new MetadataSyncService(targetRepo);
+        MetadataSyncResult importResult = importService.ImportFromStore(metaRoot, MetadataSyncOptions.Default);
+        Assert.Equal(MetadataSyncStatus.Success, importResult.Status);
+
+        Project importedProject = targetRepo.GetProjectByName("Project Settings Only");
+        Assert.NotNull(importedProject);
+        AppConfig refreshedConfig = AppConfigStore.Load();
+        Assert.Contains(importedProject!.Id, refreshedConfig.Backups.AutoBackupDisabledProjects);
     }
 
     [Fact]
@@ -1252,13 +1168,7 @@ public sealed class MetadataSyncTests : IDisposable
             MetadataSyncService.ProjectColorApplier = null;
 
             SqliteRepository repo = CreateRepository(dbPath);
-            int projectId = repo.AddProject(new Project
-            {
-                Name = "Project Export Contract",
-                RootPath = CreateTempDir(),
-                Preset = "unity",
-                CreatedUtc = DateTime.UtcNow
-            });
+            int projectId = TestRepository.AddProject(repo, "Project Export Contract", CreateTempDir(), "unity", DateTime.UtcNow);
 
             var diffSummary = new SnapshotDiffSummary(
                 5,
@@ -1320,55 +1230,48 @@ public sealed class MetadataSyncTests : IDisposable
         string dbPath = Path.Combine(CreateTempDir(), "vaultsync.db");
         string projectRoot = CreateTempDir();
         DateTime now = DateTime.UtcNow;
-        AppConfig originalConfig = CloneConfig(AppConfigStore.Load());
 
-        try
+        using var configScope = new TestAppConfigScope();
+        var destination = new BackupDestination
         {
-            var destination = new BackupDestination
-            {
-                Path = CreateTempDir(),
-                Alias = "Imported Destination",
-                Active = true
-            };
-            string destinationId = DestinationIdentityService.GetId(destination);
-            AppConfig cfg = CloneConfig(originalConfig);
-            cfg.Advanced.ProjectMetadataConflicts.Clear();
-            cfg.Backups.Destinations = [destination];
-            AppConfigStore.Save(cfg);
+            Path = CreateTempDir(),
+            Alias = "Imported Destination",
+            Active = true
+        };
+        string destinationId = DestinationIdentityService.GetId(destination);
+        AppConfig cfg = AppConfigStore.Load();
+        cfg.Advanced.ProjectMetadataConflicts.Clear();
+        cfg.Backups.Destinations = [destination];
+        AppConfigStore.Save(cfg);
 
-            SqliteRepository repo = CreateRepository(dbPath);
-            MetadataStore store = CreateStore(metaRoot);
-            SeedMetaInfo(store, "machine-settings-apply");
-            store.UpsertProject(new MetaProject
-            {
-                ExternalId = "proj-settings-apply",
-                Name = "Project Settings Apply",
-                Preset = "unity",
-                RootPathHint = projectRoot,
-                CreatedUtc = now.AddDays(-2),
-                SettingsJson = $"{{\"preferredDestinationId\":\"{destinationId}\",\"restoreMode\":\"sandbox\",\"verificationPolicy\":\"manual\",\"tags\":\"imported,remote\"}}",
-                UpdatedUtc = now
-            });
-
-            var service = new MetadataSyncService(repo);
-            MetadataSyncResult result = service.ImportFromStore(metaRoot, MetadataSyncOptions.Default);
-
-            Assert.Equal(MetadataSyncStatus.Success, result.Status);
-
-            Project project = repo.GetProjectByExternalId("proj-settings-apply");
-            Assert.NotNull(project);
-            Assert.Equal(destinationId, project!.PreferredDestinationId);
-            Assert.Equal(ProjectRestoreMode.Sandbox, project.RestoreMode);
-            Assert.Equal(ProjectVerificationPolicy.Manual, project.VerificationPolicy);
-            Assert.Equal("imported,remote", project.Tags);
-
-            AppConfig refreshedConfig = AppConfigStore.Load();
-            Assert.Empty(refreshedConfig.Advanced.ProjectMetadataConflicts);
-        }
-        finally
+        SqliteRepository repo = CreateRepository(dbPath);
+        MetadataStore store = CreateStore(metaRoot);
+        SeedMetaInfo(store, "machine-settings-apply");
+        store.UpsertProject(new MetaProject
         {
-            AppConfigStore.Save(originalConfig);
-        }
+            ExternalId = "proj-settings-apply",
+            Name = "Project Settings Apply",
+            Preset = "unity",
+            RootPathHint = projectRoot,
+            CreatedUtc = now.AddDays(-2),
+            SettingsJson = $"{{\"preferredDestinationId\":\"{destinationId}\",\"restoreMode\":\"sandbox\",\"verificationPolicy\":\"manual\",\"tags\":\"imported,remote\"}}",
+            UpdatedUtc = now
+        });
+
+        var service = new MetadataSyncService(repo);
+        MetadataSyncResult result = service.ImportFromStore(metaRoot, MetadataSyncOptions.Default);
+
+        Assert.Equal(MetadataSyncStatus.Success, result.Status);
+
+        Project project = repo.GetProjectByExternalId("proj-settings-apply");
+        Assert.NotNull(project);
+        Assert.Equal(destinationId, project!.PreferredDestinationId);
+        Assert.Equal(ProjectRestoreMode.Sandbox, project.RestoreMode);
+        Assert.Equal(ProjectVerificationPolicy.Manual, project.VerificationPolicy);
+        Assert.Equal("imported,remote", project.Tags);
+
+        AppConfig refreshedConfig = AppConfigStore.Load();
+        Assert.Empty(refreshedConfig.Advanced.ProjectMetadataConflicts);
     }
 
     [Fact]
@@ -1377,47 +1280,40 @@ public sealed class MetadataSyncTests : IDisposable
         string metaRoot = CreateTempDir();
         string dbPath = Path.Combine(CreateTempDir(), "vaultsync.db");
         string projectRoot = CreateTempDir();
-        AppConfig originalConfig = CloneConfig(AppConfigStore.Load());
 
-        try
+        using var configScope = new TestAppConfigScope();
+        var destination = new BackupDestination
         {
-            var destination = new BackupDestination
-            {
-                Path = CreateTempDir(),
-                Alias = "NAS Primary",
-                Active = true
-            };
-            string destinationId = DestinationIdentityService.GetId(destination);
-            AppConfig cfg = CloneConfig(originalConfig);
-            cfg.Backups.Destinations = [destination];
-            AppConfigStore.Save(cfg);
+            Path = CreateTempDir(),
+            Alias = "NAS Primary",
+            Active = true
+        };
+        string destinationId = DestinationIdentityService.GetId(destination);
+        AppConfig cfg = AppConfigStore.Load();
+        cfg.Backups.Destinations = [destination];
+        AppConfigStore.Save(cfg);
 
-            MetadataStore store = CreateStore(metaRoot);
-            SeedMetaInfo(store, "machine-alias-import");
-            store.UpsertProject(new MetaProject
-            {
-                ExternalId = "proj-settings-alias",
-                Name = "Project Settings Alias",
-                Preset = "unity",
-                RootPathHint = projectRoot,
-                CreatedUtc = DateTime.UtcNow.AddDays(-1),
-                SettingsJson = "{\"preferredDestinationId\":\"NAS Primary\"}",
-                UpdatedUtc = DateTime.UtcNow
-            });
-
-            SqliteRepository repo = CreateRepository(dbPath);
-            var service = new MetadataSyncService(repo);
-            MetadataSyncResult result = service.ImportFromStore(metaRoot, MetadataSyncOptions.Default);
-
-            Assert.Equal(MetadataSyncStatus.Success, result.Status);
-            Project project = repo.GetProjectByExternalId("proj-settings-alias");
-            Assert.NotNull(project);
-            Assert.Equal(destinationId, project!.PreferredDestinationId);
-        }
-        finally
+        MetadataStore store = CreateStore(metaRoot);
+        SeedMetaInfo(store, "machine-alias-import");
+        store.UpsertProject(new MetaProject
         {
-            AppConfigStore.Save(originalConfig);
-        }
+            ExternalId = "proj-settings-alias",
+            Name = "Project Settings Alias",
+            Preset = "unity",
+            RootPathHint = projectRoot,
+            CreatedUtc = DateTime.UtcNow.AddDays(-1),
+            SettingsJson = "{\"preferredDestinationId\":\"NAS Primary\"}",
+            UpdatedUtc = DateTime.UtcNow
+        });
+
+        SqliteRepository repo = CreateRepository(dbPath);
+        var service = new MetadataSyncService(repo);
+        MetadataSyncResult result = service.ImportFromStore(metaRoot, MetadataSyncOptions.Default);
+
+        Assert.Equal(MetadataSyncStatus.Success, result.Status);
+        Project project = repo.GetProjectByExternalId("proj-settings-alias");
+        Assert.NotNull(project);
+        Assert.Equal(destinationId, project!.PreferredDestinationId);
     }
 
     [Fact]
@@ -1427,66 +1323,59 @@ public sealed class MetadataSyncTests : IDisposable
         string dbPath = Path.Combine(CreateTempDir(), "vaultsync.db");
         string projectRoot = CreateTempDir();
         DateTime now = DateTime.UtcNow;
-        AppConfig originalConfig = CloneConfig(AppConfigStore.Load());
 
-        try
+        using var configScope = new TestAppConfigScope();
+        var destination = new BackupDestination
         {
-            var destination = new BackupDestination
-            {
-                Path = CreateTempDir(),
-                Alias = "NAS Imported",
-                Active = true
-            };
-            string destinationId = DestinationIdentityService.GetId(destination);
-            AppConfig cfg = CloneConfig(originalConfig);
-            cfg.Advanced.ProjectMetadataConflicts.Clear();
-            cfg.Backups.Destinations = [destination];
-            AppConfigStore.Save(cfg);
+            Path = CreateTempDir(),
+            Alias = "NAS Imported",
+            Active = true
+        };
+        string destinationId = DestinationIdentityService.GetId(destination);
+        AppConfig cfg = AppConfigStore.Load();
+        cfg.Advanced.ProjectMetadataConflicts.Clear();
+        cfg.Backups.Destinations = [destination];
+        AppConfigStore.Save(cfg);
 
-            SqliteRepository repo = CreateRepository(dbPath);
-            int projectId = repo.AddProject(new Project
-            {
-                ExternalId = "proj-conflict-normalized",
-                Name = "Project Conflict Normalized",
-                RootPath = projectRoot,
-                Preset = "unity",
-                CreatedUtc = now.AddDays(-2),
-                PreferredDestinationId = "dest-local",
-                RestoreMode = ProjectRestoreMode.Direct,
-                VerificationPolicy = ProjectVerificationPolicy.Always,
-                Tags = "local"
-            });
-
-            MetadataStore store = CreateStore(metaRoot);
-            SeedMetaInfo(store, "machine-conflict-normalized");
-            store.UpsertProject(new MetaProject
-            {
-                ExternalId = "proj-conflict-normalized",
-                Name = "Project Conflict Normalized",
-                Preset = "unity",
-                RootPathHint = projectRoot,
-                CreatedUtc = now.AddDays(-2),
-                SettingsJson = "{\"preferredDestinationId\":\"NAS Imported\",\"restoreMode\":\"sandbox\",\"verificationPolicy\":\"manual\",\"tags\":\"imported\"}",
-                UpdatedUtc = now
-            });
-
-            var service = new MetadataSyncService(repo);
-            MetadataSyncResult result = service.ImportFromStore(metaRoot, MetadataSyncOptions.Default);
-
-            Assert.Equal(MetadataSyncStatus.Success, result.Status);
-            Project project = repo.GetProjectById(projectId);
-            Assert.NotNull(project);
-            Assert.Equal("dest-local", project!.PreferredDestinationId);
-
-            AppConfig refreshedConfig = AppConfigStore.Load();
-            ProjectMetadataConflictRecord conflict = Assert.Single(refreshedConfig.Advanced.ProjectMetadataConflicts);
-            Assert.Equal(destinationId, conflict.Imported.PreferredDestinationId);
-            Assert.Equal("dest-local", conflict.Local.PreferredDestinationId);
-        }
-        finally
+        SqliteRepository repo = CreateRepository(dbPath);
+        int projectId = repo.AddProject(new Project
         {
-            AppConfigStore.Save(originalConfig);
-        }
+            ExternalId = "proj-conflict-normalized",
+            Name = "Project Conflict Normalized",
+            RootPath = projectRoot,
+            Preset = "unity",
+            CreatedUtc = now.AddDays(-2),
+            PreferredDestinationId = "dest-local",
+            RestoreMode = ProjectRestoreMode.Direct,
+            VerificationPolicy = ProjectVerificationPolicy.Always,
+            Tags = "local"
+        });
+
+        MetadataStore store = CreateStore(metaRoot);
+        SeedMetaInfo(store, "machine-conflict-normalized");
+        store.UpsertProject(new MetaProject
+        {
+            ExternalId = "proj-conflict-normalized",
+            Name = "Project Conflict Normalized",
+            Preset = "unity",
+            RootPathHint = projectRoot,
+            CreatedUtc = now.AddDays(-2),
+            SettingsJson = "{\"preferredDestinationId\":\"NAS Imported\",\"restoreMode\":\"sandbox\",\"verificationPolicy\":\"manual\",\"tags\":\"imported\"}",
+            UpdatedUtc = now
+        });
+
+        var service = new MetadataSyncService(repo);
+        MetadataSyncResult result = service.ImportFromStore(metaRoot, MetadataSyncOptions.Default);
+
+        Assert.Equal(MetadataSyncStatus.Success, result.Status);
+        Project project = repo.GetProjectById(projectId);
+        Assert.NotNull(project);
+        Assert.Equal("dest-local", project!.PreferredDestinationId);
+
+        AppConfig refreshedConfig = AppConfigStore.Load();
+        ProjectMetadataConflictRecord conflict = Assert.Single(refreshedConfig.Advanced.ProjectMetadataConflicts);
+        Assert.Equal(destinationId, conflict.Imported.PreferredDestinationId);
+        Assert.Equal("dest-local", conflict.Local.PreferredDestinationId);
     }
 
     [Fact]
@@ -1598,46 +1487,39 @@ public sealed class MetadataSyncTests : IDisposable
         string metaRoot = CreateTempDir();
         string dbPath = Path.Combine(CreateTempDir(), "vaultsync.db");
         string projectRoot = CreateTempDir();
-        AppConfig originalConfig = CloneConfig(AppConfigStore.Load());
 
-        try
+        using var configScope = new TestAppConfigScope();
+        SqliteRepository repo = CreateRepository(dbPath);
+        int projectId = repo.AddProject(new Project
         {
-            SqliteRepository repo = CreateRepository(dbPath);
-            int projectId = repo.AddProject(new Project
-            {
-                ExternalId = "proj-remove-me",
-                Name = "Project Remove Me",
-                RootPath = projectRoot,
-                Preset = "unity",
-                CreatedUtc = DateTime.UtcNow
-            });
+            ExternalId = "proj-remove-me",
+            Name = "Project Remove Me",
+            RootPath = projectRoot,
+            Preset = "unity",
+            CreatedUtc = DateTime.UtcNow
+        });
 
-            AppConfig cfg = CloneConfig(originalConfig);
-            cfg.Backups.AutoBackupDisabledProjects = [projectId];
-            AppConfigStore.Save(cfg);
+        AppConfig cfg = AppConfigStore.Load();
+        cfg.Backups.AutoBackupDisabledProjects = [projectId];
+        AppConfigStore.Save(cfg);
 
-            MetadataStore store = CreateStore(metaRoot);
-            store.AddTombstone(new MetaTombstone
-            {
-                EntityType = "project",
-                EntityId = "proj-remove-me",
-                DeletedUtc = DateTime.UtcNow,
-                OriginMachineId = "machine-delete"
-            });
-
-            var service = new MetadataSyncService(repo);
-            MetadataSyncResult result = service.ImportFromStore(metaRoot);
-
-            Assert.Equal(MetadataSyncStatus.Success, result.Status);
-            Assert.Null(repo.GetProjectById(projectId));
-
-            AppConfig refreshedConfig = AppConfigStore.Load();
-            Assert.DoesNotContain(projectId, refreshedConfig.Backups.AutoBackupDisabledProjects);
-        }
-        finally
+        MetadataStore store = CreateStore(metaRoot);
+        store.AddTombstone(new MetaTombstone
         {
-            AppConfigStore.Save(originalConfig);
-        }
+            EntityType = "project",
+            EntityId = "proj-remove-me",
+            DeletedUtc = DateTime.UtcNow,
+            OriginMachineId = "machine-delete"
+        });
+
+        var service = new MetadataSyncService(repo);
+        MetadataSyncResult result = service.ImportFromStore(metaRoot);
+
+        Assert.Equal(MetadataSyncStatus.Success, result.Status);
+        Assert.Null(repo.GetProjectById(projectId));
+
+        AppConfig refreshedConfig = AppConfigStore.Load();
+        Assert.DoesNotContain(projectId, refreshedConfig.Backups.AutoBackupDisabledProjects);
     }
 
     [Fact]
@@ -1648,13 +1530,7 @@ public sealed class MetadataSyncTests : IDisposable
         string targetDbPath = Path.Combine(CreateTempDir(), "vaultsync-target.db");
 
         SqliteRepository sourceRepo = CreateRepository(sourceDbPath);
-        int projectId = sourceRepo.AddProject(new Project
-        {
-            Name = "Project Mixed",
-            RootPath = CreateTempDir(),
-            Preset = "unity",
-            CreatedUtc = DateTime.UtcNow
-        });
+        int projectId = TestRepository.AddProject(sourceRepo, "Project Mixed", CreateTempDir(), "unity", DateTime.UtcNow);
 
         int plainSnapshotId = sourceRepo.CreateSnapshot(projectId, 10, 10_000);
         const string plainPath = "project-mixed/2026-01-01_00-00-00";
@@ -1768,9 +1644,7 @@ public sealed class MetadataSyncTests : IDisposable
 
     private static SqliteRepository CreateRepository(string dbPath)
     {
-        var repo = new SqliteRepository(dbPath);
-        repo.EnsureSchema();
-        return repo;
+        return TestRepository.Create(dbPath);
     }
 
     private static void SeedMetaInfo(MetadataStore store, string machineId)
@@ -1942,9 +1816,4 @@ public sealed class MetadataSyncTests : IDisposable
         }
     }
 
-    private static AppConfig CloneConfig(AppConfig config)
-    {
-        string json = JsonSerializer.Serialize(config);
-        return JsonSerializer.Deserialize<AppConfig>(json) ?? new AppConfig();
-    }
 }

--- a/tests/VaultSync.Core.Tests/PowerStatusProviderTests.cs
+++ b/tests/VaultSync.Core.Tests/PowerStatusProviderTests.cs
@@ -1,5 +1,5 @@
-using System;
 using System.IO;
+using VaultSync.Core.Tests.TestSupport;
 using VaultSync.UI.Services;
 using Xunit;
 
@@ -10,73 +10,45 @@ public sealed class PowerStatusProviderTests
     [Fact]
     public void GetLinuxState_IgnoresDeviceScopedControllerBattery()
     {
-        string root = CreateTempPowerSupplyRoot();
-        try
-        {
-            string battery = Directory.CreateDirectory(Path.Combine(root, "ps-controller-battery")).FullName;
-            File.WriteAllText(Path.Combine(battery, "type"), "Battery");
-            File.WriteAllText(Path.Combine(battery, "scope"), "Device");
-            File.WriteAllText(Path.Combine(battery, "status"), "Discharging");
+        using var root = new TempDirectory();
+        string battery = Directory.CreateDirectory(Path.Combine(root.Path, "ps-controller-battery")).FullName;
+        File.WriteAllText(Path.Combine(battery, "type"), "Battery");
+        File.WriteAllText(Path.Combine(battery, "scope"), "Device");
+        File.WriteAllText(Path.Combine(battery, "status"), "Discharging");
 
-            PowerState state = PowerStatusProvider.GetLinuxState(root);
+        PowerState state = PowerStatusProvider.GetLinuxState(root.Path);
 
-            Assert.Equal(PowerState.Unknown, state);
-        }
-        finally
-        {
-            Directory.Delete(root, recursive: true);
-        }
+        Assert.Equal(PowerState.Unknown, state);
     }
 
     [Fact]
     public void GetLinuxState_SystemBatteryDischarging_ReturnsOnBattery()
     {
-        string root = CreateTempPowerSupplyRoot();
-        try
-        {
-            string battery = Directory.CreateDirectory(Path.Combine(root, "BAT0")).FullName;
-            File.WriteAllText(Path.Combine(battery, "type"), "Battery");
-            File.WriteAllText(Path.Combine(battery, "scope"), "System");
-            File.WriteAllText(Path.Combine(battery, "status"), "Discharging");
+        using var root = new TempDirectory();
+        string battery = Directory.CreateDirectory(Path.Combine(root.Path, "BAT0")).FullName;
+        File.WriteAllText(Path.Combine(battery, "type"), "Battery");
+        File.WriteAllText(Path.Combine(battery, "scope"), "System");
+        File.WriteAllText(Path.Combine(battery, "status"), "Discharging");
 
-            PowerState state = PowerStatusProvider.GetLinuxState(root);
+        PowerState state = PowerStatusProvider.GetLinuxState(root.Path);
 
-            Assert.Equal(PowerState.OnBattery, state);
-        }
-        finally
-        {
-            Directory.Delete(root, recursive: true);
-        }
+        Assert.Equal(PowerState.OnBattery, state);
     }
 
     [Fact]
     public void GetLinuxState_AcOnline_ReturnsPluggedInEvenWithBattery()
     {
-        string root = CreateTempPowerSupplyRoot();
-        try
-        {
-            string ac = Directory.CreateDirectory(Path.Combine(root, "AC")).FullName;
-            File.WriteAllText(Path.Combine(ac, "type"), "Mains");
-            File.WriteAllText(Path.Combine(ac, "online"), "1");
+        using var root = new TempDirectory();
+        string ac = Directory.CreateDirectory(Path.Combine(root.Path, "AC")).FullName;
+        File.WriteAllText(Path.Combine(ac, "type"), "Mains");
+        File.WriteAllText(Path.Combine(ac, "online"), "1");
 
-            string battery = Directory.CreateDirectory(Path.Combine(root, "BAT0")).FullName;
-            File.WriteAllText(Path.Combine(battery, "type"), "Battery");
-            File.WriteAllText(Path.Combine(battery, "status"), "Discharging");
+        string battery = Directory.CreateDirectory(Path.Combine(root.Path, "BAT0")).FullName;
+        File.WriteAllText(Path.Combine(battery, "type"), "Battery");
+        File.WriteAllText(Path.Combine(battery, "status"), "Discharging");
 
-            PowerState state = PowerStatusProvider.GetLinuxState(root);
+        PowerState state = PowerStatusProvider.GetLinuxState(root.Path);
 
-            Assert.Equal(PowerState.PluggedIn, state);
-        }
-        finally
-        {
-            Directory.Delete(root, recursive: true);
-        }
-    }
-
-    private static string CreateTempPowerSupplyRoot()
-    {
-        string root = Path.Combine(Path.GetTempPath(), $"vaultsync-power-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(root);
-        return root;
+        Assert.Equal(PowerState.PluggedIn, state);
     }
 }

--- a/tests/VaultSync.Core.Tests/ProjectPresetSelectionTests.cs
+++ b/tests/VaultSync.Core.Tests/ProjectPresetSelectionTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using VaultSync.Core.Tests.TestSupport;
 using VaultSync.UI.ViewModels;
 using Xunit;
 
@@ -8,18 +9,12 @@ namespace VaultSync.Core.Tests;
 
 public sealed class ProjectPresetSelectionTests : IDisposable
 {
-    private readonly string _tempDir;
-
-    public ProjectPresetSelectionTests()
-    {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"vaultsync-preset-selection-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_tempDir);
-    }
+    private readonly TempDirectory _tempDir = new();
 
     [Fact]
     public void RequiredPreset_UsesRecommendationBeforeGenericFallback()
     {
-        var projectRoot = Path.Combine(_tempDir, "UnityGame");
+        var projectRoot = Path.Combine(_tempDir.Path, "UnityGame");
         Directory.CreateDirectory(Path.Combine(projectRoot, "Assets"));
         Directory.CreateDirectory(Path.Combine(projectRoot, "ProjectSettings"));
 
@@ -36,7 +31,7 @@ public sealed class ProjectPresetSelectionTests : IDisposable
     [Fact]
     public void RequiredPreset_UsesGenericWhenNoRecommendationApplies()
     {
-        var projectRoot = Path.Combine(_tempDir, "PlainProject");
+        var projectRoot = Path.Combine(_tempDir.Path, "PlainProject");
         Directory.CreateDirectory(projectRoot);
 
         var vm = new ProjectsViewModel();
@@ -51,14 +46,7 @@ public sealed class ProjectPresetSelectionTests : IDisposable
 
     public void Dispose()
     {
-        try
-        {
-            if (Directory.Exists(_tempDir))
-                Directory.Delete(_tempDir, recursive: true);
-        }
-        catch
-        {
-        }
+        _tempDir.Dispose();
     }
 
     private static string ResolveRequiredPreset(ProjectsViewModel vm, ProjectItemViewModel project)

--- a/tests/VaultSync.Core.Tests/ProjectRootResolverTests.cs
+++ b/tests/VaultSync.Core.Tests/ProjectRootResolverTests.cs
@@ -1,18 +1,19 @@
 using System;
 using System.IO;
 using VaultSync.Core.Services;
+using VaultSync.Core.Tests.TestSupport;
 using Xunit;
 
 namespace VaultSync.Core.Tests;
 
 public sealed class ProjectRootResolverTests : IDisposable
 {
-    private readonly string _tempRoot = Path.Combine(Path.GetTempPath(), $"vaultsync-root-resolver-{Guid.NewGuid():N}");
+    private readonly TempDirectory _tempRoot = new();
 
     [Fact]
     public void TryResolveExistingProjectRoot_UsesLeafFromWindowsPathWhenProjectNameDiffers()
     {
-        string projectsRoot = Directory.CreateDirectory(Path.Combine(_tempRoot, "Projects")).FullName;
+        string projectsRoot = Directory.CreateDirectory(Path.Combine(_tempRoot.Path, "Projects")).FullName;
         string projectRoot = Directory.CreateDirectory(Path.Combine(projectsRoot, "real-folder")).FullName;
 
         bool resolved = ProjectRootResolver.TryResolveExistingProjectRoot(
@@ -28,7 +29,7 @@ public sealed class ProjectRootResolverTests : IDisposable
     [Fact]
     public void TryResolveExistingProjectRoot_MatchesProjectFolderIgnoringCase()
     {
-        string projectsRoot = Directory.CreateDirectory(Path.Combine(_tempRoot, "Projects")).FullName;
+        string projectsRoot = Directory.CreateDirectory(Path.Combine(_tempRoot.Path, "Projects")).FullName;
         string projectRoot = Directory.CreateDirectory(Path.Combine(projectsRoot, "Blueprints")).FullName;
 
         bool resolved = ProjectRootResolver.TryResolveExistingProjectRoot(
@@ -43,7 +44,6 @@ public sealed class ProjectRootResolverTests : IDisposable
 
     public void Dispose()
     {
-        if (Directory.Exists(_tempRoot))
-            Directory.Delete(_tempRoot, recursive: true);
+        _tempRoot.Dispose();
     }
 }

--- a/tests/VaultSync.Core.Tests/RestoreReadinessServiceTests.cs
+++ b/tests/VaultSync.Core.Tests/RestoreReadinessServiceTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using VaultSync.Core.Config;
 using VaultSync.Core.Models;
 using VaultSync.Core.Services;
+using VaultSync.Core.Tests.TestSupport;
 using Xunit;
 
 namespace VaultSync.Core.Tests;
@@ -16,7 +17,7 @@ public sealed class RestoreReadinessServiceTests
         var config = new AppConfig();
         Project[] projects =
         [
-            new Project { Id = 1, Name = "VaultSync", RootPath = "C:\\Repo", Preset = "default" }
+            new ProjectBuilder().Build()
         ];
 
         RestoreReadinessSummary summary = service.BuildSummary(
@@ -33,7 +34,7 @@ public sealed class RestoreReadinessServiceTests
     [Fact]
     public void BuildSummary_MarksProjectReady_WhenRecentBackupAndReachableDestination()
     {
-        var destination = new BackupDestination { Path = "C:\\Backups", Alias = "Primary", Active = true };
+        var destination = new BackupDestinationBuilder().Build();
         var config = new AppConfig
         {
             Backups = new BackupsConfig
@@ -43,27 +44,15 @@ public sealed class RestoreReadinessServiceTests
             }
         };
 
-        var project = new Project
-        {
-            Id = 1,
-            Name = "VaultSync",
-            RootPath = "C:\\Repo",
-            Preset = "default",
-            PreferredDestinationId = DestinationIdentityService.GetId(destination),
-            VerificationPolicy = ProjectVerificationPolicy.Always
-        };
+        var project = new ProjectBuilder()
+            .WithPreferredDestinationId(DestinationIdentityService.GetId(destination))
+            .WithVerificationPolicy(ProjectVerificationPolicy.Always)
+            .Build();
 
-        var backup = new Backup
-        {
-            Id = 10,
-            ProjectId = 1,
-            SnapshotId = 11,
-            ExternalId = "b1",
-            CreatedUtc = DateTime.UtcNow.AddHours(-2),
-            Type = "auto",
-            Path = "vaultsync\\2026-03-13_12-00-00",
-            DestinationPath = destination.Path
-        };
+        var backup = new BackupBuilder()
+            .CreatedUtc(DateTime.UtcNow.AddHours(-2))
+            .AtDestination(destination.Path)
+            .Build();
 
         RestoreReadinessSummary summary = new RestoreReadinessService().BuildSummary(
             [project],
@@ -79,7 +68,10 @@ public sealed class RestoreReadinessServiceTests
     [Fact]
     public void BuildSummary_MarksProjectRisk_WhenBackupIsStale_AndDestinationUnreachable()
     {
-        var destination = new BackupDestination { Path = "\\\\nas\\backups", Alias = "NAS", Active = true };
+        var destination = new BackupDestinationBuilder()
+            .WithPath("\\\\nas\\backups")
+            .WithAlias("NAS")
+            .Build();
         var config = new AppConfig
         {
             Backups = new BackupsConfig
@@ -89,27 +81,16 @@ public sealed class RestoreReadinessServiceTests
             }
         };
 
-        var project = new Project
-        {
-            Id = 1,
-            Name = "VaultSync",
-            RootPath = "C:\\Repo",
-            Preset = "default",
-            PreferredDestinationId = DestinationIdentityService.GetId(destination),
-            VerificationPolicy = ProjectVerificationPolicy.Manual
-        };
+        var project = new ProjectBuilder()
+            .WithPreferredDestinationId(DestinationIdentityService.GetId(destination))
+            .WithVerificationPolicy(ProjectVerificationPolicy.Manual)
+            .Build();
 
-        var backup = new Backup
-        {
-            Id = 10,
-            ProjectId = 1,
-            SnapshotId = 11,
-            ExternalId = "b1",
-            CreatedUtc = DateTime.UtcNow.AddDays(-5),
-            Type = "manual",
-            Path = "vaultsync\\2026-03-08_12-00-00",
-            DestinationPath = destination.Path
-        };
+        var backup = new BackupBuilder()
+            .CreatedUtc(DateTime.UtcNow.AddDays(-5))
+            .Manual()
+            .AtDestination(destination.Path)
+            .Build();
 
         RestoreReadinessSummary summary = new RestoreReadinessService().BuildSummary(
             [project],

--- a/tests/VaultSync.Core.Tests/SnapshotDiffSummaryTests.cs
+++ b/tests/VaultSync.Core.Tests/SnapshotDiffSummaryTests.cs
@@ -7,27 +7,27 @@ using System.Threading.Tasks;
 using VaultSync.Core.Models;
 using VaultSync.Core.Repositories;
 using VaultSync.Core.Services;
+using VaultSync.Core.Tests.TestSupport;
 using Xunit;
 
 namespace VaultSync.Core.Tests;
 
 public sealed class SnapshotDiffSummaryTests : IDisposable
 {
-    private readonly List<string> _tempDirs = [];
+    private readonly List<TempDirectory> _tempDirs = [];
 
     [Fact]
     public void Repository_CreateSnapshot_PersistsDiffSummaryFields()
     {
         string dbPath = Path.Combine(CreateTempDir(), "vaultsync.db");
         string root = CreateTempDir();
-        SqliteRepository repo = CreateRepository(dbPath);
-        int projectId = repo.AddProject(new Project
-        {
-            Name = "Diff Repo Project",
-            RootPath = root,
-            Preset = string.Empty,
-            CreatedUtc = DateTime.UtcNow
-        });
+        SqliteRepository repo = TestRepository.Create(dbPath);
+        int projectId = TestRepository.AddProject(
+            repo,
+            "Diff Repo Project",
+            root,
+            preset: string.Empty,
+            createdUtc: DateTime.UtcNow);
 
         var summary = new SnapshotDiffSummary(
             Added: 3,
@@ -66,14 +66,13 @@ public sealed class SnapshotDiffSummaryTests : IDisposable
         File.WriteAllText(Path.Combine(projectRoot, "src", "a.txt"), "0123456789");
         File.WriteAllText(Path.Combine(projectRoot, "docs", "readme.md"), "01234567890123456789");
 
-        SqliteRepository repo = CreateRepository(dbPath);
-        int projectId = repo.AddProject(new Project
-        {
-            Name = "Diff Service Project",
-            RootPath = projectRoot,
-            Preset = string.Empty,
-            CreatedUtc = DateTime.UtcNow
-        });
+        SqliteRepository repo = TestRepository.Create(dbPath);
+        int projectId = TestRepository.AddProject(
+            repo,
+            "Diff Service Project",
+            projectRoot,
+            preset: string.Empty,
+            createdUtc: DateTime.UtcNow);
         Project project = repo.GetProjectById(projectId);
         Assert.NotNull(project);
 
@@ -152,7 +151,7 @@ public sealed class SnapshotDiffSummaryTests : IDisposable
             KdfParamsJson = "{}"
         });
 
-        SqliteRepository repo = CreateRepository(dbPath);
+        SqliteRepository repo = TestRepository.Create(dbPath);
         var sync = new MetadataSyncService(repo);
         MetadataSyncResult result = sync.ImportFromStore(metaRoot, MetadataSyncOptions.Default);
 
@@ -172,32 +171,16 @@ public sealed class SnapshotDiffSummaryTests : IDisposable
 
     public void Dispose()
     {
-        foreach (string path in _tempDirs.OrderByDescending(p => p.Length))
+        foreach (TempDirectory directory in _tempDirs.OrderByDescending(directory => directory.Path.Length))
         {
-            try
-            {
-                if (Directory.Exists(path))
-                    Directory.Delete(path, recursive: true);
-            }
-            catch
-            {
-                // Ignore cleanup failures in tests.
-            }
+            directory.Dispose();
         }
-    }
-
-    private static SqliteRepository CreateRepository(string dbPath)
-    {
-        var repo = new SqliteRepository(dbPath);
-        repo.EnsureSchema();
-        return repo;
     }
 
     private string CreateTempDir()
     {
-        string path = Path.Combine(Path.GetTempPath(), $"vaultsync-test-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(path);
-        _tempDirs.Add(path);
-        return path;
+        var directory = new TempDirectory();
+        _tempDirs.Add(directory);
+        return directory.Path;
     }
 }

--- a/tests/VaultSync.Core.Tests/SqliteRepositoryProjectUpdateTests.cs
+++ b/tests/VaultSync.Core.Tests/SqliteRepositoryProjectUpdateTests.cs
@@ -2,33 +2,26 @@ using System;
 using System.IO;
 using VaultSync.Core.Models;
 using VaultSync.Core.Repositories;
+using VaultSync.Core.Tests.TestSupport;
 using Xunit;
 
 namespace VaultSync.Core.Tests;
 
 public sealed class SqliteRepositoryProjectUpdateTests : IDisposable
 {
-    private readonly string _tempDir;
+    private readonly TempDirectory _tempDir = new();
     private readonly string _dbPath;
 
     public SqliteRepositoryProjectUpdateTests()
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"vaultsync-project-update-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_tempDir);
-        _dbPath = Path.Combine(_tempDir, "vaultsync.db");
+        _dbPath = Path.Combine(_tempDir.Path, "vaultsync.db");
     }
 
     [Fact]
     public void UpdateProjectPreset_PersistsTrimmedPreset()
     {
-        var repo = new SqliteRepository(_dbPath);
-        repo.EnsureSchema();
-        int projectId = repo.AddProject(new Project
-        {
-            Name = "Project",
-            RootPath = Path.Combine(_tempDir, "Project"),
-            Preset = "dotnet"
-        });
+        var repo = TestRepository.Create(_dbPath);
+        int projectId = TestRepository.AddProject(repo, "Project", Path.Combine(_tempDir.Path, "Project"));
 
         repo.UpdateProjectPreset(projectId, " unity ");
 
@@ -40,14 +33,8 @@ public sealed class SqliteRepositoryProjectUpdateTests : IDisposable
     [Fact]
     public void UpdateProjectPreset_BlankPreset_PersistsNoPreset()
     {
-        var repo = new SqliteRepository(_dbPath);
-        repo.EnsureSchema();
-        int projectId = repo.AddProject(new Project
-        {
-            Name = "Project",
-            RootPath = Path.Combine(_tempDir, "Project"),
-            Preset = "dotnet"
-        });
+        var repo = TestRepository.Create(_dbPath);
+        int projectId = TestRepository.AddProject(repo, "Project", Path.Combine(_tempDir.Path, "Project"));
 
         repo.UpdateProjectPreset(projectId, " ");
 
@@ -58,13 +45,6 @@ public sealed class SqliteRepositoryProjectUpdateTests : IDisposable
 
     public void Dispose()
     {
-        try
-        {
-            if (Directory.Exists(_tempDir))
-                Directory.Delete(_tempDir, recursive: true);
-        }
-        catch
-        {
-        }
+        _tempDir.Dispose();
     }
 }

--- a/tests/VaultSync.Core.Tests/TestSupport/BackupBuilder.cs
+++ b/tests/VaultSync.Core.Tests/TestSupport/BackupBuilder.cs
@@ -1,0 +1,61 @@
+using System;
+using VaultSync.Core.Models;
+
+namespace VaultSync.Core.Tests.TestSupport;
+
+public sealed class BackupBuilder
+{
+    private int _id = 10;
+    private int _projectId = 1;
+    private int _snapshotId = 11;
+    private string _externalId = "backup-1";
+    private DateTime _createdUtc = new(2026, 3, 13, 12, 0, 0, DateTimeKind.Utc);
+    private string _type = "auto";
+    private string _path = "vaultsync\\2026-03-13_12-00-00";
+    private string _destinationPath = string.Empty;
+
+    public BackupBuilder WithId(int id)
+    {
+        _id = id;
+        _snapshotId = id;
+        _externalId = $"backup-{id}";
+        return this;
+    }
+
+    public BackupBuilder ForProject(int projectId)
+    {
+        _projectId = projectId;
+        return this;
+    }
+
+    public BackupBuilder CreatedUtc(DateTime createdUtc)
+    {
+        _createdUtc = createdUtc;
+        return this;
+    }
+
+    public BackupBuilder Manual()
+    {
+        _type = "manual";
+        return this;
+    }
+
+    public BackupBuilder AtDestination(string destinationPath)
+    {
+        _destinationPath = destinationPath;
+        return this;
+    }
+
+    public Backup Build() =>
+        new()
+        {
+            Id = _id,
+            ProjectId = _projectId,
+            SnapshotId = _snapshotId,
+            ExternalId = _externalId,
+            CreatedUtc = _createdUtc,
+            Type = _type,
+            Path = _path,
+            DestinationPath = _destinationPath
+        };
+}

--- a/tests/VaultSync.Core.Tests/TestSupport/BackupDestinationBuilder.cs
+++ b/tests/VaultSync.Core.Tests/TestSupport/BackupDestinationBuilder.cs
@@ -1,0 +1,52 @@
+using VaultSync.Core.Config;
+
+namespace VaultSync.Core.Tests.TestSupport;
+
+public sealed class BackupDestinationBuilder
+{
+    private string _path = @"C:\Backups";
+    private string _alias = "Primary";
+    private bool _active = true;
+    private string _credentialName = string.Empty;
+    private bool _preMounted;
+
+    public BackupDestinationBuilder WithPath(string path)
+    {
+        _path = path;
+        return this;
+    }
+
+    public BackupDestinationBuilder WithAlias(string alias)
+    {
+        _alias = alias;
+        return this;
+    }
+
+    public BackupDestinationBuilder WithCredentialName(string credentialName)
+    {
+        _credentialName = credentialName;
+        return this;
+    }
+
+    public BackupDestinationBuilder Active(bool active = true)
+    {
+        _active = active;
+        return this;
+    }
+
+    public BackupDestinationBuilder PreMounted(bool preMounted = true)
+    {
+        _preMounted = preMounted;
+        return this;
+    }
+
+    public BackupDestination Build() =>
+        new()
+        {
+            Path = _path,
+            Alias = _alias,
+            Active = _active,
+            CredentialName = _credentialName,
+            PreMounted = _preMounted
+        };
+}

--- a/tests/VaultSync.Core.Tests/TestSupport/ProjectBuilder.cs
+++ b/tests/VaultSync.Core.Tests/TestSupport/ProjectBuilder.cs
@@ -1,0 +1,60 @@
+using VaultSync.Core.Models;
+
+namespace VaultSync.Core.Tests.TestSupport;
+
+public sealed class ProjectBuilder
+{
+    private int _id = 1;
+    private string _name = "VaultSync";
+    private string _rootPath = @"C:\Repo";
+    private string _preset = "default";
+    private string _preferredDestinationId = null;
+    private string _verificationPolicy = ProjectVerificationPolicy.Always;
+
+    public ProjectBuilder WithId(int id)
+    {
+        _id = id;
+        return this;
+    }
+
+    public ProjectBuilder WithName(string name)
+    {
+        _name = name;
+        return this;
+    }
+
+    public ProjectBuilder WithRootPath(string rootPath)
+    {
+        _rootPath = rootPath;
+        return this;
+    }
+
+    public ProjectBuilder WithPreset(string preset)
+    {
+        _preset = preset;
+        return this;
+    }
+
+    public ProjectBuilder WithPreferredDestinationId(string preferredDestinationId)
+    {
+        _preferredDestinationId = preferredDestinationId;
+        return this;
+    }
+
+    public ProjectBuilder WithVerificationPolicy(string policy)
+    {
+        _verificationPolicy = policy;
+        return this;
+    }
+
+    public Project Build() =>
+        new()
+        {
+            Id = _id,
+            Name = _name,
+            RootPath = _rootPath,
+            Preset = _preset,
+            PreferredDestinationId = _preferredDestinationId,
+            VerificationPolicy = _verificationPolicy
+        };
+}

--- a/tests/VaultSync.Core.Tests/TestSupport/TempDirectory.cs
+++ b/tests/VaultSync.Core.Tests/TestSupport/TempDirectory.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+using System.Threading;
+
+namespace VaultSync.Core.Tests.TestSupport;
+
+public sealed class TempDirectory : IDisposable
+{
+    private const int MaxDeleteAttempts = 3;
+
+    public TempDirectory()
+    {
+        Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"vaultsync-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path);
+    }
+
+    public string Path { get; }
+
+    public void Dispose()
+    {
+        for (int attempt = 1; attempt <= MaxDeleteAttempts; attempt++)
+        {
+            try
+            {
+                if (Directory.Exists(Path))
+                    Directory.Delete(Path, recursive: true);
+
+                return;
+            }
+            catch when (attempt < MaxDeleteAttempts)
+            {
+                Thread.Sleep(25 * attempt);
+            }
+            catch
+            {
+                // Ignore cleanup failures in tests.
+            }
+        }
+    }
+}

--- a/tests/VaultSync.Core.Tests/TestSupport/TestAppConfigScope.cs
+++ b/tests/VaultSync.Core.Tests/TestSupport/TestAppConfigScope.cs
@@ -1,0 +1,28 @@
+using System;
+using VaultSync.Core.Config;
+
+namespace VaultSync.Core.Tests.TestSupport;
+
+public sealed class TestAppConfigScope : IDisposable
+{
+    private readonly TempDirectory _directory = new();
+    private readonly IDisposable _configScope;
+    private bool _disposed;
+
+    public TestAppConfigScope()
+    {
+        _configScope = AppConfigStore.UseDirectoryForTests(_directory.Path);
+    }
+
+    public string ConfigDirectory => _directory.Path;
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _configScope.Dispose();
+        _directory.Dispose();
+        _disposed = true;
+    }
+}

--- a/tests/VaultSync.Core.Tests/TestSupport/TestRepository.cs
+++ b/tests/VaultSync.Core.Tests/TestSupport/TestRepository.cs
@@ -1,0 +1,33 @@
+using System;
+using VaultSync.Core.Models;
+using VaultSync.Core.Repositories;
+
+namespace VaultSync.Core.Tests.TestSupport;
+
+public static class TestRepository
+{
+    public static SqliteRepository Create(string dbPath)
+    {
+        var repo = new SqliteRepository(dbPath);
+        repo.EnsureSchema();
+        return repo;
+    }
+
+    public static int AddProject(
+        SqliteRepository repo,
+        string name,
+        string rootPath,
+        string preset = "dotnet",
+        DateTime? createdUtc = null)
+    {
+        var project = new Project
+        {
+            Name = name,
+            RootPath = rootPath,
+            Preset = preset,
+            CreatedUtc = createdUtc ?? DateTime.UtcNow
+        };
+
+        return repo.AddProject(project);
+    }
+}

--- a/tests/VaultSync.Core.Tests/VaultSync.Core.Tests.csproj
+++ b/tests/VaultSync.Core.Tests/VaultSync.Core.Tests.csproj
@@ -6,10 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary
- Prepare VaultSync 1.7.5 release metadata, installer version, changelog, and What's New notes.
- Centralize package versions and shared config/logging/formatting helpers.
- Consolidate UI property notifications, test fixtures, and reusable builders.
- Add verbose runtime timings and a durable unchanged-source cache for background metadata auto-imports.

## Tracking issues
Closes #323
Closes #324
Closes #325
Closes #326
Closes #327

## Validation
- dotnet build VaultSync.sln --no-restore
- dotnet test VaultSync.sln --no-restore
- git diff --check origin/Dev..HEAD

## Notes
This PR targets Dev for the 1.7.5 train. The metadata import skip is limited to background read-only auto-imports after a previous successful unchanged source import; manual refresh remains authoritative.