### PR TITLE
Harden 1.8.6 patch releases

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -11,11 +11,8 @@ on:
           - beta
           - stable
       previous_version:
-        description: "Primary previous/base version for patch manifests (optional if the allowlist is provided)"
-        required: false
-      previous_versions:
-        description: "Optional comma/newline separated exact base-version allowlist for one manifest (defaults to previous_version only)"
-        required: false
+        description: "Single qualified previous/base version for patch manifests"
+        required: true
       target_version:
         description: "Target version for patch manifests (e.g., 1.8.0-Beta.1 or 1.8.0)"
         required: true
@@ -53,7 +50,6 @@ jobs:
         env:
           RELEASE_CHANNEL: ${{ inputs.release_channel }}
           PREVIOUS_VERSION: ${{ inputs.previous_version }}
-          PREVIOUS_VERSIONS: ${{ inputs.previous_versions }}
           TARGET_VERSION: ${{ inputs.target_version }}
           RELEASE_CANDIDATE: ${{ inputs.release_candidate }}
         run: |
@@ -61,7 +57,6 @@ jobs:
 
           channel="$RELEASE_CHANNEL"
           previous="$PREVIOUS_VERSION"
-          previous_versions_raw="$PREVIOUS_VERSIONS"
           target="$TARGET_VERSION"
           release_candidate="$RELEASE_CANDIDATE"
           branch="${{ github.ref_name }}"
@@ -98,31 +93,13 @@ jobs:
             exit 1
           fi
 
