### PR TITLE
Harden updater and public repository security

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Default owner and security-sensitive repository controls.
+* @ATAC-Helicopter
+
+/.github/ @ATAC-Helicopter
+/SECURITY.md @ATAC-Helicopter
+/Directory.Packages.props @ATAC-Helicopter
+/src/VaultSync.Core/Services/BackupArchiveCryptoService.cs @ATAC-Helicopter
+/src/VaultSync.Core/Services/BackupEncryptionSecretService.cs @ATAC-Helicopter
+/src/VaultSync.Core/Services/CredentialVault.cs @ATAC-Helicopter
+/src/VaultSync.UI/Services/GitHubUpdateService.cs @ATAC-Helicopter
+/src/VaultSync.UI/Services/PatchInstallService.cs @ATAC-Helicopter
+/src/VaultSync.UI/Services/PatchUpdateService.cs @ATAC-Helicopter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [ "Dev", "Stable", "release/v1.8" ]
+    branches: [ "Dev", "Stable", "release/v*" ]
   push:
-    branches: [ "Dev", "Stable", "release/v1.8" ]
+    branches: [ "Dev", "Stable", "release/v*" ]
   workflow_dispatch:
 
 permissions:
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: "10.0.x"
 
@@ -43,10 +43,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: "10.0.x"
 
@@ -65,10 +65,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: "10.0.x"
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,9 +14,9 @@ name: "CodeQL Advanced"
 on:
   workflow_dispatch:
   push:
-    branches: [ "Dev", "Stable", "release/v1.8" ]
+    branches: [ "Dev", "Stable", "release/v*" ]
   pull_request:
-    branches: [ "Dev", "Stable", "release/v1.8" ]
+    branches: [ "Dev", "Stable", "release/v*" ]
   schedule:
     - cron: '31 14 * * 4'
 
@@ -60,7 +60,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -70,7 +70,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@bce182f857edf1feab116e9795a3393d21977282 # v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -99,6 +99,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@bce182f857edf1feab116e9795a3393d21977282 # v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/download-stats.yml
+++ b/.github/workflows/download-stats.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
 

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -2,9 +2,9 @@ name: PR Quality Gates
 
 on:
   pull_request:
-    branches: [ "Dev", "Stable", "release/v1.8" ]
+    branches: [ "Dev", "Stable", "release/v*" ]
   push:
-    branches: [ "Dev", "Stable", "release/v1.8" ]
+    branches: [ "Dev", "Stable", "release/v*" ]
   workflow_dispatch:
 
 permissions:
