### PR TITLE
Fix metadata export lock contention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [VS-1818] Extended CI, PR quality gates, and CodeQL triggers to the active `release/v1.8` branch.
 - [VS-1820] Scoped release checks to the exact 1.8.0 milestone, aligned release docs, and enforced locale key parity.
 ### Fixed
+- [BUG-18056] Metadata exports now skip backups removed before asynchronous export and commit each shared SQLite metadata update atomically, reducing false invalid-store reports and lock contention.
 - [BUG-18055] Replaced the vulnerable SQLite native bundle with the maintained SQLitePCLRaw 3.x package graph.
 - [BUG-18054] Patched .NET 10 runtime-pack servicing alerts by pinning ASP.NET Core runtime downloads and Microsoft platform packages to `10.0.9`.
 - [BUG-18053] Restore target folders and sandbox apply paths now stay under their intended roots when project names or relative paths contain unsafe segments.

--- a/src/VaultSync.Core/Services/MetadataStore.cs
+++ b/src/VaultSync.Core/Services/MetadataStore.cs
@@ -16,6 +16,8 @@ public sealed class MetadataStore
 
     private readonly string _dbPath;
     private readonly bool _allowReadRecovery;
+    private SqliteConnection? _activeWriteConnection;
+    private SqliteTransaction? _activeWriteTransaction;
 
     public MetadataStore(string rootPath, bool allowReadRecovery = false)
     {
@@ -25,6 +27,28 @@ public sealed class MetadataStore
     }
 
     public string DatabasePath => _dbPath;