-          declare -A seen_versions=()
-          requested_versions=()
-          while IFS= read -r candidate; do
-            candidate="$(printf '%s' "$candidate" | trim)"
-            [[ -n "$candidate" ]] || continue
-
-            candidate_key="$(normalize_version "$candidate")"
-            if [[ "$candidate_key" == "$target_key" ]]; then
-              echo "::warning::Ignoring base version '$candidate' because it matches target_version '$target'."
-              continue
-            fi
-
-            if [[ -z "${seen_versions[$candidate_key]+x}" ]]; then
-              seen_versions[$candidate_key]=1
-              requested_versions+=("$candidate")
-            fi
-          done < <(
-            {
-              printf '%s\n' "$previous"
-              printf '%s\n' "$previous_versions_raw" | tr ',;' '\n'
-            }
-          )
-
-          if [[ ${#requested_versions[@]} -eq 0 ]]; then
-            echo "At least one previous/base version different from target_version '$target' is required."
+          previous_key="$(normalize_version "$previous")"
+          if [[ -z "$previous" ]]; then
+            echo "previous_version is required. Automated patch builds support one explicitly qualified base version."
+            exit 1
+          fi
+          if [[ "$previous_key" == "$target_key" ]]; then
+            echo "previous_version must be different from target_version '$target'."
             exit 1
           fi
 
@@ -131,10 +108,8 @@ jobs:
               echo "release_candidate can only be used with the stable channel."
               exit 1
             fi
-            beta_base_version="${target_key%%-*}"
-            expected_beta_branch="release/v${beta_base_version}"
-            if [[ "$branch" != "Dev" && "$branch" != "$expected_beta_branch" ]]; then
-              echo "Beta asset builds must run from Dev or '$expected_beta_branch'. Current branch: $branch"
+            if [[ "$branch" != "Dev" ]]; then
+              echo "Beta asset builds must run from Dev. Current branch: $branch"
               exit 1
             fi
             if [[ "$target" != *-* ]]; then
@@ -162,7 +137,7 @@ jobs:
 
           {
             echo "patch_base_versions<<EOF"
-            printf '%s\n' "${requested_versions[@]}"
+            printf '%s\n' "$previous"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
@@ -173,11 +148,9 @@ jobs:
           - Release candidate: \`$release_candidate\`
           - Project version: \`$project_version\`
           - Primary previous version: \`${previous:-"(none)"}\`
-          - Base allow-list:
+          - Qualified patch base:
           EOF
-          for base in "${requested_versions[@]}"; do
-            echo "  - \`$base\`" >> "$GITHUB_STEP_SUMMARY"
-          done
+          echo "  - \`$previous\`" >> "$GITHUB_STEP_SUMMARY"
           cat <<EOF >> "$GITHUB_STEP_SUMMARY"
           - Target version: \`$target\`
           EOF

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,20 +15,20 @@
     <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />
 
     <!-- Avalonia UI -->
-    <PackageVersion Include="Avalonia" Version="12.1.0" />
-    <PackageVersion Include="Avalonia.Controls.ColorPicker" Version="12.1.0" />
-    <PackageVersion Include="Avalonia.Desktop" Version="12.1.0" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.1.0" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.1.0" />
+    <PackageVersion Include="Avalonia" Version="12.1.1" />
+    <PackageVersion Include="Avalonia.Controls.ColorPicker" Version="12.1.1" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.1.1" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.1.1" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.1.1" />
     <PackageVersion Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.1.0-dev-798" />
 
     <!-- Text and rendering native assets -->
-    <PackageVersion Include="SkiaSharp" Version="4.150.1" />
-    <PackageVersion Include="SkiaSharp.HarfBuzz" Version="4.150.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="4.150.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.macOS" Version="4.150.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="4.150.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Win32" Version="4.150.1" />
+    <PackageVersion Include="SkiaSharp" Version="4.151.0" />
+    <PackageVersion Include="SkiaSharp.HarfBuzz" Version="4.151.0" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="4.151.0" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.macOS" Version="4.151.0" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="4.151.0" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Win32" Version="4.151.0" />
     <PackageVersion Include="HarfBuzzSharp" Version="14.2.1.1" />
     <PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux" Version="14.2.1.1" />
     <PackageVersion Include="HarfBuzzSharp.NativeAssets.macOS" Version="14.2.1.1" />

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -74,7 +74,7 @@ without merging the release PR. The workflow rejects a candidate build unless
 the branch name exactly matches `release/v<target_version>`.
 
 Beta example for future prereleases:
-- branch: `release/v1.8.5` (or `Dev` after the beta changes are present there)
+- branch: `Dev` after the beta changes are merged there
 - release channel: `beta`
 - `release_candidate = false`
 - `previous_version = 1.8.4`
@@ -85,18 +85,11 @@ The `release_candidate` switch is not used for beta builds. It exists only to
 build unpublished, stable-version candidate assets from a matching release
 branch before the final merge into `Stable`.
 
-Example multi-base input:
-- `previous_version = 1.6.2`
-- `previous_versions =`
-  - `1.6.0`
-  - `1.6.1`
-  - `1.6.2`
-
-This produces one manifest with:
+Patch builds require one qualified predecessor through `previous_version`. This produces a manifest with:
 - `previousVersion` for backward compatibility
-- `baseVersions` as the exact allowed base-version list
+- `baseVersions` containing that same qualified predecessor
 
-Older or unlisted installs must fall back to the full installer.
+Do not broaden the allowlist to older releases without a separate qualification mechanism and test evidence for every platform. Older or unlisted installs must fall back to the full installer.
 
 ## 5) Release Checklist
 - Run the release gate before publishing:
@@ -132,7 +125,7 @@ Never describe an unsigned package as signed, notarized, or publisher-verified.
 
 macOS users may need to run:
 ```bash
-xattr -dr com.apple.quarantine /Applications/VaultSync.app
+xattr -dr com.apple.quarantine /Applications/VaultSync-macos-<arch>.app
 ```
 
 Linux AppImage users may need to run:

--- a/docs/UPDATER.md
+++ b/docs/UPDATER.md
@@ -37,17 +37,19 @@ Linux can use architecture-specific patch names:
 ## Runtime Expectations
 - Updater checks according to Settings policy.
 - Patch apply does not replace user config/data.
+- A failed in-process replacement restores overwritten files and removes newly created files before reporting failure.
+- Full power-loss atomicity requires a future directory-level installer transaction; until then, release qualification must exercise interrupted updates and retain full-installer recovery.
 - Installer fallback is used when patch update is not viable.
 
 ## Patch Manifest Base-Version Rules
 - Legacy manifests may declare one exact base version via `previousVersion`.
-- Multi-base manifests may additionally declare `baseVersions`.
+- Current release automation emits one qualified base in `baseVersions`.
 - `baseVersions` is an exact allowlist, not a version range.
 - Patch preflight and helper apply both require the installed version to match one listed base exactly.
 - If the installed version is not listed, VaultSync must fall back to the installer.
 - Prerelease labels are part of the exact version identity, so `1.7.4-Beta.1` and `1.7.4` are treated as different bases.
 
-This is required because patch archives are partial target payloads. Files omitted from the patch are assumed to already be correct on every listed base version.
+This is required because patch archives do not remove obsolete files. The automated release path therefore accepts exactly one explicitly tested predecessor. Older or additional base versions use the full installer.
 
 ## Release Validation
 After publishing assets, verify:
@@ -55,7 +57,7 @@ After publishing assets, verify:
 - patch downloads succeed
 - patch apply succeeds on target platform
 - installer fallback remains functional
-- every base version listed in `baseVersions` was actually validated against that same patch payload
+- the single base version listed in `baseVersions` was validated against that same patch payload
 
 ## Related Docs
 - `docs/RELEASING.md`

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -11,8 +11,8 @@ VaultSync is distributed through two Windows channels plus the existing macOS/Li
    - Windows Direct: download from GitHub Releases.
    - Windows Store: install from Microsoft Store when that channel is published.
    - macOS/Linux: download from GitHub Releases.
-2. Windows Direct: run the `.exe` installer. Linux x64: use the `.AppImage` for the most app-like portable launch, or extract the `.tar.gz` and run `./install.sh` for a per-user desktop/menu install. Linux arm64: extract the `.tar.gz` and run `./install.sh`. macOS: open the `.dmg` and drag `VaultSync.app` to `/Applications`.
-3. Direct packages are intentionally unsigned. Download only from the official VaultSync GitHub release and compare its published SHA-256 digest before bypassing an operating-system warning. On macOS, right-click -> Open the first time (or run `xattr -dr com.apple.quarantine /Applications/VaultSync.app`).
+2. Windows Direct: run the `.exe` installer. Linux x64: use the `.AppImage` for the most app-like portable launch, or extract the `.tar.gz` and run `./install.sh` for a per-user desktop/menu install. Linux arm64: extract the `.tar.gz` and run `./install.sh`. macOS: open the `.dmg` and drag `VaultSync-macos-arm64.app` (Apple Silicon) or `VaultSync-macos-x64.app` (Intel) to `/Applications`.
+3. Direct packages are intentionally unsigned. Download only from the official VaultSync GitHub release and compare its published SHA-256 digest before bypassing an operating-system warning. On macOS, right-click -> Open the first time (or run `xattr -dr com.apple.quarantine /Applications/VaultSync-macos-<arch>.app`, replacing `<arch>` with `arm64` or `x64`).
 4. Launch VaultSync.
 
 ## Updating

--- a/scripts/build_patch.py
+++ b/scripts/build_patch.py
@@ -97,6 +97,24 @@ def build_patch(base_dir: Path, out_zip: Path, out_manifest: Path, platform: str
         raise ValueError("Patch archive output must use a .zip extension.")
     if out_manifest.suffix.lower() != ".json":
         raise ValueError("Patch manifest output must use a .json extension.")
+
+    normalized_previous = []
+    seen_previous = set()
+    for previous in previous_versions:
+        trimmed = previous.strip()
+        if not trimmed or trimmed in seen_previous:
+            continue
+        seen_previous.add(trimmed)
+        normalized_previous.append(trimmed)
+
+    if not normalized_previous:
+        raise ValueError("At least one --previous version is required.")
+    if len(normalized_previous) > 1:
+        raise ValueError(
+            "Automated patch manifests support exactly one qualified base version. "
+            "Use a full installer for older or additional base versions."
+        )
+
     paths = [ensure_child_path(p, base_dir) for p in base_dir.rglob("*") if p.is_file()]
     paths.sort(key=lambda p: str(p.relative_to(base_dir)).lower())
 
@@ -122,18 +140,6 @@ def build_patch(base_dir: Path, out_zip: Path, out_manifest: Path, platform: str
                     "size": path.stat().st_size,
                 }
             )
-
-    normalized_previous = []
-    seen_previous = set()
-    for previous in previous_versions:
-        trimmed = previous.strip()
-        if not trimmed or trimmed in seen_previous:
-            continue
-        seen_previous.add(trimmed)
-        normalized_previous.append(trimmed)
-
-    if not normalized_previous:
-        raise ValueError("At least one --previous version is required.")
 
     manifest = {
         "previousVersion": normalized_previous[0],

--- a/src/VaultSync.UI/Services/PatchInstallService.cs
+++ b/src/VaultSync.UI/Services/PatchInstallService.cs
@@ -367,7 +367,7 @@ namespace VaultSync.UI.Services
                     SafeZipExtractor.ExtractToDirectory(request.ArchivePath, stagingDir);
                     LogLine("Verifying extracted files.");
                     VerifyExtractedFiles(manifest, stagingDir);
-                    LogLine("Copying updated files.");
+                    LogLine("Installing updated files with rollback protection.");
                     CopyIntoInstall(manifest, stagingDir, request.InstallDir, LogLine);
                 }
                 finally
@@ -422,22 +422,207 @@ namespace VaultSync.UI.Services
             }
         }
 
-        private static void CopyIntoInstall(PatchManifest manifest, string stagingDir, string installDir, Action<string> logLine)
+        internal static void CopyIntoInstall(PatchManifest manifest, string stagingDir, string installDir, Action<string> logLine)
         {
-            foreach (PatchFileEntry file in manifest.Files)
+            string transactionDir = Path.Combine(GetTrustedPatchRoot(), $"patch-rollback-{Guid.NewGuid():N}");
+            string backupDir = Path.Combine(transactionDir, "backup");
+            var operations = new List<PatchInstallOperation>();
+            var createdDirectories = new List<string>();
+
+            Directory.CreateDirectory(backupDir);
+            RestrictDirectoryToCurrentUser(transactionDir);
+
+            try
             {
-                string source = CombineUnderRoot(stagingDir, file.RelativePath, "manifest source path");
-                string target = CombineUnderRoot(installDir, file.RelativePath, "manifest target path");
-                SafeZipExtractor.EnsureNoLinkedPathComponents(stagingDir, source);
-                SafeZipExtractor.EnsureNoLinkedPathComponents(installDir, target);
-                string? targetDir = Path.GetDirectoryName(target);
-                if (!string.IsNullOrWhiteSpace(targetDir))
+                foreach (PatchFileEntry file in manifest.Files)
                 {
-                    Directory.CreateDirectory(targetDir);
+                    string source = CombineUnderRoot(stagingDir, file.RelativePath, "manifest source path");
+                    string target = CombineUnderRoot(installDir, file.RelativePath, "manifest target path");
+                    SafeZipExtractor.EnsureNoLinkedPathComponents(stagingDir, source);
+                    SafeZipExtractor.EnsureNoLinkedPathComponents(installDir, target);
+
+                    bool targetExisted = File.Exists(target);
+                    string? backup = null;
+                    if (targetExisted)
+                    {
+                        backup = CombineUnderRoot(backupDir, file.RelativePath, "rollback backup path");
+                        string? backupParent = Path.GetDirectoryName(backup);
+                        if (!string.IsNullOrWhiteSpace(backupParent))
+                            Directory.CreateDirectory(backupParent);
+
+                        File.Copy(target, backup, overwrite: false);
+                    }
+
+                    operations.Add(new PatchInstallOperation(file.RelativePath, source, target, backup, targetExisted));
                 }
 
-                File.Copy(source, target, overwrite: true);
-                logLine($"Replaced {file.RelativePath}");
+                foreach (PatchInstallOperation operation in operations)
+                {
+                    string? targetDir = Path.GetDirectoryName(operation.Target);
+                    if (!string.IsNullOrWhiteSpace(targetDir) && !Directory.Exists(targetDir))
+                    {
+                        CreateDirectoryTree(targetDir, installDir, createdDirectories);
+                    }
+
+                    ReplaceFromSource(operation.Source, operation.Target);
+                    operation.Applied = true;
+                    logLine($"Replaced {operation.RelativePath}");
+                }
+            }
+            catch (Exception installError)
+            {
+                var rollbackErrors = RollBackInstall(operations, createdDirectories);
+                if (rollbackErrors.Count > 0)
+                {
+                    rollbackErrors.Insert(0, installError);
+                    throw new AggregateException("Patch installation failed and rollback was incomplete.", rollbackErrors);
+                }
+
+                throw;
+            }
+            finally
+            {
+                try
+                {
+                    Directory.Delete(transactionDir, recursive: true);
+                }
+                catch
+                {
+                    // Best effort cleanup. A failed cleanup only leaves rollback data in the trusted runtime directory.
+                }
+            }
+        }
+
+        private static void ReplaceFromSource(string source, string target)
+        {
+            string temporary = target + $".vaultsync-patch-{Guid.NewGuid():N}.tmp";
+            try
+            {
+                File.Copy(source, temporary, overwrite: false);
+                File.Move(temporary, target, overwrite: true);
+            }
+            finally
+            {
+                if (File.Exists(temporary))
+                    File.Delete(temporary);
+            }
+        }
+
+        private static List<Exception> RollBackInstall(
+            IReadOnlyList<PatchInstallOperation> operations,
+            IReadOnlyList<string> createdDirectories)
+        {
+            var errors = new List<Exception>();
+            foreach (PatchInstallOperation operation in operations.Reverse())
+            {
+                if (!operation.Applied)
+                    continue;
+
+                try
+                {
+                    if (operation.TargetExisted)
+                    {
+                        if (string.IsNullOrWhiteSpace(operation.Backup) || !File.Exists(operation.Backup))
+                            throw new FileNotFoundException($"Rollback backup is missing for {operation.RelativePath}.", operation.Backup);
+
+                        ReplaceFromSource(operation.Backup, operation.Target);
+                    }
+                    else if (File.Exists(operation.Target))
+                    {
+                        File.Delete(operation.Target);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    errors.Add(new IOException($"Failed to roll back {operation.RelativePath}.", ex));
+                }
+            }
+
+            foreach (string directory in createdDirectories.Reverse())
+            {
+                try
+                {
+                    if (Directory.Exists(directory) && !Directory.EnumerateFileSystemEntries(directory).Any())
+                        Directory.Delete(directory);
+                }
+                catch (Exception ex)
+                {
+                    errors.Add(new IOException($"Failed to remove patch-created directory {directory}.", ex));
+                }
+            }
+
+            return errors;
+        }
+
+        private static void CreateDirectoryTree(string directory, string installDir, ICollection<string> createdDirectories)
+        {
+            var missing = new Stack<string>();
+            string? current = directory;
+            string normalizedRoot = Path.GetFullPath(installDir)
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+            while (!string.IsNullOrWhiteSpace(current) && !Directory.Exists(current))
+            {
+                if (string.Equals(current, normalizedRoot, StringComparison.OrdinalIgnoreCase))
+                    break;
+
+                missing.Push(current);
+                current = Path.GetDirectoryName(current);
+            }
+
+            while (missing.Count > 0)
+            {
+                string created = missing.Pop();
+                Directory.CreateDirectory(created);
+                createdDirectories.Add(created);
+            }
+        }
+
+        private sealed class PatchInstallOperation
+        {
+            public PatchInstallOperation(
+                string relativePath,
+                string source,
+                string target,
+                string? backup,
+                bool targetExisted)
+            {
+                RelativePath = relativePath;
+                Source = source;
+                Target = target;
+                Backup = backup;
+                TargetExisted = targetExisted;
+            }
+
+            public string RelativePath
+            {
+                get;
+            }
+
+            public string Source
+            {
+                get;
+            }
+
+            public string Target
+            {
+                get;
+            }
+
+            public string? Backup
+            {
+                get;
+            }
+
+            public bool TargetExisted
+            {
+                get;
+            }
+
+            public bool Applied
+            {
+                get;
+                set;
             }
         }
 

--- a/tests/VaultSync.Core.Tests/PatchInstallTransactionTests.cs
+++ b/tests/VaultSync.Core.Tests/PatchInstallTransactionTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using VaultSync.UI.Services;
+using Xunit;
+
+namespace VaultSync.Core.Tests;
+
+public sealed class PatchInstallTransactionTests
+{
+    [Fact]
+    public void CopyIntoInstall_RollsBackReplacedAndCreatedFiles_WhenInstallFails()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"vaultsync-patch-test-{Guid.NewGuid():N}");
+        string stagingDir = Path.Combine(root, "staging");
+        string installDir = Path.Combine(root, "install");
+
+        try
+        {
+            Directory.CreateDirectory(stagingDir);
+            Directory.CreateDirectory(installDir);
+            File.WriteAllText(Path.Combine(stagingDir, "existing.txt"), "updated");
+            Directory.CreateDirectory(Path.Combine(stagingDir, "new"));
+            File.WriteAllText(Path.Combine(stagingDir, "new", "created.txt"), "created");
+            File.WriteAllText(Path.Combine(installDir, "existing.txt"), "original");
+
+            var manifest = new PatchManifest
+            {
+                Files = new List<PatchFileEntry>
+                {
+                    new() { RelativePath = "existing.txt" },
+                    new() { RelativePath = "new/created.txt" }
+                }
+            };
+            int replacements = 0;
+
+            Assert.Throws<InvalidOperationException>(() => PatchInstallService.CopyIntoInstall(
+                manifest,
+                stagingDir,
+                installDir,
+                _ =>
+                {
+                    replacements++;
+                    if (replacements == 2)
+                        throw new InvalidOperationException("Simulated interruption.");
+                }));
+
+            Assert.Equal("original", File.ReadAllText(Path.Combine(installDir, "existing.txt")));
+            Assert.False(File.Exists(Path.Combine(installDir, "new", "created.txt")));
+            Assert.False(Directory.Exists(Path.Combine(installDir, "new")));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CopyIntoInstall_CommitsAllFiles_WhenEveryReplacementSucceeds()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"vaultsync-patch-test-{Guid.NewGuid():N}");
+        string stagingDir = Path.Combine(root, "staging");
+        string installDir = Path.Combine(root, "install");
+
+        try
+        {
+            Directory.CreateDirectory(stagingDir);
+            Directory.CreateDirectory(installDir);
+            File.WriteAllText(Path.Combine(stagingDir, "app.bin"), "updated");
+            File.WriteAllText(Path.Combine(installDir, "app.bin"), "original");
+            var manifest = new PatchManifest
+            {
+                Files = new List<PatchFileEntry> { new() { RelativePath = "app.bin" } }
+            };
+
+            PatchInstallService.CopyIntoInstall(manifest, stagingDir, installDir, _ => { });
+
+            Assert.Equal("updated", File.ReadAllText(Path.Combine(installDir, "app.bin")));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/tests/scripts/test_build_patch.py
+++ b/tests/scripts/test_build_patch.py
@@ -64,6 +64,26 @@ class BuildPatchTests(unittest.TestCase):
             self.assertTrue((root / "patch.zip").is_file())
             self.assertTrue((root / "patch.json").is_file())
 
+    def test_build_patch_rejects_unqualified_multi_base_manifest(self) -> None:
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmp:
+            root = Path(tmp)
+            base_dir = root / "publish"
+            base_dir.mkdir()
+            (base_dir / "VaultSync.UI").write_bytes(b"binary")
+
+            with self.assertRaisesRegex(ValueError, "exactly one qualified base version"):
+                build_patch.build_patch(
+                    base_dir,
+                    root / "patch.zip",
+                    root / "patch.json",
+                    "linux",
+                    ["1.8.4", "1.8.5-Beta.1"],
+                    "1.8.5",
+                )
+
+            self.assertFalse((root / "patch.zip").exists())
+            self.assertFalse((root / "patch.json").exists())
+
     def test_build_patch_rejects_symlink_outside_base(self) -> None:
         if os.name == "nt":
             self.skipTest("Creating symlinks is not reliably permitted on Windows.")


### PR DESCRIPTION
## Summary

- add failure-safe patch replacement with rollback for overwritten and newly created files
- restrict automated patch manifests to one explicitly qualified predecessor
- enforce beta asset builds from `Dev` and stable asset builds from `Stable`
- correct architecture-specific macOS application paths in release documentation
- update Avalonia to 12.1.1 and align the complete SkiaSharp family at 4.151.0
- add updater interruption and release-script regression tests

## Why

The 1.8.5 post-release audit found that patch installation copied files in place without rollback, multi-base manifests could claim upgrade paths without checked-in qualification evidence, macOS documentation used a bundle name that did not match shipped artifacts, and the open rendering dependency update mixed SkiaSharp versions.

## Impact

Ordinary patch I/O or process failures now restore overwritten files, remove patch-created files and directories, and report incomplete rollback explicitly. Release automation emits a single-base manifest so older installations fall back to a full installer. Beta work remains integrated through `Dev`; `Stable` remains the production release branch.

Full power-loss atomicity remains separate installer-level work because an in-place multi-file update cannot guarantee it.

## Validation

- Release build: 0 warnings, 0 errors
- .NET tests: 464 passed
- release-script tests: 14 passed
- isolated CLI snapshot/sync/verify self-test passed
- localization audit clean across 1,638 keys
- no vulnerable NuGet packages
- workflow YAML and diff checks passed
- self-contained publishes succeeded for Windows x64, Linux x64/arm64, and macOS x64/arm64 with the expected native architectures

The local `.blueprints/`, `log/`, and `project/` generated files are intentionally excluded from this PR.