@@ -26,7 +26,7 @@ jobs:
       workflows_changed: ${{ steps.detect.outputs.workflows_changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
@@ -84,11 +84,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Lint GitHub YAML files
         run: |
-          npx --yes --ignore-scripts yaml-lint \
+          npx --yes --ignore-scripts yaml-lint@1.7.0 \
             .github/workflows/*.yml \
             .github/ISSUE_TEMPLATE/*.yml \
             .github/dependabot.yml
@@ -100,10 +100,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.x"
 
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Run local release gate
         shell: pwsh
@@ -130,15 +130,15 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: "10.0.x"
 
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2
 
       - name: Validate Store manifest metadata
         shell: pwsh

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -45,7 +45,7 @@ jobs:
       patch_base_versions: ${{ steps.validate_inputs.outputs.patch_base_versions }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Validate release inputs
         id: validate_inputs
@@ -188,10 +188,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: "10.0.x"
 
@@ -221,16 +221,16 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: "10.0.x"
 
       - name: Setup MSBuild
         if: ${{ inputs.include_store_upload }}
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2
 
       - name: Install Microsoft Store packaging workload
         if: ${{ inputs.include_store_upload }}
@@ -424,7 +424,7 @@ jobs:
           Add-Content $env:GITHUB_STEP_SUMMARY "- Upload artifact: ``$targetPath``"
 
       - name: Upload Windows artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: windows-release-assets
           if-no-files-found: error
@@ -435,7 +435,7 @@ jobs:
 
       - name: Upload Microsoft Store artifact
         if: ${{ inputs.include_store_upload }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: windows-store-upload
           if-no-files-found: error
@@ -448,10 +448,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: "10.0.x"
 
@@ -525,7 +525,7 @@ jobs:
           done
 
       - name: Upload macOS artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: macos-release-assets
           if-no-files-found: error
@@ -542,10 +542,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: "10.0.x"
 
@@ -628,7 +628,7 @@ jobs:
           done
 
       - name: Upload Linux artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: linux-release-assets
           if-no-files-found: error

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -2,9 +2,9 @@ name: SonarQube
 
 on:
   pull_request:
-    branches: [ "Dev", "Stable", "release/v1.8" ]
+    branches: [ "Dev", "Stable", "release/v*" ]
   push:
-    branches: [ "Dev", "Stable", "release/v1.8" ]
+    branches: [ "Dev", "Stable", "release/v*" ]
   workflow_dispatch:
 
 permissions:
@@ -50,19 +50,19 @@ jobs:
 
       - name: Checkout
         if: steps.config.outputs.configured == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
       - name: Setup .NET
         if: steps.config.outputs.configured == 'true'
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: "10.0.x"
 
       - name: Setup Java
         if: steps.config.outputs.configured == 'true'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: "17"
@@ -70,8 +70,8 @@ jobs:
       - name: Install analysis tools
         if: steps.config.outputs.configured == 'true'
         run: |
-          dotnet tool install --global dotnet-sonarscanner
-          dotnet tool install --global dotnet-coverage
+          dotnet tool install --global dotnet-sonarscanner --version 11.2.1
+          dotnet tool install --global dotnet-coverage --version 18.9.0
           echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
 
       - name: Restore

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,9 @@ Preferred channel:
 - GitHub Security Advisory (private report)
 
 Fallback channel:
-- GitHub issue/discussion with minimal sensitive details, requesting private follow-up
+- Email the maintainer listed on the repository owner's GitHub profile
+
+Do not open a public issue or discussion for a suspected vulnerability.
 
 Please include:
 - affected version

--- a/src/VaultSync.UI/Infrastructure/SafeZipExtractor.cs
+++ b/src/VaultSync.UI/Infrastructure/SafeZipExtractor.cs
@@ -49,12 +49,18 @@ internal static class SafeZipExtractor
     {
         string normalized = (entryFullName ?? string.Empty)
             .Replace('/', Path.DirectorySeparatorChar)
+            .Replace('\\', Path.DirectorySeparatorChar)
             .Trim();
 
         if (string.IsNullOrWhiteSpace(normalized))
             return string.Empty;
 
-        if (Path.IsPathFullyQualified(normalized))
+        bool hasDrivePrefix = normalized.Length >= 2 &&
+                              char.IsLetter(normalized[0]) &&
+                              normalized[1] == ':';
+        if (Path.IsPathFullyQualified(normalized) ||
+            Path.IsPathRooted(normalized) ||
+            hasDrivePrefix)
             throw new InvalidDataException($"Archive entry '{entryFullName}' is absolute.");
 
         string root = NormalizeRoot(Path.Combine(Path.GetTempPath(), "vaultsync-archive-root"));

--- a/src/VaultSync.UI/Services/PatchInstallService.cs
+++ b/src/VaultSync.UI/Services/PatchInstallService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
@@ -265,23 +266,10 @@ namespace VaultSync.UI.Services
 
         private static string PrepareHelperDirectory(string installDir)
         {
-            string root = Path.Combine(Path.GetTempPath(), TempRootName);
-            Directory.CreateDirectory(root);
-
-            string helperDir = Path.Combine(root, "patch-helper");
-            try
-            {
-                if (Directory.Exists(helperDir))
-                {
-                    Directory.Delete(helperDir, recursive: true);
-                }
-            }
-            catch
-            {
-                helperDir = Path.Combine(root, $"patch-helper-{Guid.NewGuid():N}");
-            }
-
+            string root = GetTrustedPatchRoot();
+            string helperDir = Path.Combine(root, $"patch-helper-{Guid.NewGuid():N}");
             Directory.CreateDirectory(helperDir);
+            RestrictDirectoryToCurrentUser(helperDir);
             CopyInstallToHelper(installDir, helperDir);
             return helperDir;
         }
@@ -314,8 +302,7 @@ namespace VaultSync.UI.Services
             Action<string>? onLog,
             CancellationToken cancellationToken)
         {
-            string logDir = Path.Combine(Path.GetTempPath(), TempRootName);
-            Directory.CreateDirectory(logDir);
+            string logDir = GetTrustedPatchRoot();
             string logPath = Path.Combine(logDir, "patch-helper.log");
 
             using var log = new StreamWriter(logPath, append: true) { AutoFlush = true };
@@ -364,14 +351,18 @@ namespace VaultSync.UI.Services
                 PatchManifest? manifest = JsonSerializer.Deserialize<PatchManifest>(File.ReadAllText(request.ManifestPath));
                 if (manifest is null)
                     throw new InvalidOperationException("Unable to parse patch manifest.");
+                if (!PatchUpdateService.TryValidatePatchManifest(manifest, out string? manifestStatus, out string? manifestError))
+                    throw new InvalidOperationException($"Patch manifest rejected ({manifestStatus}): {manifestError}");
                 VerifyBaseVersionCompatibility(manifest);
                 VerifyArchivePreflight(request.ArchivePath, manifest);
 
-                string stagingDir = Path.Combine(Path.GetTempPath(), TempRootName, $"patch-{Guid.NewGuid():N}");
+                string stagingDir = Path.Combine(GetTrustedPatchRoot(), $"patch-{Guid.NewGuid():N}");
                 Directory.CreateDirectory(stagingDir);
+                RestrictDirectoryToCurrentUser(stagingDir);
 
                 try
                 {
+                    VerifyArchiveContents(manifest, request.ArchivePath);
                     LogLine("Extracting patch archive.");
                     SafeZipExtractor.ExtractToDirectory(request.ArchivePath, stagingDir);
                     LogLine("Verifying extracted files.");
@@ -493,18 +484,45 @@ namespace VaultSync.UI.Services
             if (!info.Exists)
                 throw new FileNotFoundException("Patch archive not found.", archivePath);
 
-            if (manifest.ArchiveSize > 0 && info.Length != manifest.ArchiveSize)
+            if (info.Length != manifest.ArchiveSize)
             {
                 throw new InvalidOperationException(
                     $"Patch archive size mismatch. Expected {manifest.ArchiveSize}, got {info.Length}.");
             }
 
-            if (!string.IsNullOrWhiteSpace(manifest.ArchiveSha256))
+            string actual = ComputeSha256(archivePath);
+            string expected = manifest.ArchiveSha256.Trim();
+            if (!actual.Equals(expected, StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException("Patch archive checksum mismatch.");
+        }
+
+        private static void VerifyArchiveContents(PatchManifest manifest, string archivePath)
+        {
+            var expected = manifest.Files.ToDictionary(
+                file => SafeZipExtractor.GetSafeEntryRelativePath(file.RelativePath).Replace('\\', '/'),
+                file => file,
+                StringComparer.OrdinalIgnoreCase);
+            var found = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            using ZipArchive archive = ZipFile.OpenRead(archivePath);
+            foreach (ZipArchiveEntry entry in archive.Entries)
             {
-                string actual = ComputeSha256(archivePath);
-                string expected = manifest.ArchiveSha256.Trim();
-                if (!actual.Equals(expected, StringComparison.OrdinalIgnoreCase))
-                    throw new InvalidOperationException("Patch archive checksum mismatch.");
+                if (string.IsNullOrEmpty(entry.Name))
+                    continue;
+
+                string relative = SafeZipExtractor.GetSafeEntryRelativePath(entry.FullName).Replace('\\', '/');
+                if (!found.Add(relative))
+                    throw new InvalidDataException($"Patch archive contains duplicate file '{relative}'.");
+                if (!expected.TryGetValue(relative, out PatchFileEntry? file))
+                    throw new InvalidDataException($"Patch archive contains unexpected file '{relative}'.");
+                if (entry.Length != file.Size)
+                    throw new InvalidDataException($"Patch archive file size mismatch for '{relative}'.");
+            }
+
+            if (found.Count != expected.Count)
+            {
+                string missing = expected.Keys.First(path => !found.Contains(path));
+                throw new InvalidDataException($"Patch archive is missing manifest file '{missing}'.");
             }
         }
 
@@ -540,7 +558,7 @@ namespace VaultSync.UI.Services
             try
             {
                 string normalizedPath = Path.GetFullPath(path);
-                string root = Path.Combine(Path.GetTempPath(), TempRootName);
+                string root = GetTrustedPatchRoot();
                 string normalizedRoot = Path.GetFullPath(root)
                     .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
                     + Path.DirectorySeparatorChar;
@@ -550,6 +568,28 @@ namespace VaultSync.UI.Services
             {
                 return false;
             }
+        }
+
+        private static string GetTrustedPatchRoot()
+        {
+            string appData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            if (string.IsNullOrWhiteSpace(appData))
+                throw new InvalidOperationException("Current-user application data directory is unavailable.");
+
+            string root = Path.Combine(appData, TempRootName, "patch-runtime");
+            Directory.CreateDirectory(root);
+            RestrictDirectoryToCurrentUser(root);
+            return root;
+        }
+
+        private static void RestrictDirectoryToCurrentUser(string path)
+        {
+            if (OperatingSystem.IsWindows())
+                return;
+
+            File.SetUnixFileMode(
+                path,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
         }
 
         private static PatchElevationKind GetElevationKind(string installDir)

--- a/src/VaultSync.UI/Services/PatchUpdateService.cs
+++ b/src/VaultSync.UI/Services/PatchUpdateService.cs
@@ -99,6 +99,8 @@ namespace VaultSync.UI.Services
     public sealed class PatchUpdateService
     {
         private const string InvalidBaseAllowlistStatus = "manifest-invalid-base-allowlist";
+        internal const long MaxPatchArchiveBytes = 4L * 1024 * 1024 * 1024;
+        internal const long MaxExtractedPatchBytes = 8L * 1024 * 1024 * 1024;
         private static readonly HttpClient s_httpClient = CreateHttpClient();
         private static readonly TimeSpan s_manifestCacheWindow = TimeSpan.FromMinutes(30);
         private static readonly ConcurrentDictionary<string, (PatchManifest Manifest, DateTimeOffset FetchedAt)> s_manifestCache =
@@ -193,9 +195,37 @@ namespace VaultSync.UI.Services
                     hasInstaller: hasInstaller);
             }
 
+            if (!TryValidatePatchManifest(manifest, out string? manifestStatusCode, out string? manifestMessage))
+            {
+                return new PatchPreflightResult(
+                    eligible: false,
+                    requiresInstaller: true,
+                    statusCode: manifestStatusCode,
+                    message: manifestMessage,
+                    plan: null,
+                    manifest: manifest,
+                    hasManifest: hasManifest,
+                    hasArchive: hasArchive,
+                    hasInstaller: hasInstaller);
+            }
+
             string archiveName = string.IsNullOrWhiteSpace(updateResult.PatchArchiveName)
                 ? Path.GetFileName(updateResult.PatchArchiveUrl!.AbsolutePath)
                 : updateResult.PatchArchiveName;
+            if (!TryGetSafeArchiveName(archiveName, out archiveName))
+            {
+                return new PatchPreflightResult(
+                    eligible: false,
+                    requiresInstaller: true,
+                    statusCode: "archive-name-invalid",
+                    message: "Patch archive name is not a safe ZIP file name.",
+                    plan: null,
+                    manifest: manifest,
+                    hasManifest: hasManifest,
+                    hasArchive: hasArchive,
+                    hasInstaller: hasInstaller);
+            }
+
             var plan = new PatchPlan(manifest, updateResult.PatchArchiveUrl!, archiveName);
 
             return new PatchPreflightResult(
@@ -221,7 +251,13 @@ namespace VaultSync.UI.Services
                 "patches");
             Directory.CreateDirectory(stagingDir);
 
-            string destinationPath = Path.Combine(stagingDir, plan.ArchiveName);
+            if (!TryGetSafeArchiveName(plan.ArchiveName, out string safeArchiveName) ||
+                !TryValidatePatchManifest(plan.Manifest, out _, out _))
+            {
+                return null;
+            }
+
+            string destinationPath = Path.Combine(stagingDir, safeArchiveName);
 
             // If the file already exists and matches size/hash, reuse it instead of re-downloading.
             if (File.Exists(destinationPath))
@@ -235,31 +271,67 @@ namespace VaultSync.UI.Services
                 }
             }
 
-            using (HttpResponseMessage response = await s_httpClient.GetAsync(plan.ArchiveUrl, HttpCompletionOption.ResponseHeadersRead, cancellationToken))
+            string temporaryPath = destinationPath + $".{Guid.NewGuid():N}.download";
+            try
             {
+                using HttpResponseMessage response = await s_httpClient.GetAsync(
+                    plan.ArchiveUrl,
+                    HttpCompletionOption.ResponseHeadersRead,
+                    cancellationToken);
                 if (!response.IsSuccessStatusCode)
                     return null;
 
                 long? totalBytes = response.Content.Headers.ContentLength;
+                if (totalBytes is > MaxPatchArchiveBytes ||
+                    (totalBytes.HasValue && totalBytes.Value != plan.Manifest.ArchiveSize))
+                {
+                    return null;
+                }
+
                 await using Stream sourceStream = await response.Content.ReadAsStreamAsync(cancellationToken);
-                await using FileStream destinationStream = File.Create(destinationPath);
-                await CopyToWithProgressAsync(sourceStream, destinationStream, totalBytes, progress, cancellationToken);
+                await using (var destinationStream = new FileStream(
+                    temporaryPath,
+                    FileMode.CreateNew,
+                    FileAccess.Write,
+                    FileShare.None))
+                {
+                    await CopyToWithProgressAsync(
+                        sourceStream,
+                        destinationStream,
+                        totalBytes,
+                        plan.Manifest.ArchiveSize,
+                        progress,
+                        cancellationToken);
+                }
+
+                var downloaded = new FileInfo(temporaryPath);
+                if (downloaded.Length != plan.Manifest.ArchiveSize)
+                    return null;
+
+                if (!await VerifyChecksumAsync(temporaryPath, plan.Manifest.ArchiveSha256, cancellationToken))
+                    return null;
+
+                File.Move(temporaryPath, destinationPath, overwrite: true);
+                return destinationPath;
             }
-
-            var downloaded = new FileInfo(destinationPath);
-            if (plan.Manifest.ArchiveSize > 0 && downloaded.Length != plan.Manifest.ArchiveSize)
-                return null;
-
-            if (!await VerifyChecksumAsync(destinationPath, plan.Manifest.ArchiveSha256, cancellationToken))
-                return null;
-
-            return destinationPath;
+            finally
+            {
+                try
+                {
+                    File.Delete(temporaryPath);
+                }
+                catch
+                {
+                    // Best-effort cleanup of an incomplete or rejected download.
+                }
+            }
         }
 
         private static async Task CopyToWithProgressAsync(
             Stream source,
             Stream destination,
             long? totalBytes,
+            long maximumBytes,
             Action<long, long?, double?>? progress,
             CancellationToken cancellationToken)
         {
@@ -275,8 +347,11 @@ namespace VaultSync.UI.Services
                 if (read <= 0)
                     break;
 
-                await destination.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
                 totalRead += read;
+                if (totalRead > maximumBytes || totalRead > MaxPatchArchiveBytes)
+                    throw new InvalidDataException("Patch archive exceeds its declared size.");
+
+                await destination.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
 
                 if (progress is null)
                     continue;
@@ -317,6 +392,100 @@ namespace VaultSync.UI.Services
             byte[] hash = await sha.ComputeHashAsync(stream, cancellationToken);
             string actual = HashService.FormatSha256Lower(hash);
             return string.Equals(actual, expectedSha256.Trim().ToLowerInvariant(), StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static bool TryValidatePatchManifest(
+            PatchManifest manifest,
+            out string statusCode,
+            out string message)
+        {
+            statusCode = "manifest-invalid";
+            message = string.Empty;
+            if (manifest is null)
+            {
+                message = "Patch manifest is missing.";
+                return false;
+            }
+
+            if (manifest.ArchiveSize <= 0 || manifest.ArchiveSize > MaxPatchArchiveBytes)
+            {
+                message = "Patch archive size is missing or outside the supported limit.";
+                return false;
+            }
+
+            if (!IsSha256(manifest.ArchiveSha256))
+            {
+                message = "Patch archive SHA-256 is missing or invalid.";
+                return false;
+            }
+
+            if (manifest.Files is null || manifest.Files.Count == 0)
+            {
+                message = "Patch manifest does not contain any file entries.";
+                return false;
+            }
+
+            var paths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            long extractedBytes = 0;
+            foreach (PatchFileEntry file in manifest.Files)
+            {
+                if (!IsSafePatchRelativePath(file.RelativePath) || !paths.Add(file.RelativePath.Replace('\\', '/')))
+                {
+                    message = $"Patch manifest contains an unsafe or duplicate file path: '{file.RelativePath}'.";
+                    return false;
+                }
+
+                if (file.Size < 0 || !IsSha256(file.Sha256))
+                {
+                    message = $"Patch manifest contains invalid size or SHA-256 metadata for '{file.RelativePath}'.";
+                    return false;
+                }
+
+                try
+                {
+                    extractedBytes = checked(extractedBytes + file.Size);
+                }
+                catch (OverflowException)
+                {
+                    message = "Patch manifest extracted size overflows the supported range.";
+                    return false;
+                }
+
+                if (extractedBytes > MaxExtractedPatchBytes)
+                {
+                    message = "Patch manifest extracted size exceeds the supported limit.";
+                    return false;
+                }
+            }
+
+            statusCode = "eligible";
+            return true;
+        }
+
+        internal static bool TryGetSafeArchiveName(string? archiveName, out string safeArchiveName)
+        {
+            safeArchiveName = (archiveName ?? string.Empty).Trim();
+            return !string.IsNullOrWhiteSpace(safeArchiveName) &&
+                   !safeArchiveName.Contains('/') &&
+                   !safeArchiveName.Contains('\\') &&
+                   !safeArchiveName.Contains(':') &&
+                   string.Equals(Path.GetFileName(safeArchiveName), safeArchiveName, StringComparison.Ordinal) &&
+                   safeArchiveName.EndsWith(".zip", StringComparison.OrdinalIgnoreCase) &&
+                   safeArchiveName.IndexOfAny(Path.GetInvalidFileNameChars()) < 0;
+        }
+
+        private static bool IsSha256(string? value) =>
+            value is { Length: 64 } && value.All(Uri.IsHexDigit);
+
+        private static bool IsSafePatchRelativePath(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return false;
+
+            string normalized = value.Replace('\\', '/');
+            return !normalized.StartsWith("/", StringComparison.Ordinal) &&
+                   !normalized.Contains(':') &&
+                   normalized.Split('/').All(part => part is not ("" or "." or ".."));
         }
 
         private static bool VersionsMatch(string? previousVersion, string? currentVersion)

--- a/tests/VaultSync.Core.Tests/PatchSecurityTests.cs
+++ b/tests/VaultSync.Core.Tests/PatchSecurityTests.cs
@@ -1,0 +1,94 @@
+using System;
+using VaultSync.UI.Infrastructure;
+using VaultSync.UI.Services;
+using Xunit;
+
+namespace VaultSync.Core.Tests;
+
+public sealed class PatchSecurityTests
+{
+    private const string Sha256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    [Theory]
+    [InlineData("../patch.zip")]
+    [InlineData("folder/patch.zip")]
+    [InlineData(@"folder\patch.zip")]
+    [InlineData("patch.exe")]
+    [InlineData("")]
+    public void ArchiveName_RejectsUnsafeNames(string name)
+    {
+        Assert.False(PatchUpdateService.TryGetSafeArchiveName(name, out _));
+    }
+
+    [Fact]
+    public void ArchiveName_AcceptsLeafZipName()
+    {
+        Assert.True(PatchUpdateService.TryGetSafeArchiveName("vaultsync-patch-linux.zip", out string safe));
+        Assert.Equal("vaultsync-patch-linux.zip", safe);
+    }
+
+    [Theory]
+    [InlineData("../VaultSync.dll")]
+    [InlineData("/tmp/VaultSync.dll")]
+    [InlineData(@"C:\VaultSync.dll")]
+    [InlineData("bin//VaultSync.dll")]
+    public void Manifest_RejectsUnsafeFilePaths(string path)
+    {
+        PatchManifest manifest = CreateManifest(path);
+
+        Assert.False(PatchUpdateService.TryValidatePatchManifest(manifest, out _, out _));
+    }
+
+    [Fact]
+    public void Manifest_RequiresArchiveAndFileHashes()
+    {
+        PatchManifest manifest = CreateManifest("bin/VaultSync.dll");
+        manifest.ArchiveSha256 = string.Empty;
+
+        Assert.False(PatchUpdateService.TryValidatePatchManifest(manifest, out _, out _));
+
+        manifest.ArchiveSha256 = Sha256;
+        manifest.Files[0].Sha256 = "not-a-sha256";
+        Assert.False(PatchUpdateService.TryValidatePatchManifest(manifest, out _, out _));
+    }
+
+    [Fact]
+    public void Manifest_RejectsCaseInsensitiveDuplicatePaths()
+    {
+        PatchManifest manifest = CreateManifest("bin/VaultSync.dll");
+        manifest.Files.Add(new PatchFileEntry
+        {
+            RelativePath = "BIN/vaultsync.dll",
+            Sha256 = Sha256,
+            Size = 1
+        });
+
+        Assert.False(PatchUpdateService.TryValidatePatchManifest(manifest, out _, out _));
+    }
+
+    [Theory]
+    [InlineData("../outside")]
+    [InlineData("/absolute")]
+    [InlineData(@"C:\absolute")]
+    public void SafeZipExtractor_RejectsEscapingEntryPaths(string path)
+    {
+        Assert.ThrowsAny<Exception>(() => SafeZipExtractor.GetSafeEntryRelativePath(path));
+    }
+
+    private static PatchManifest CreateManifest(string path) => new()
+    {
+        PreviousVersion = "1.8.4",
+        TargetVersion = "1.8.5",
+        ArchiveSha256 = Sha256,
+        ArchiveSize = 1,
+        Files =
+        [
+            new PatchFileEntry
+            {
+                RelativePath = path,
+                Sha256 = Sha256,
+                Size = 1
+            }
+        ]
+    };
+}


### PR DESCRIPTION
## What changed

- require complete SHA-256 and size metadata for patch archives and every patched file
- reject unsafe archive names and cross-platform path traversal
- download patches to bounded temporary files and publish them atomically only after verification
- reject unexpected, duplicate, oversized, or missing ZIP entries before extraction
- move elevated patch-helper state into a private per-user runtime directory
- add regression tests for updater and ZIP security boundaries
- add CODEOWNERS and clarify private vulnerability reporting
- pin every GitHub Action and analysis tool dependency to an immutable version/commit
- make CI and CodeQL run for all `release/v*` branches

## Why

The public repository and self-updater are trust boundaries. These changes reduce archive/path abuse, incomplete-download replacement, ZIP resource abuse, shared-temp races, and Actions supply-chain exposure.

## Validation

- `dotnet test tests/VaultSync.Core.Tests/VaultSync.Core.Tests.csproj --configuration Release --no-restore -warnaserror -p:UseSharedCompilation=false` — 439 passed
- `python3 -m unittest discover -s tests/scripts -p 'test_*.py'` — 13 passed
- `npx --yes --ignore-scripts yaml-lint@1.7.0 ...` — passed
- NuGet vulnerable-package audit — no known vulnerable packages
- GitHub CodeQL, Dependabot, and secret-scanning open-alert audit — zero open alerts

Repository rules and Actions allowlisting were hardened separately through GitHub settings. SHA-only Actions enforcement should be enabled after this PR is merged so workflows on the base branch remain operational.