+
+    public void ExecuteWriteBatch(Action writeAction)
+    {
+        ArgumentNullException.ThrowIfNull(writeAction);
+        if (_activeWriteConnection is not null)
+            throw new InvalidOperationException("A metadata write batch is already active.");
+
+        using SqliteConnection connection = Open(write: true);
+        using SqliteTransaction transaction = connection.BeginTransaction(deferred: false);
+        _activeWriteConnection = connection;
+        _activeWriteTransaction = transaction;
+        try
+        {
+            writeAction();
+            transaction.Commit();
+        }
+        finally
+        {
+            _activeWriteTransaction = null;
+            _activeWriteConnection = null;
+        }
+    }
 
     public void EnsureSchema()
     {
@@ -147,9 +171,9 @@ public sealed class MetadataStore
 
     public void UpsertMetaInfo(MetaInfo info)
     {
-        using SqliteConnection c = Open(write: true);
-        c.Execute("DELETE FROM meta_info;");
-        c.Execute(
+        ExecuteWrite(
+            "DELETE FROM meta_info;");
+        ExecuteWrite(
             """
             INSERT INTO meta_info(schema_version, created_utc, last_write_utc, writer_app_version, writer_machine_id)
             VALUES(@SchemaVersion, @CreatedUtc, @LastWriteUtc, @WriterAppVersion, @WriterMachineId);
@@ -166,8 +190,7 @@ public sealed class MetadataStore
 
     public void UpsertProject(MetaProject project)
     {
-        using SqliteConnection c = Open(write: true);
-        c.Execute(
+        ExecuteWrite(
             """
             INSERT INTO projects(external_id, name, preset, root_path_hint, created_utc, settings_json, updated_utc)
             VALUES(@ExternalId, @Name, @Preset, @RootPathHint, @CreatedUtc, @SettingsJson, @UpdatedUtc)
@@ -192,8 +215,7 @@ public sealed class MetadataStore
 
     public void UpsertSnapshot(MetaSnapshot snapshot)
     {
-        using SqliteConnection c = Open(write: true);
-        c.Execute(
+        ExecuteWrite(
             """
             INSERT INTO snapshots(
               external_id,
@@ -248,8 +270,7 @@ public sealed class MetadataStore
         var descriptor = BackupCryptoDescriptor.FromMetadata(backup.IsEncrypted, backup.KdfParamsJson);
         string descriptorJson = descriptor.ToMetadataJson(backup.IsEncrypted);
 
-        using SqliteConnection c = Open(write: true);
-        c.Execute(
+        ExecuteWrite(
             """
             INSERT INTO backups(external_id, project_external_id, snapshot_external_id, created_utc, type, backup_mode, total_bytes, path_rel, destination_alias, origin_machine_name, is_protected, enc_flag, kdf_params_json)
             VALUES(@ExternalId, @ProjectExternalId, @SnapshotExternalId, @CreatedUtc, @Type, @BackupMode, @TotalBytes, @PathRel, @DestinationAlias, @OriginMachineName, @IsProtected, @EncFlag, @KdfParamsJson)
@@ -287,8 +308,7 @@ public sealed class MetadataStore
 
     public void AddTombstone(MetaTombstone tombstone)
     {
-        using SqliteConnection c = Open(write: true);
-        c.Execute(
+        ExecuteWrite(
             """
             INSERT INTO tombstones(entity_type, entity_id, deleted_utc, origin_machine_id)
             VALUES(@EntityType, @EntityId, @DeletedUtc, @OriginMachineId)
@@ -301,6 +321,18 @@ public sealed class MetadataStore
                 DeletedUtc = ToUtcString(tombstone.DeletedUtc),
                 tombstone.OriginMachineId
             });
+    }
+
+    private void ExecuteWrite(string sql, object? param = null)
+    {
+        if (_activeWriteConnection is not null)
+        {
+            _activeWriteConnection.Execute(sql, param, _activeWriteTransaction);
+            return;
+        }
+
+        using SqliteConnection connection = Open(write: true);
+        connection.Execute(sql, param);
     }
 
     public IEnumerable<MetaProject> ListProjects()

--- a/src/VaultSync.Core/Services/MetadataSyncService.cs
+++ b/src/VaultSync.Core/Services/MetadataSyncService.cs
@@ -1898,8 +1898,11 @@ public sealed class MetadataSyncService(SqliteRepository repo, IAppConfigStore? 
 
         try
         {
-            store.UpsertMetaInfo(metaInfo);
-            AddTombstones(store, externalIds, entityType, now, machineId);
+            store.ExecuteWriteBatch(() =>
+            {
+                store.UpsertMetaInfo(metaInfo);
+                AddTombstones(store, externalIds, entityType, now, machineId);
+            });
         }
         catch (Exception ex)
         {
@@ -2078,16 +2081,19 @@ public sealed class MetadataSyncService(SqliteRepository repo, IAppConfigStore? 
 
         try
         {
-            store.UpsertMetaInfo(metaInfo);
-            store.UpsertProject(new MetaProject
+            store.ExecuteWriteBatch(() =>
             {
-                ExternalId = projectExternalId,
-                Name = project.Name,
-                Preset = project.Preset,
-                RootPathHint = project.RootPath,
-                CreatedUtc = project.CreatedUtc,
-                SettingsJson = BuildProjectSettingsJson(project),
-                UpdatedUtc = now
+                store.UpsertMetaInfo(metaInfo);
+                store.UpsertProject(new MetaProject
+                {
+                    ExternalId = projectExternalId,
+                    Name = project.Name,
+                    Preset = project.Preset,
+                    RootPathHint = project.RootPath,
+                    CreatedUtc = project.CreatedUtc,
+                    SettingsJson = BuildProjectSettingsJson(project),
+                    UpdatedUtc = now
+                });
             });
         }
         catch (Exception ex) when (ex is not SqliteException sqliteEx || !IsCannotOpenOrLocked(sqliteEx))
@@ -2176,6 +2182,39 @@ public sealed class MetadataSyncService(SqliteRepository repo, IAppConfigStore? 
             return MetadataSyncResult.Failure(MetadataSyncStatus.InvalidPath, "Root path is empty.");
         }
 
+        Backup? backup = _repo.GetBackupById(backupId);
+        if (backup == null)
+        {
+            Console.WriteLine($"[MetadataSync] Export skipped: backup {backupId} no longer exists.");
+            return new MetadataSyncResult(
+                MetadataSyncStatus.Success,
+                0,
+                0,
+                0,
+                0,
+                "Backup no longer exists; metadata export skipped.");
+        }
+
+        Project? project = _repo.GetProjectById(backup.ProjectId);
+        if (project == null)
+        {
+            Console.WriteLine($"[MetadataSync] Export failed: project {backup.ProjectId} not found.");
+            return MetadataSyncResult.Failure(MetadataSyncStatus.InvalidStore, "Project not found.");
+        }
+
+        Snapshot? snapshot = _repo.GetSnapshotById(backup.SnapshotId);
+        if (snapshot == null)
+        {
+            Console.WriteLine($"[MetadataSync] Export skipped: snapshot {backup.SnapshotId} no longer exists.");
+            return new MetadataSyncResult(
+                MetadataSyncStatus.Success,
+                0,
+                0,
+                0,
+                0,
+                "Snapshot no longer exists; metadata export skipped.");
+        }
+
         TryFlushDeferredExport(rootPath);
 
         string storeRoot = rootPath;
@@ -2197,27 +2236,6 @@ public sealed class MetadataSyncService(SqliteRepository repo, IAppConfigStore? 
         {
             Console.WriteLine($"[MetadataSync] Export failed: store init error at '{rootPath}': {ex.Message}");
             return MetadataSyncResult.Failure(MetadataSyncStatus.WriteFailed, ex.Message);
-        }
-
-        Backup? backup = _repo.GetBackupById(backupId);
-        if (backup == null)
-        {
-            Console.WriteLine($"[MetadataSync] Export failed: backup {backupId} not found.");
-            return MetadataSyncResult.Failure(MetadataSyncStatus.InvalidStore, "Backup not found.");
-        }
-
-        Project? project = _repo.GetProjectById(backup.ProjectId);
-        if (project == null)
-        {
-            Console.WriteLine($"[MetadataSync] Export failed: project {backup.ProjectId} not found.");
-            return MetadataSyncResult.Failure(MetadataSyncStatus.InvalidStore, "Project not found.");
-        }
-
-        Snapshot? snapshot = _repo.GetSnapshotById(backup.SnapshotId);
-        if (snapshot == null)
-        {
-            Console.WriteLine($"[MetadataSync] Export failed: snapshot {backup.SnapshotId} not found.");
-            return MetadataSyncResult.Failure(MetadataSyncStatus.InvalidStore, "Snapshot not found.");
         }
 
         string projectExternalId = EnsureProjectExternalId(project);
@@ -2247,63 +2265,65 @@ public sealed class MetadataSyncService(SqliteRepository repo, IAppConfigStore? 
         int exportedProjects = 0;
         int exportedSnapshots = 0;
         int exportedBackups = 0;
-        bool backfilled = false;
+        bool backfilled = forceBackfill || !store.HasProject(projectExternalId);
 
         try
         {
-            store.UpsertMetaInfo(metaInfo);
-        if (forceBackfill || !store.HasProject(projectExternalId))
-        {
-            backfilled = true;
-                (int snapshots, int backups) = ExportProjectHistory(store, project, projectExternalId, now, machineId);
-            exportedProjects = 1;
-            exportedSnapshots = snapshots;
-            exportedBackups = backups;
-            }
-            else
+            store.ExecuteWriteBatch(() =>
             {
-                store.UpsertProject(new MetaProject
+                store.UpsertMetaInfo(metaInfo);
+                if (backfilled)
                 {
-                    ExternalId = projectExternalId,
-                    Name = project.Name,
-                    Preset = project.Preset,
-                    RootPathHint = project.RootPath,
-                    CreatedUtc = project.CreatedUtc,
-                    SettingsJson = BuildProjectSettingsJson(project),
-                    UpdatedUtc = now
-                });
-                store.UpsertSnapshot(new MetaSnapshot
+                    (int snapshots, int backups) = ExportProjectHistory(store, project, projectExternalId, now, machineId);
+                    exportedProjects = 1;
+                    exportedSnapshots = snapshots;
+                    exportedBackups = backups;
+                }
+                else
                 {
-                    ExternalId = snapshotExternalId,
-                    ProjectExternalId = projectExternalId,
-                    CreatedUtc = snapshot.CreatedUtc,
-                    FileCount = snapshot.FileCount,
-                    TotalBytes = snapshot.TotalBytes,
-                    DiffAdded = snapshot.DiffAdded,
-                    DiffModified = snapshot.DiffModified,
-                    DiffDeleted = snapshot.DiffDeleted,
-                    DiffNetBytes = snapshot.DiffNetBytes,
-                    DiffTopPathsJson = string.IsNullOrWhiteSpace(snapshot.DiffTopPathsJson) ? "[]" : snapshot.DiffTopPathsJson
-                });
-                var descriptor = BackupCryptoDescriptor.FromMetadata(backup.IsEncrypted, backup.CryptoDescriptorJson);
-                store.UpsertBackup(new MetaBackup
-                {
-                    ExternalId = backupExternalId,
-                    ProjectExternalId = projectExternalId,
-                    SnapshotExternalId = snapshotExternalId,
-                    CreatedUtc = backup.CreatedUtc,
-                    Type = backup.Type,
-                    BackupMode = BackupModes.Normalize(backup.BackupMode),
-                    TotalBytes = backup.TotalBytes,
-                    PathRel = backup.Path,
-                    DestinationAlias = backup.DestinationAlias ?? string.Empty,
-                    OriginMachineName = machineId,
-                    IsProtected = backup.IsProtected,
-                    IsEncrypted = backup.IsEncrypted,
-                    KdfParamsJson = descriptor.ToMetadataJson(backup.IsEncrypted)
-                });
-                exportedBackups = 1;
-            }
+                    store.UpsertProject(new MetaProject
+                    {
+                        ExternalId = projectExternalId,
+                        Name = project.Name,
+                        Preset = project.Preset,
+                        RootPathHint = project.RootPath,
+                        CreatedUtc = project.CreatedUtc,
+                        SettingsJson = BuildProjectSettingsJson(project),
+                        UpdatedUtc = now
+                    });
+                    store.UpsertSnapshot(new MetaSnapshot
+                    {
+                        ExternalId = snapshotExternalId,
+                        ProjectExternalId = projectExternalId,
+                        CreatedUtc = snapshot.CreatedUtc,
+                        FileCount = snapshot.FileCount,
+                        TotalBytes = snapshot.TotalBytes,
+                        DiffAdded = snapshot.DiffAdded,
+                        DiffModified = snapshot.DiffModified,
+                        DiffDeleted = snapshot.DiffDeleted,
+                        DiffNetBytes = snapshot.DiffNetBytes,
+                        DiffTopPathsJson = string.IsNullOrWhiteSpace(snapshot.DiffTopPathsJson) ? "[]" : snapshot.DiffTopPathsJson
+                    });
+                    var descriptor = BackupCryptoDescriptor.FromMetadata(backup.IsEncrypted, backup.CryptoDescriptorJson);
+                    store.UpsertBackup(new MetaBackup
+                    {
+                        ExternalId = backupExternalId,
+                        ProjectExternalId = projectExternalId,
+                        SnapshotExternalId = snapshotExternalId,
+                        CreatedUtc = backup.CreatedUtc,
+                        Type = backup.Type,
+                        BackupMode = BackupModes.Normalize(backup.BackupMode),
+                        TotalBytes = backup.TotalBytes,
+                        PathRel = backup.Path,
+                        DestinationAlias = backup.DestinationAlias ?? string.Empty,
+                        OriginMachineName = machineId,
+                        IsProtected = backup.IsProtected,
+                        IsEncrypted = backup.IsEncrypted,
+                        KdfParamsJson = descriptor.ToMetadataJson(backup.IsEncrypted)
+                    });
+                    exportedBackups = 1;
+                }
+            });
         }
         catch (Exception ex) when (ex is not SqliteException sqliteEx || !IsCannotOpenOrLocked(sqliteEx))
         {
@@ -2412,8 +2432,11 @@ public sealed class MetadataSyncService(SqliteRepository repo, IAppConfigStore? 
                 machineId,
                 updateExistingAppVersion: true);
 
-            store.UpsertMetaInfo(metaInfo);
-            AddTombstones(store, [backupExternalId], "backup", now, machineId);
+            store.ExecuteWriteBatch(() =>
+            {
+                store.UpsertMetaInfo(metaInfo);
+                AddTombstones(store, [backupExternalId], "backup", now, machineId);
+            });
 
             Console.WriteLine($"[MetadataSync] Tombstone export deferred locally for '{rootPath}'.");
         }
@@ -2456,8 +2479,11 @@ public sealed class MetadataSyncService(SqliteRepository repo, IAppConfigStore? 
 
         try
         {
-            store.UpsertMetaInfo(metaInfo);
-            AddTombstones(store, [backupExternalId], "backup", now, machineId);
+            store.ExecuteWriteBatch(() =>
+            {
+                store.UpsertMetaInfo(metaInfo);
+                AddTombstones(store, [backupExternalId], "backup", now, machineId);
+            });
         }
         catch (Exception ex) when (ex is not SqliteException sqliteEx || !IsCannotOpenOrLocked(sqliteEx))
         {

--- a/src/VaultSync.UI/ViewModels/AppViewModel.RuntimeOps.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.RuntimeOps.cs
@@ -1246,7 +1246,10 @@ namespace VaultSync.UI.ViewModels
                     Console.WriteLine($"[MetadataSync] Export ({name}) result: {result.Status}.");
                     if (forceBackfillOverride is null &&
                         dest.ForceMetadataBackfill &&
-                        result.Status == MetadataSyncStatus.Success)
+                        result.Status == MetadataSyncStatus.Success &&
+                        (result.ImportedProjects > 0 ||
+                         result.ImportedSnapshots > 0 ||
+                         result.ImportedBackups > 0))
                     {
                         ClearDestinationForceBackfill(dest);
                     }

--- a/tests/VaultSync.Core.Tests/MetadataSyncTests.cs
+++ b/tests/VaultSync.Core.Tests/MetadataSyncTests.cs
@@ -914,6 +914,48 @@ public sealed class MetadataSyncTests : IDisposable
     }
 
     [Fact]
+    public void ExportBackupToStore_MissingBackup_SkipsWithoutCreatingStore()
+    {
+        string metaRoot = CreateTempDir();
+        string dbPath = Path.Combine(CreateTempDir(), "vaultsync.db");
+        SqliteRepository repo = CreateRepository(dbPath);
+        var service = new MetadataSyncService(repo);
+
+        MetadataSyncResult result = service.ExportBackupToStore(metaRoot, 180, "1.8.0", "machine-d");
+
+        Assert.Equal(MetadataSyncStatus.Success, result.Status);
+        Assert.Equal(0, result.ImportedProjects);
+        Assert.Equal(0, result.ImportedSnapshots);
+        Assert.Equal(0, result.ImportedBackups);
+        Assert.False(File.Exists(new MetadataStore(metaRoot).DatabasePath));
+    }
+
+    [Fact]
+    public void MetadataStore_WriteBatch_RollsBackAllWritesOnFailure()
+    {
+        string metaRoot = CreateTempDir();
+        MetadataStore store = CreateStore(metaRoot);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            store.ExecuteWriteBatch(() =>
+            {
+                store.UpsertProject(new MetaProject
+                {
+                    ExternalId = "project-batch",
+                    Name = "Batch Project",
+                    Preset = "generic",
+                    RootPathHint = CreateTempDir(),
+                    CreatedUtc = DateTime.UtcNow,
+                    SettingsJson = "{}",
+                    UpdatedUtc = DateTime.UtcNow
+                });
+                throw new InvalidOperationException("Simulated export failure.");
+            }));
+
+        Assert.Empty(store.ListProjects());
+    }
+
+    [Fact]
     public void ImportFromStore_ProjectSettings_AppliesEncryptionPolicyAndKeyRef()
     {
         string metaRoot = CreateTempDir();


### PR DESCRIPTION
## What changed

- Skip asynchronous metadata exports when the referenced backup or snapshot was removed before the worker starts, without touching the destination store.
- Write each metadata export or tombstone update through one immediate SQLite transaction instead of several independent write connections.
- Preserve the force-backfill flag when an export was skipped without writing data.
- Add regression tests for stale backup IDs and transactional rollback.
- Document the fix as BUG-18056 in the 1.8.0 changelog.

## Root cause

Metadata export runs asynchronously using a backup ID. A backup could be removed before the worker loaded it, but the worker initialized the shared store first and then reported the missing backup as `InvalidStore`. Successful exports also opened a new SQLite connection for every upsert, creating several lock-acquisition windows against the shared/network metadata database.

## Impact

Stale export jobs now finish as harmless no-op successes, and real exports hold one short atomic write transaction. This substantially reduces misleading invalid-store logs and SQLite lock contention while preventing partial metadata updates.

## Validation

- `dotnet build VaultSync.sln -c Release --no-restore -warnaserror`
- `dotnet test tests/VaultSync.Core.Tests/VaultSync.Core.Tests.csproj -c Release --no-restore` (229 passed)
- `dotnet list VaultSync.sln package --vulnerable --include-transitive` (no vulnerable packages)
- `git diff --check`