### PR TITLE
Block linked-path restore escapes

### DIFF
--- a/src/VaultSync.UI/Infrastructure/SafeZipExtractor.cs
+++ b/src/VaultSync.UI/Infrastructure/SafeZipExtractor.cs
@@ -42,7 +42,38 @@ internal static class SafeZipExtractor
         if (!candidate.StartsWith(normalizedRoot, GetPathComparison()))
             throw new InvalidDataException($"Archive entry '{entryFullName}' escapes the extraction destination.");
 
+        EnsureNoLinkedPathComponents(destinationDirectory, candidate);
         return candidate;
+    }
+
+    public static void EnsureNoLinkedPathComponents(string rootDirectory, string destinationPath)
+    {
+        string normalizedRoot = NormalizeRoot(rootDirectory);
+        string candidate = Path.GetFullPath(destinationPath);
+        if (!candidate.StartsWith(normalizedRoot, GetPathComparison()))
+            throw new InvalidDataException($"Destination '{destinationPath}' escapes the selected root.");
+
+        string relative = Path.GetRelativePath(normalizedRoot, candidate);
+        string current = normalizedRoot;
+        foreach (string component in relative.Split(
+                     [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+                     StringSplitOptions.RemoveEmptyEntries))
+        {
+            current = Path.Combine(current, component);
+            try
+            {
+                if ((File.GetAttributes(current) & FileAttributes.ReparsePoint) != 0)
+                    throw new InvalidDataException($"Destination path '{relative}' contains a linked path component.");
+            }
+            catch (FileNotFoundException)
+            {
+                // The remaining path does not exist yet.
+            }
+            catch (DirectoryNotFoundException)
+            {
+                // The remaining path does not exist yet.
+            }
+        }
     }
 
     public static string GetSafeEntryRelativePath(string entryFullName)

--- a/src/VaultSync.UI/ViewModels/AppViewModel.BackupHistoryHandlers.cs
+++ b/src/VaultSync.UI/ViewModels/AppViewModel.BackupHistoryHandlers.cs
@@ -2966,6 +2966,7 @@ namespace VaultSync.UI.ViewModels
                 if (!string.IsNullOrEmpty(parentDir))
                     Directory.CreateDirectory(parentDir);
 
+                SafeZipExtractor.EnsureNoLinkedPathComponents(targetDir, target);
                 File.Copy(filePath, target, overwrite: true);
                 processedBytes += fileLength;
                 processed++;

--- a/tests/VaultSync.Core.Tests/PatchSecurityTests.cs
+++ b/tests/VaultSync.Core.Tests/PatchSecurityTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using VaultSync.UI.Infrastructure;
 using VaultSync.UI.Services;
 using Xunit;
@@ -73,6 +74,27 @@ public sealed class PatchSecurityTests
     public void SafeZipExtractor_RejectsEscapingEntryPaths(string path)
     {
         Assert.ThrowsAny<Exception>(() => SafeZipExtractor.GetSafeEntryRelativePath(path));
+    }
+
+    [Fact]
+    public void SafeZipExtractor_RejectsLinkedDestinationComponents()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"vaultsync-zip-root-{Guid.NewGuid():N}");
+        string outside = Path.Combine(Path.GetTempPath(), $"vaultsync-zip-outside-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        Directory.CreateDirectory(outside);
+        try
+        {
+            Directory.CreateSymbolicLink(Path.Combine(root, "linked"), outside);
+
+            Assert.Throws<InvalidDataException>(() =>
+                SafeZipExtractor.GetSafeEntryPath(root, "linked/escaped.txt"));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+            Directory.Delete(outside, recursive: true);
+        }
     }
 
     private static PatchManifest CreateManifest(string path) => new()


### PR DESCRIPTION
## What changed

- reject pre-existing symlink/reparse-point components beneath archive restore destinations
- apply the same boundary check before ordinary backup file copies
- add a regression test proving a linked directory cannot redirect an archive write outside the selected restore root

## Security impact

This closes a local path-boundary weakness where a restore target containing a crafted linked directory could redirect an overwrite outside the user-selected destination.

## Validation

- 440 .NET tests passed with warnings treated as errors
- diff whitespace validation passed